### PR TITLE
Twitter: Use Credential Manager for API Keys

### DIFF
--- a/orangecontrib/text/credentials.py
+++ b/orangecontrib/text/credentials.py
@@ -1,0 +1,26 @@
+import keyring
+
+SERVICE_NAME = 'Orange3 Text - {}'
+
+
+class CredentialManager:
+    def __init__(self, username):
+        """
+        Class for storing passwords in the system keyring service.
+
+        Args:
+            username: username used for storing a matching password.
+        """
+        self.username = username
+        self.service_name = SERVICE_NAME.format(self.username)
+
+    @property
+    def key(self):
+        return keyring.get_password(self.service_name, self.username)
+
+    @key.setter
+    def key(self, value):
+        keyring.set_password(self.service_name, self.username, value)
+
+    def delete_password(self):
+        keyring.delete_password(self.service_name, self.username)

--- a/orangecontrib/text/tests/test_credentials.py
+++ b/orangecontrib/text/tests/test_credentials.py
@@ -1,0 +1,12 @@
+import unittest
+
+from orangecontrib.text.credentials import CredentialManager
+
+
+class CredentialManagerTests(unittest.TestCase):
+    def test_credential_manager(self):
+        cm = CredentialManager('Foo')
+        cm.key = 'Bar'
+        self.assertEqual(cm.key, 'Bar')
+        cm.delete_password()
+        self.assertEqual(cm.key, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ beautifulsoup4
 simhash
 wikipedia
 keyring
+keyrings.alt    # for running test on travis

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tweepy
 beautifulsoup4
 simhash
 wikipedia
+keyring


### PR DESCRIPTION
This PR proposes two changes to APICredentialDialogs. I.e. to use:

- credential manager to store passwords in system keyring services,
- `OWWidget` instead of `QDialog` directly.


**Credential Manager:**
Storing API keys in settings is problematic due to many reasons. The most annoying one for developers being the need to re-input all keys one settings are reseted. Moreover, settings are allegedly saved in plain text and also inside schemas, which is problematic when sending schemas around to others.

Here proposed Credential Manager stores API keys in system keyring services like Keychain, Credential Vault, Secret Service, etc. One consequence of this is that we now store only one key instead of many as we did before. The example of usage is shown on the Twitter Widget.

**OWWidget:**
Currently all widgets for inputing API keys extend `QDialog` directly and not Orange's `OWWidget`. Hence many Orange's benefits like warnings etc. cannot be used.