### PR TITLE
Fixing broken tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+scipy
 nltk
 scikit-learn
 numpy

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ KEYWORDS = [
 ]
 
 INSTALL_REQUIRES = (
+    'scipy',
     'nltk',
     'scikit-learn',
     'numpy',


### PR DESCRIPTION
The missing `scipy` requirement somehow only now broke the travis build.