### PR TITLE
Speeding-up Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ cache:
         - $HOME/.ccache
         - $HOME/nltk_data
 
+before_cache:   # prevent logs from caching
+    - rm -f $HOME/.cache/pip/log/debug.log
+
 before_install:
     - pip install -U setuptools pip wheel
     - pip install codecov

--- a/travis/nltk_download.sh
+++ b/travis/nltk_download.sh
@@ -3,5 +3,5 @@ if [ "$(ls -A $HOME/nltk_data)" ]; then
     echo "Using cached NLTK data containing folders:";
     ls $HOME/nltk_data;
 else
-    python -m nltk.downloader all;
+    python -m nltk.downloader wordnet;
 fi


### PR DESCRIPTION
Downloading all NLTK data was slowing the build process significantly. Since we only need WordNet, downloading other stuff is unnecessary and was removed.

Also, we now delete pip log messages to prevent them from triggering a new cache packaging and archiving.