### PR TITLE
geomap: skip missing (None) values

### DIFF
--- a/orangecontrib/text/widgets/owgeomap.py
+++ b/orangecontrib/text/widgets/owgeomap.py
@@ -155,7 +155,7 @@ html, body, #map {{margin:0px;padding:0px;width:100%;height:100%;}}
         if attr.is_discrete:
             return self.warning(0, 'Discrete region attributes not yet supported. Patches welcome!')
         countries = (set(map(str.strip, CC_NAMES.findall(i.lower()))) if len(i) > 3 else (i,)
-                     for i in self.data.get_column_view(self.data.domain.index(attr))[0])
+                     for i in self.data.get_column_view(self.data.domain.index(attr))[0] if i is not None)
         def flatten(seq):
             return (i for sub in seq for i in sub)
         self.cc_counts = Counter(flatten(countries))


### PR DESCRIPTION
As of some time ago, missing vales are stored as `None` (and not as empty string any more). This causes the code to break with `TypeError: object of type 'NoneType' has no len()`. I propose skipping the `None` values since they represent missing information.