### PR TITLE
Implement __getitem__ for Corpus

### DIFF
--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -156,6 +156,37 @@ class CorpusTests(unittest.TestCase):
             first_attr = c.domain.attributes[0].str_val(first_attr)
             self.assertIn(first_attr, d)
 
+    def test_getitem(self):
+        c = Corpus.from_file('bookexcerpts')
+
+        # without preprocessing
+        self.assertEqual(len(c[:, :]), len(c))
+
+        # run default preprocessing
+        c.tokens
+
+        sel = c[:, :]
+        self.assertEqual(sel, c)
+
+        sel = c[0]
+        self.assertEqual(len(sel), 1)
+        self.assertEqual(len(sel._tokens), 1)
+        np.testing.assert_equal(sel._tokens, np.array([c._tokens[0]]))
+        self.assertEqual(sel._dictionary, c._dictionary)
+
+        sel = c[0:5]
+        self.assertEqual(len(sel), 5)
+        self.assertEqual(len(sel._tokens), 5)
+        np.testing.assert_equal(sel._tokens, c._tokens[0:5])
+        self.assertEqual(sel._dictionary, c._dictionary)
+
+        ind = [3, 4, 5, 6]
+        sel = c[ind]
+        self.assertEqual(len(sel), len(ind))
+        self.assertEqual(len(sel._tokens), len(ind))
+        np.testing.assert_equal(sel._tokens, c._tokens[ind])
+        self.assertEqual(sel._dictionary, c._dictionary)
+
     def test_asserting_errors(self):
         c = Corpus.from_file('bookexcerpts')
 
@@ -171,3 +202,7 @@ class CorpusTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             c.set_text_features([c.domain.metas[0], c.domain.metas[0]])
+
+        c.tokens    # preprocess
+        with self.assertRaises(TypeError):
+            c[..., 0]

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -4,6 +4,7 @@ import unittest
 import itertools
 import nltk
 from gensim import corpora
+import numpy as np
 
 from orangecontrib.text import preprocess
 from orangecontrib.text.corpus import Corpus
@@ -31,12 +32,14 @@ class PreprocessTests(unittest.TestCase):
                 return string[:-1]
         p = Preprocessor(transformers=StripStringTransformer())
 
-        self.assertEqual(p(self.corpus).tokens, [[doc[:-1]] for doc in self.corpus.documents])
+        np.testing.assert_equal(p(self.corpus).tokens,
+                                np.array([[doc[:-1]] for doc in self.corpus.documents]))
 
         p = Preprocessor(transformers=[StripStringTransformer(),
                                        preprocess.LowercaseTransformer()])
 
-        self.assertEqual(p(self.corpus).tokens, [[doc[:-1].lower()] for doc in self.corpus.documents])
+        np.testing.assert_equal(p(self.corpus).tokens,
+                                np.array([[doc[:-1].lower()] for doc in self.corpus.documents]))
 
         self.assertRaises(TypeError, Preprocessor, string_transformers=1)
 
@@ -47,8 +50,8 @@ class PreprocessTests(unittest.TestCase):
                 return string.split()
         p = Preprocessor(tokenizer=SpaceTokenizer())
 
-        self.assertEqual(p(self.corpus).tokens,
-                         [sent.split() for sent in self.corpus.documents])
+        np.testing.assert_equal(p(self.corpus).tokens,
+                         np.array([sent.split() for sent in self.corpus.documents]))
 
     def test_token_normalizer(self):
         class CapTokenNormalizer(preprocess.BaseNormalizer):
@@ -57,8 +60,8 @@ class PreprocessTests(unittest.TestCase):
                 return token.capitalize()
         p = Preprocessor(normalizer=CapTokenNormalizer())
 
-        self.assertEqual(p(self.corpus).tokens,
-                         [[sent.capitalize()] for sent in self.corpus.documents])
+        np.testing.assert_equal(p(self.corpus).tokens,
+                                np.array([[sent.capitalize()] for sent in self.corpus.documents]))
 
     def test_token_filter(self):
         class SpaceTokenizer(preprocess.BaseTokenizer):
@@ -72,9 +75,9 @@ class PreprocessTests(unittest.TestCase):
                 return len(token) < 4
 
         p = Preprocessor(tokenizer=SpaceTokenizer(), filters=LengthFilter())
-        self.assertEqual(p(self.corpus).tokens,
-                         [[token for token in doc.split() if len(token) < 4]
-                          for doc in self.corpus.documents])
+        np.testing.assert_equal(p(self.corpus).tokens,
+                         np.array([[token for token in doc.split() if len(token) < 4]
+                                   for doc in self.corpus.documents]))
 
 
 class TransformationTests(unittest.TestCase):


### PR DESCRIPTION
Currently when indexing a corpus preprocessing is lost. This PR introduces two changes:
- Before storing tokens cast them to `ndarray`. This makes indexing easier and unifies the type of `tokens` with `X`, `Y` and `metas`.
- Implement `Corpus.__getitem__` that retains preprocessing.