### PR TITLE
Fixups

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -284,6 +284,11 @@ class Corpus(Table):
             else:
                 raise TypeError('Indexing by type {} not supported.'.format(type(key)))
             c._dictionary = self._dictionary
+
+        c.text_features = self.text_features
+        c.ngram_range = self.ngram_range
+        c.attributes = self.attributes
+
         return c
 
     def __len__(self):

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -3,7 +3,7 @@ import unittest
 from distutils.version import LooseVersion
 
 import numpy as np
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, issparse
 
 import Orange
 from Orange.data import Table
@@ -61,6 +61,22 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(c.metas.shape[0], c_copy.metas.shape[0]*2)
         self.assertEqual(c.metas.shape[1], c_copy.metas.shape[1])
         self.assertEqual(len(c_copy.domain.class_var.values), n_classes+1)
+
+    def test_extend_attributes(self):
+        # corpus without features
+        c = Corpus.from_file('bookexcerpts')
+        X = np.random.random((len(c), 3))
+        c.extend_attributes(X, ['1', '2', '3'])
+        self.assertEqual(c.X.shape, (len(c), 3))
+
+        # add to non empty corpus
+        c.extend_attributes(X, ['1', '2', '3'])
+        self.assertEqual(c.X.shape, (len(c), 6))
+
+        # extend sparse
+        c.extend_attributes(csr_matrix(X), ['1', '2', '3'])
+        self.assertEqual(c.X.shape, (len(c), 9))
+        self.assertTrue(issparse(c.X))
 
     def test_corpus_not_eq(self):
         c = Corpus.from_file('bookexcerpts')

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -207,6 +207,9 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(sel._tokens), len(ind))
         np.testing.assert_equal(sel._tokens, c._tokens[ind])
         self.assertEqual(sel._dictionary, c._dictionary)
+        self.assertEqual(sel.text_features, c.text_features)
+        self.assertEqual(sel.ngram_range, c.ngram_range)
+        self.assertEqual(sel.attributes, c.attributes)
 
     def test_asserting_errors(self):
         c = Corpus.from_file('bookexcerpts')


### PR DESCRIPTION
The PR includes two fixups on Corpus:
- fix `extend_attributes` for dense matrices,
- fix `__getitem__` to copy all attributes.