### PR TITLE
Fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false   # use container-based infrastructure
 
 python:
   - "3.4"
+  - "3.5"
 
 addons:
     apt:

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Python's site-packages directory), run
 Usage
 -----
 
-After the installation, the widget from this add-on is registered with Orange. To run Orange from the terminal,
+After the installation, the widgets from this add-on are registered with Orange. To run Orange from the terminal,
 use
 
     python3 -m Orange.canvas
 
-Text Mining widgets are in the toolbox bar under Text Mining section.
+new widgets are in the toolbox bar under Text Mining section.

--- a/README.pypi
+++ b/README.pypi
@@ -1,11 +1,8 @@
-Orange Text - In Development
-============================
+Orange3 Text
+============
 
-**NOTE: This plug-in currently could NOT be installed. We are working on resolving the issue; until then if curious you can install it [from source](https://github.com/biolab/orange3-text) but beware that it is still in development.**
-
-Orange3 Text extends Orange with common functionality for text mining. It provides access
-to publicly available data, like NY Times, Twitter and PubMed. Further,
-it provides tools for preprocessing, constructing vector spaces (like
-bag-of-words, topic modeling and word2vec) and visualizations like word cloud
-end geo map. All features can be combined with powerful data mining techniques
-from the Orange data mining framework.
+Orange add-on for text mining. It provides access to publicly available data,
+like NY Times, Twitter and PubMed. Further, it provides tools for preprocessing,
+constructing vector spaces (like bag-of-words, topic modeling and word2vec) and
+visualizations like word cloud end geo map. All features can be combined with
+powerful data mining techniques from the Orange data mining framework.

--- a/orangecontrib/text/nyt.py
+++ b/orangecontrib/text/nyt.py
@@ -27,6 +27,7 @@ def _parse_record_json(records, includes_metadata):
     :type includes_metadata: list
     :return: A list of the corresponding metadata and class values for the instances.
     """
+    IGNORED_FIELDS = {'content_kicker', 'kicker', 'print_headline'}     # the garbage fields next to headline
     class_values = []
     metadata = []
     for doc in records:
@@ -34,7 +35,7 @@ def _parse_record_json(records, includes_metadata):
         for field in includes_metadata:
             field_value = doc.get(field) or ''
             if isinstance(field_value, dict):
-                field_value = " ".join([v for v in field_value.values() if v])
+                field_value = " ".join([v for k, v in field_value.items() if v and k not in IGNORED_FIELDS])
             elif isinstance(field_value, list):
                 field_value = " ".join([kw["value"] for kw in field_value if kw])
             metas_row.append(unescape(field_value) if isinstance(field_value, str) else field_value)
@@ -73,9 +74,6 @@ def _generate_corpus(records, required_text_fields):
     :return: :class: `orangecontrib.text.corpus.Corpus`
     """
     metas, class_values = _parse_record_json(records, required_text_fields)
-    documents = []
-    for doc in metas:
-        documents.append(" ".join([d for d in doc if d is not None]).strip())
 
     # Create domain.
     meta_vars = [StringVariable.make(field) for field in required_text_fields]

--- a/orangecontrib/text/stats.py
+++ b/orangecontrib/text/stats.py
@@ -9,19 +9,24 @@ _c = [1.0]
 for m in range(2, 100000):
     _c.append(_c[-1] + 1.0/m)
 
+
 def is_sorted(l):
     return all(l[i] <= l[i+1] for i in range(len(l)-1))
+
 
 def false_discovery_rate(p_values, dependent=False, m=None, ordered=False):
     """
     `False Discovery Rate <http://en.wikipedia.org/wiki/False_discovery_rate>`_ correction on a list of p-values.
 
-    :param p_values: a list of p-values.
-    :param dependent: use correction for dependent hypotheses (default False).
-    :param m: number of hypotheses tested (default ``len(p_values)``).
-    :param ordered: prevent sorting of p-values if they are already sorted (default False).
-    """
+    Args:
+        p_values: a list of p-values.
+        dependent: use correction for dependent hypotheses.
+        m: number of hypotheses tested (default ``len(p_values)``).
+        ordered: prevent sorting of p-values if they are already sorted.
 
+    Returns: A list of corrected p-values.
+
+    """
     if not ordered:
         ordered = is_sorted(p_values)
 
@@ -62,12 +67,15 @@ def hypergeom_p_values(data, selected, callback=None):
     Calculates p_values using Hypergeometric distribution for two numpy arrays.
     Works on a matrices containing zeros and ones. All other values are truncated to zeros and ones.
 
-    :param data: all examples in rows, theirs features in columns
-    :type data: numpy.array
-    :param selected: selected examples in rows, theirs features in columns
-    :type selected: numpy.array
-    :return: p-values for features
+    Args:
+        data (numpy.array): all examples in rows, theirs features in columns.
+        selected (numpy.array): selected examples in rows, theirs features in columns.
+        callback: callback function used for printing progress.
+
+    Returns: p-values for features
+
     """
+
     if data.shape[1] != selected.shape[1]:
         raise ValueError("Number of columns does not match.")
 

--- a/orangecontrib/text/tests/test_stats.py
+++ b/orangecontrib/text/tests/test_stats.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from orangecontrib.text.stats import hypergeom_p_values
+from orangecontrib.text.stats import hypergeom_p_values, false_discovery_rate, is_sorted
 
 class StatsTests(unittest.TestCase):
     x = np.array([[0, 0, 9, 0, 1],
@@ -19,3 +19,40 @@ class StatsTests(unittest.TestCase):
         clipped = self.x.clip(min=0, max=1)
         pvals = hypergeom_p_values(clipped, clipped[-2:, :])
         np.testing.assert_almost_equal(pvals, results)
+
+        with self.assertRaises(ValueError):
+            hypergeom_p_values(self.x, self.x[-2:, :-1])
+
+
+    def test_false_discovery_rate(self):
+        p_values = np.array(
+            [0.727, 0.281, 0.791, 0.034, 0.628, 0.743, 0.958, 0.552, 0.867, 0.606,
+             0.611, 0.594, 0.071, 0.517, 0.526, 0.526, 0.635, 0.932, 0.210, 0.636])
+        # calculated with http://www.sdmproject.com/utilities/?show=FDR
+        fdr_fixed = np.array(
+            [0.92875, 0.9085714, 0.9305882, 0.68, 0.9085714, 0.92875, 0.958, 0.9085714,
+             0.958, 0.9085714, 0.9085714, 0.9085714, 0.71, 0.9085714, 0.9085714, 0.9085714,
+             0.9085714, 0.958, 0.9085714, 0.9085714]
+        )
+        corrected = false_discovery_rate(p_values)
+        np.testing.assert_allclose(corrected, fdr_fixed)
+
+        corrected = false_discovery_rate(p_values, m=len(p_values))
+        np.testing.assert_allclose(corrected, fdr_fixed)
+
+        corrected = false_discovery_rate(sorted(p_values), ordered=True)
+        np.testing.assert_allclose(sorted(corrected), sorted(fdr_fixed))
+
+        np.testing.assert_equal(false_discovery_rate([]), [])
+        np.testing.assert_equal(false_discovery_rate(p_values, m=-1), [])
+
+        dependant = [3.3414007065721947, 3.2688034599191167, 3.3480141985890031, 2.446462966857704,
+                     3.2688034599191167, 3.3414007065721947, 3.4466345915436469, 3.2688034599191167,
+                     3.4466345915436469, 3.2688034599191167, 3.2688034599191167, 3.2688034599191167,
+                     2.554395156572014, 3.2688034599191167, 3.2688034599191167, 3.2688034599191167,
+                     3.2688034599191167, 3.4466345915436469, 3.2688034599191167, 3.2688034599191167]
+        np.testing.assert_equal(false_discovery_rate(p_values, dependent=True), dependant)
+
+    def test_is_sorted(self):
+        self.assertTrue(is_sorted(range(10)))
+        self.assertFalse(is_sorted(range(10)[::-1]))

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -133,10 +133,7 @@ class OWCorpusViewer(OWWidget):
         should_filter = bool(search_keyword)
         is_match = re.compile(search_keyword, re.IGNORECASE).search
 
-        for i, document in enumerate(self.corpus):
-            # TODO: remove corpus.documents due to problems with inconsistencies.
-            document_contents = self.corpus.documents[i]
-
+        for i, (document, document_contents) in enumerate(zip(self.corpus, self.corpus.documents)):
             has_hit = not should_filter or is_match(document_contents)
             if has_hit:
                 item = QStandardItem()

--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -16,8 +16,8 @@ class OWWordEnrichment(OWWidget):
     priority = 60
 
     # Input/output
-    inputs = [("Data", Table, "set_data"),
-              ("Selected Data", Table, "set_data_selected")]
+    inputs = [("Selected Data", Table, "set_data_selected"),
+              ("Data", Table, "set_data"),]
     want_main_area = True
 
     # Settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ scipy
 nltk
 scikit-learn
 numpy
-gensim
+gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,10 @@ KEYWORDS = [
     'orange3 add-on',
 ]
 
-INSTALL_REQUIRES = (
-    'scipy',
-    'nltk',
-    'scikit-learn',
-    'numpy',
-    'gensim>=0.12.3',
-)
+INSTALL_REQUIRES = sorted(set(
+    line.partition('#')[0].strip()
+    for line in open(os.path.join(os.path.dirname(__file__), 'requirements.txt'))
+) - {''})
 
 if 'test' in sys.argv:
     extra_setuptools_args = dict(

--- a/travis/nltk_download.sh
+++ b/travis/nltk_download.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-if [ "$(ls -A $HOME/nltk_data)" ]; then
-    echo "Using cached NLTK data containing folders:";
-    ls $HOME/nltk_data;
-else
-    python -m nltk.downloader wordnet;
-fi
+data=( "wordnet" )
+
+for d in "${data[@]}"
+do
+    python -m nltk.downloader $d;
+done
+
+echo "Contents of NLTK data folder:"
+ls $HOME/nltk_data;


### PR DESCRIPTION
Various fixes before new release:
* since `corpus.documents` now regenerates documents on the fly, so calling is inside a loop causes unnecessary square time complexity
* removed garbage fields from NYT headline
* fixed NLTK data download
* added Python 3.5 testing
* `setup.py` requirements are read from file
* other small fixes & tests