### PR TITLE
OWPreprocessor: Remove redundant change_signal.emit()

### DIFF
--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -147,7 +147,6 @@ class PreprocessorModule(gui.OWComponent, QWidget):
         # Activated when the widget is enabled/disabled.
         self.enabled = not self.enabled
         self.display_widget()
-        self.change_signal.emit()
 
     def display_widget(self):
         if self.enabled:


### PR DESCRIPTION
Fixes #81. Emitting `change_signal` in `on_toggle` is redundant since it also calls `display_widget`. Inside `display_widget` we set `self.value` and since value setters itself emmits `change_signal` we shouldn't re-emit it inside `on_toggle`.