### PR TITLE
fixing Orange installation script

### DIFF
--- a/travis/install_orange.sh
+++ b/travis/install_orange.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 git clone https://github.com/biolab/orange3
 cd orange3
-pip install -r requirements.txt
+pip install -r requirements-core.txt
 python setup.py develop
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Fixing orange installation. Due to changes in Orange, we need to update the `install_orange.sh` script.