### PR TITLE
corpus: from_file looks in default corpora location

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -1,23 +1,22 @@
 import os
 
 import numpy as np
-from Orange.data import StringVariable, Table, DiscreteVariable, Domain
+
+from Orange.data import StringVariable, Table
 
 
 def get_sample_corpora_dir():
     path = os.path.dirname(__file__)
-    dir = os.path.join(path, 'datasets')
-    return os.path.realpath(dir)
+    directory = os.path.join(path, 'datasets')
+    return os.path.abspath(directory)
 
 
 class Corpus(Table):
-    """
-        Internal class for storing a corpus of orangecontrib.text.corpus.Corpus.
-    """
+    """Internal class for storing a corpus of orangecontrib.text.corpus.Corpus."""
 
     def __new__(cls, *args, **kwargs):
         """Bypass Table.__new__."""
-        return object.__new__(Corpus)
+        return object.__new__(cls)
 
     def __init__(self, documents, X, Y, metas, domain):
         self.documents = documents
@@ -43,6 +42,15 @@ class Corpus(Table):
 
     @classmethod
     def from_file(cls, filename):
+        if not os.path.exists(filename):        # check the default corpora location
+            abs_path = os.path.join(get_sample_corpora_dir(), filename)
+            if not abs_path.endswith('.tab'):
+                abs_path += '.tab'
+            if not os.path.exists(abs_path):
+                raise FileNotFoundError('File "{}" was not found.'.format(filename))
+            else:
+                filename = abs_path
+
         table = Table.from_file(filename)
         include_ids = []
         first_id = None
@@ -86,3 +94,10 @@ class Corpus(Table):
 
     def __len__(self):
         return len(self.documents)
+
+    def __eq__(self, other):
+        return (self.documents == other.documents and
+                np.array_equal(self.X, other.X) and
+                np.array_equal(self.Y, other.Y) and
+                np.array_equal(self.metas, other.metas) and
+                self.domain == other.domain)

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -1,30 +1,50 @@
 import os
-import copy
 import unittest
+import numpy as np
+
+from Orange.data.domain import Domain, StringVariable
+
 from orangecontrib.text.corpus import Corpus
-
-
-DATASET_PATH = os.path.join(os.path.dirname(__file__), '..', 'datasets')
 
 
 class CorpusTests(unittest.TestCase):
     def test_corpus_from_file(self):
-        c = Corpus.from_file(os.path.join(DATASET_PATH, 'bookexcerpts.tab'))
+        c = Corpus.from_file('bookexcerpts')
         self.assertEqual(len(c), 140)
         self.assertEqual(len(c.domain), 1)
         self.assertEqual(len(c.domain.metas), 1)
         self.assertEqual(c.metas.shape, (140, 1))
 
-    def test_corpus_from_file_just_text(self):
-        c = Corpus.from_file(os.path.join(DATASET_PATH, 'deerwester.tab'))
+    def test_corpus_from_file_abs_path(self):
+        c = Corpus.from_file('bookexcerpts')
+        path = os.path.dirname(__file__)
+        file = os.path.abspath(os.path.join(path, '..', 'datasets', 'bookexcerpts.tab'))
+        c2 = Corpus.from_file(file)
+        self.assertEqual(c, c2)
 
+    def test_corpus_from_file_with_tab(self):
+        c = Corpus.from_file('bookexcerpts')
+        c2 = Corpus.from_file('bookexcerpts.tab')
+        self.assertEqual(c, c2)
+
+    def test_corpus_from_file_missing(self):
+        with self.assertRaises(FileNotFoundError):
+            Corpus.from_file('missing_file')
+
+    def test_corpus_from_init(self):
+        c = Corpus.from_file('bookexcerpts')
+        c2 = Corpus(c.documents, c.X, c.Y, c.metas, c.domain)
+        self.assertEqual(c, c2)
+
+    def test_corpus_from_file_just_text(self):
+        c = Corpus.from_file('deerwester')
         self.assertEqual(len(c), 9)
         self.assertEqual(len(c.domain), 0)
         self.assertEqual(len(c.domain.metas), 1)
         self.assertEqual(c.metas.shape, (9, 1))
 
     def test_extend_corpus(self):
-        c = Corpus.from_file(os.path.join(DATASET_PATH, 'bookexcerpts.tab'))
+        c = Corpus.from_file('bookexcerpts')
         n_classes = len(c.domain.class_var.values)
         c_copy = c.copy()
         new_y = [c.domain.class_var.values[int(i)] for i in c.Y]
@@ -36,3 +56,17 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(c.metas.shape[0], c_copy.metas.shape[0]*2)
         self.assertEqual(c.metas.shape[1], c_copy.metas.shape[1])
         self.assertEqual(len(c_copy.domain.class_var.values), n_classes+1)
+
+    def test_corpus_not_eq(self):
+        c = Corpus.from_file('bookexcerpts')
+        c2 = Corpus(c.documents[:-1], c.X, c.Y, c.metas, c.domain)
+        self.assertNotEqual(c, c2)
+        c2 = Corpus(c.documents, np.vstack((c.X, c.X)), c.Y, c.metas, c.domain)
+        self.assertNotEqual(c, c2)
+        c2 = Corpus(c.documents, c.X, np.vstack((c.Y, c.Y)), c.metas, c.domain)
+        self.assertNotEqual(c, c2)
+        c2 = Corpus(c.documents, c.X, c.Y, c.metas.T, c.domain)
+        self.assertNotEqual(c, c2)
+        broken_domain = Domain(c.domain.attributes, c.domain.class_var, [StringVariable('text2')])
+        c2 = Corpus(c.documents, c.X, c.Y, c.metas, broken_domain)
+        self.assertNotEqual(c, c2)


### PR DESCRIPTION
Added support for `Corpus.from_file('bookexcerpts')` which looks in default corpora location. Also added equality for corpus.