### PR TITLE
CorpusViewer: Support Table, search in Search features

### DIFF
--- a/orangecontrib/text/bagofowords.py
+++ b/orangecontrib/text/bagofowords.py
@@ -50,7 +50,7 @@ class BagOfWords():
 
         bow_corpus = corpus.copy()
         feats = [v for k, v in sorted(dictionary.items())]
-        bow_corpus.extend_attributes(X, feats)
+        bow_corpus.extend_attributes(X, feats, var_attrs={'bow_feature': True})
         self.check_progress()  # Step 4
 
         return bow_corpus

--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -113,18 +113,25 @@ class Corpus(Table):
 
         self._tokens = None     # invalidate tokens
 
-    def extend_attributes(self, X, feature_names):
+    def extend_attributes(self, X, feature_names, var_attrs=None):
         """
         Append features to corpus.
 
         Args:
             X (numpy.ndarray): Features to append
             feature_names (list): List of string containing feature names
+            var_attrs (dict): Additional attributes appended to variable.attributes.
         """
         self.X = np.hstack((self.X, X))
 
         new_attr = self.domain.attributes
-        new_attr += tuple(ContinuousVariable.make(f) for f in feature_names)
+
+        for f in feature_names:
+            var = ContinuousVariable.make(f)
+            if isinstance(var_attrs, dict):
+                var.attributes.update(var_attrs)
+            new_attr += (var, )
+
         new_domain = Domain(
                 attributes=new_attr,
                 class_vars=self.domain.class_vars,

--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -24,7 +24,7 @@ def _check_arrays(*arrays):
 
 
 class Corpus(Table):
-    """Internal class for storing a corpus of orangecontrib.text.corpus.Corpus."""
+    """Internal class for storing a corpus."""
 
     def __new__(cls, *args, **kwargs):
         """Bypass Table.__new__."""
@@ -134,11 +134,30 @@ class Corpus(Table):
     @property
     def documents(self):
         """
-        Returns a list of strings representing documents.
-        Each documents is created by joining selected text features.
+        Returns: a list of strings representing documents — created by joining
+            selected text features.
         """
-        indices = [self.domain.metas.index(f) for f in self.text_features]
-        return [' '.join(map(str, i)) for i in self.metas[:, indices]]
+        return self.documents_from_features(self.text_features)
+
+    def documents_from_features(self, feats):
+        """
+        Args:
+            feats (list): A list fo features to join.
+
+        Returns: a list of strings constructed by joining feats.
+        """
+        # create a Table where feats are in metas
+        data = Table(Domain([], [], [i.name for i in feats],
+                            source=self.domain), self)
+
+        # map DiscreteVariables to values
+        text = data.metas.astype(object)
+        for col, f in enumerate(data.domain.metas):
+            if f.is_discrete:
+                for row, val in enumerate(text[:, col]):
+                    text[row, col] = f.values[int(val)]
+
+        return [' '.join(map(str, i)) for i in text]
 
     def store_tokens(self, tokens):
         """

--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -1,4 +1,5 @@
 import os
+from itertools import chain
 
 import numpy as np
 
@@ -65,8 +66,8 @@ class Corpus(Table):
             feats (list): list of text features to include.
         """
         for f in feats:
-            if f not in self.domain.metas:
-                raise ValueError('Feature "{}" not found in metas.'.format(f))
+            if f not in chain(self.domain.variables, self.domain.metas):
+                raise ValueError('Feature "{}" not found.'.format(f))
         if len(set(feats)) != len(feats):
             raise ValueError('Text features must be unique.')
         self.text_features = feats

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -1,5 +1,7 @@
 import os
 import unittest
+from itertools import chain
+
 import numpy as np
 
 from Orange.data import Table
@@ -105,6 +107,27 @@ class CorpusTests(unittest.TestCase):
         tf = c.text_features
         self.assertEqual(len(tf), 1)
         self.assertEqual(tf[0].name, 'text')
+
+    def test_documents(self):
+        c = Corpus.from_file('bookexcerpts')
+        docs = c.documents
+        types = set(type(i) for i in docs)
+
+        self.assertEqual(len(docs), len(c))
+        self.assertEqual(len(types), 1)
+        self.assertIn(str, types)
+
+    def test_documents_from_features(self):
+        c = Corpus.from_file('bookexcerpts')
+        docs = c.documents_from_features([c.domain.class_var])
+        types = set(type(i) for i in docs)
+
+        self.assertTrue(all(
+            [sum(cls in doc for cls in c.domain.class_var.values) == 1
+             for doc in docs]))
+        self.assertEqual(len(docs), len(c))
+        self.assertEqual(len(types), 1)
+        self.assertIn(str, types)
 
     def test_asserting_errors(self):
         c = Corpus.from_file('bookexcerpts')

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -135,7 +135,9 @@ class OWCorpusViewer(OWWidget):
         self.display_features = []
         if self.corpus is not None:
             domain = self.corpus.domain
-            self.features = list(chain(domain.variables, domain.metas))
+            self.features = list(filter(
+                lambda x: not x.attributes.get('bow_feature', False),
+                chain(domain.variables, domain.metas)))
             # FIXME: Select features based on ContextSetting
             self.search_features = list(range(len(self.features)))
             self.display_features = list(range(len(self.features)))

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -1,4 +1,5 @@
 import re
+import sre_constants
 from itertools import chain
 
 from PyQt4 import QtCore
@@ -70,11 +71,11 @@ class OWCorpusViewer(OWWidget):
         # ---- MAIN AREA ----
         # Search
         self.filter_input = gui.lineEdit(self.mainArea, self, '',
-                                         orientation='horizontal',
+                                         orientation=Qt.Horizontal,
                                          label='RegExp Filter:')
         self.filter_input.textChanged.connect(self.refresh_search)
 
-        h_box = gui.widgetBox(self.mainArea, orientation='horizontal', addSpace=True)
+        h_box = gui.widgetBox(self.mainArea, orientation=Qt.Horizontal, addSpace=True)
         h_box.layout().setSpacing(0)
 
         # Document list.
@@ -147,11 +148,15 @@ class OWCorpusViewer(OWWidget):
         if not self.corpus or not self.corpus_docs:
             return
 
+        search_keyword = self.filter_input.text().strip('|')
+        try:
+            is_match = re.compile(search_keyword, re.IGNORECASE).search
+        except sre_constants.error:
+            return
+
+        should_filter = bool(search_keyword)
         self.output_mask = []
         self.document_table_model.clear()
-        search_keyword = self.filter_input.text().strip('|')
-        should_filter = bool(search_keyword)
-        is_match = re.compile(search_keyword, re.IGNORECASE).search
 
         for i, (document, document_contents) in enumerate(zip(self.corpus, self.corpus_docs)):
             has_hit = not should_filter or is_match(document_contents)

--- a/orangecontrib/text/widgets/owloadcorpus.py
+++ b/orangecontrib/text/widgets/owloadcorpus.py
@@ -1,4 +1,6 @@
 import os
+from itertools import chain
+
 from PyQt4 import QtGui
 
 from Orange.widgets.settings import Setting
@@ -134,7 +136,9 @@ class OWLoadCorpus(OWWidget):
             self.corpus = Corpus.from_file(path)
             self.info_label.setText("Corpus of {} documents.".format(len(self.corpus)))
             self.used_attrs.extend(self.corpus.text_features)
-            self.unused_attrs.extend([f for f in self.corpus.domain.metas if f not in self.corpus.text_features])
+            self.unused_attrs.extend([f for f in chain(self.corpus.domain.variables,
+                                                       self.corpus.domain.metas)
+                                      if f not in self.corpus.text_features])
         except BaseException as err:
             self.error(1, str(err))
 


### PR DESCRIPTION
* CorpusViewer adopted for Tables. Instead of searching in `corpus.documents` it searches in `Search features` and it displays `Display features`.
* CorpusViewer skip Bag-of-Words features.
* LoadCorpus allows attributes and class_vars for mining.
