### PR TITLE
OWLoadCorpus: Load first file in __init__

### DIFF
--- a/orangecontrib/text/widgets/owloadcorpus.py
+++ b/orangecontrib/text/widgets/owloadcorpus.py
@@ -70,6 +70,9 @@ class OWLoadCorpus(OWWidget):
         self.unused_attrs_view.setModel(self.unused_attrs)
         ibox.layout().addWidget(self.unused_attrs_view)
 
+        # load first file
+        widget.select(0)
+
     def open_file(self, path):
         self.error(1, '')
         self.used_attrs[:] = []


### PR DESCRIPTION
When reloading schemas the most recent file was selected but was not loaded. Calling `widget.select` resolves the issue.