### PR TITLE
BaseTokenizer: Skip empty strings

### DIFF
--- a/orangecontrib/text/preprocess/tokenize.py
+++ b/orangecontrib/text/preprocess/tokenize.py
@@ -17,7 +17,7 @@ class BaseTokenizer:
         return self.tokenize_sents(sent)
 
     def tokenize(self, string):
-        return self.tokenizer.tokenize(string)
+        return list(filter(lambda x: x != '', self.tokenizer.tokenize(string)))
 
     def tokenize_sents(self, strings):
         return [self.tokenize(string) for string in strings]

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -346,3 +346,8 @@ class TokenizerTests(unittest.TestCase):
     def test_str(self):
         tokenizer = preprocess.RegexpTokenizer(pattern=r'\S+')
         self.assertIn('\S+', str(tokenizer))
+
+    def test_skip_empty_strings(self):
+        tokenizer = preprocess.RegexpTokenizer(pattern=r'[^h ]*')
+        tokens = tokenizer('whatever')
+        self.assertNotIn('', tokens)


### PR DESCRIPTION
RegexpTokenizer can sometimes match empty strings which afterwards causes the call to `ContinuousVariable.make(f)` to raise the `Variables without names cannot be stored or made` exception.