### PR TITLE
[WiP] corpus: fix condition for inferring text features

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -49,9 +49,9 @@ class Corpus(Table):
         self.domain = domain
         self.text_features = None    # list of text features for mining
 
-        if domain and text_features is None:
+        if domain is not None and text_features is None:
             self._infer_text_features()
-        elif domain:
+        elif domain is not None:
             self.set_text_features(text_features)
 
         Table._init_ids(self)

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -95,6 +95,17 @@ class CorpusTests(unittest.TestCase):
         c2 = Corpus.from_corpus(c.domain, c, row_indices=list(range(5)))
         self.assertEqual(len(c2), 5)
 
+    def test_infer_text_features(self):
+        c = Corpus.from_file('friends-transcripts')
+        tf = c.text_features
+        self.assertEqual(len(tf), 1)
+        self.assertEqual(tf[0].name, 'Quote')
+
+        c = Corpus.from_file('deerwester')
+        tf = c.text_features
+        self.assertEqual(len(tf), 1)
+        self.assertEqual(tf[0].name, 'text')
+
     def test_asserting_errors(self):
         c = Corpus.from_file('bookexcerpts')
 


### PR DESCRIPTION
Checking if the domain is present did not work for some data sets. `if domain` only checks for features and class vales, but not metas. Consequently, inferring was skipped for datasets with only meta attributes.