### PR TITLE
Fix Version Imports for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 
 install:
     - travis_wait pip install -r requirements.txt
+    - python setup.py develop   # assure version.py is present; required for imports
 
 script:
     - coverage run setup.py test


### PR DESCRIPTION
Missing `version.py` seems to break travis tests due to failing imports of `orangecontrib.text`.