### PR TITLE
Corpus: Fix copy to copy _tokens and _dictionary

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -1,4 +1,5 @@
 import os
+import copy
 from itertools import chain
 
 import numpy as np
@@ -228,6 +229,8 @@ class Corpus(Table):
         """Return a copy of the table."""
         c = self.__class__(self.X, self.Y, self.metas, self.domain, self.text_features)
         c.ensure_copy()
+        c._tokens = copy.copy(self._tokens)
+        c._dictionary = copy.copy(self._dictionary)
         return c
 
     def __len__(self):


### PR DESCRIPTION
When we create a copy of corpus _tokens and _dictionary should be copied as well.