### PR TITLE
setup.py: freeze smart_open dependency to git version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,11 @@ if __name__ == '__main__':
         download_url=DOWNLOAD_URL,
         packages=find_packages(),
         package_data=PACKAGE_DATA,
-        install_requires=INSTALL_REQUIRES,
+        install_requires=
+            INSTALL_REQUIRES + ('smart_open>=1.3.0',),
+        dependency_links=(
+            'git+https://github.com/piskvorky/smart_open.git@1fe93a2#egg=smart_open-1.3.0',
+        ),
         entry_points=ENTRY_POINTS,
         keywords=KEYWORDS,
         namespace_packages=['orangecontrib'],


### PR DESCRIPTION
Revert once smart_open>=1.3.1 releases.

Fixes https://github.com/biolab/orange3-text/issues/15