### PR TITLE
Twitter: allow empty word list

### DIFF
--- a/orangecontrib/text/twitter.py
+++ b/orangecontrib/text/twitter.py
@@ -118,8 +118,13 @@ class TwitterAPI:
         if word_list is None:
             word_list = []
 
-        query = " OR ".join(['"{}"'.format(q) for q in word_list] +
-                            ['from:{}'.format(user) for user in authors])
+        if not word_list and not authors:
+            # allows empty queries
+            query = "from: "
+        else:
+            query = " OR ".join(['"{}"'.format(q) for q in word_list] +
+                                ['from:{}'.format(user) for user in authors])
+
         if since:
             query += ' since:' + since.strftime('%Y-%m-%d')
         if until:

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -152,7 +152,7 @@ class OWTwitter(OWWidget):
 
     CONTENT, AUTHOR, CONTENT_AUTHOR = 0, 1, 2
     recent_api_keys = Setting([])
-    word_list = Setting('')
+    word_list = Setting([])
     mode = Setting(0)
     limited_search = Setting(True)
     max_tweets = Setting(100)
@@ -301,8 +301,8 @@ class OWTwitter(OWWidget):
             if not self.advance:
                 self.api.reset()
             self.search_button.setText("Stop")
-            word_list = self.word_list if self.mode in [self.CONTENT, self.CONTENT_AUTHOR] else []
-            authors = self.word_list if self.mode in [self.AUTHOR, self.CONTENT_AUTHOR] else []
+            word_list = self.word_list if self.mode in [self.CONTENT, self.CONTENT_AUTHOR] else None
+            authors = self.word_list if self.mode in [self.AUTHOR, self.CONTENT_AUTHOR] else None
 
             self.api.search(max_tweets=self.max_tweets if self.limited_search else 0,
                             word_list=word_list, authors=authors, lang=self.language,

--- a/orangecontrib/text/widgets/utils/widgets.py
+++ b/orangecontrib/text/widgets/utils/widgets.py
@@ -21,7 +21,14 @@ class ListEdit(QTextEdit):
 
     def synchronize(self):
         if self.master and self.attr:
-            setattr(self.master, self.attr, self.toPlainText().split('\n'))
+            setattr(self.master, self.attr, self.value())
+
+    def value(self):
+        return self.text.split('\n') if self.text else []
+
+    @property
+    def text(self):
+        return self.toPlainText().strip()
 
 
 class CheckListLayout(QtGui.QGroupBox):


### PR DESCRIPTION
@nikicc has mentioned (#72) that OWTwitter can produce 403 error. This PR is supposed to fix it.