### PR TITLE
[RFC] Changed defaults for Preprocess

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -42,13 +42,13 @@ class WordListMixin:
 
 
 class StopwordsFilter(BaseTokenFilter, WordListMixin):
-    """ Filters out words that listed in a file or in a list of stopwords for specific language. """
+    """ Filters out words listed in a file or in a list of stopwords for specific language. """
     name = 'Stopwords'
 
-    supported_languages = [file for file in os.listdir(stopwords._get_root())
+    supported_languages = [file.capitalize() for file in os.listdir(stopwords._get_root())
                            if file.islower()]
 
-    def __init__(self, language='english', word_list=None):
+    def __init__(self, language='English', word_list=None):
         WordListMixin.__init__(self, word_list)
         super().__init__()
         self.language = language

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -328,7 +328,7 @@ class FilteringModule(MultipleMethodModule):
     KEEP_N = 4
     dlgFormats = 'Only text files (*.txt)'
 
-    stopwords_language = settings.Setting('english')
+    stopwords_language = settings.Setting('English')
 
     recent_sw_files = settings.Setting([])
     recent_lexicon_files = settings.Setting([])
@@ -336,7 +336,7 @@ class FilteringModule(MultipleMethodModule):
     pattern = settings.Setting('\.|,|:|!|\?')
     min_df = settings.Setting(0.)
     max_df = settings.Setting(1.)
-    keep_n = settings.Setting(10**5)
+    keep_n = settings.Setting(100)
     use_keep_n = settings.Setting(False)
     use_df = settings.Setting(False)
 
@@ -445,8 +445,9 @@ class NgramsModule(PreprocessorModule):
     attribute = 'ngrams_range'
     title = 'N-grams Range'
     toggle_enabled = True
+    enabled = settings.Setting(False)
 
-    ngrams_range = settings.Setting((1, 1))
+    ngrams_range = settings.Setting((1, 2))
 
     def setup_method_layout(self):
         self.method_layout.addWidget(
@@ -462,6 +463,7 @@ class NgramsModule(PreprocessorModule):
 class POSTaggingModule(SingleMethodModule):
     title = 'POS Tagger'
     attribute = 'pos_tagger'
+    enabled = settings.Setting(False)
 
     STANFORD = len(taggers)
     stanford = settings.SettingProvider(ResourceLoader)


### PR DESCRIPTION
- Token frequency set to 100
- Stopword list capitalized
- N-grams and POS tagger turned off by default
- when n-grams are on, default is (1,2)