### PR TITLE
add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include orangecontrib/text/tutorials/*.ows
+include orangecontrib/text/datasets/*
+include orangecontrib/text/widgets/icons/*
+include orangecontrib/text/widgets/resources/*
+include orangecontrib/text/tests/nyt-cache.txt
+include orangecontrib/text/tests/tweets.json
+
+include requirements.txt
+include README.md
+include README.pypi
+include LICENSE


### PR DESCRIPTION
When installing directly from git (pip install URL.zip) some required data (icons, js, datasets, ...)
were included in a ZIP but not installed. Using MANIFEST.in this works again.