### PR TITLE
asynchronous redesign

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -295,6 +295,18 @@ class MockOrange(MagicMock):
         return MockData() if name in cls.__all__ else MagicMock()  # required since Corpus extends Table
 
 
+class MockGUI(MagicMock):
+    __all__ = ['OWComponent', ]
+
+    class MockClasses:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    @classmethod
+    def __getattr__(cls, name):
+        return cls.MockClasses if name in cls.__all__ else MagicMock()
+
+
 MOCK_MODULES = [
     ('Orange', MockOrange),
     ('Orange.data', MockData),
@@ -303,6 +315,8 @@ MOCK_MODULES = [
     ('Orange.data.table', MockData),
     ('Orange.data.variable', MockData),
     ('Orange.canvas.utils', MockData),
+    ('Orange.widgets', MockGUI),
+    ('Orange.widgets.gui', MockGUI),
 ]
 
 for name, mock_class in MOCK_MODULES:
@@ -312,6 +326,7 @@ for name, mock_class in MOCK_MODULES:
 # from Orange.canvas.utils import environ
 # from Orange.data import Table, StringVariable, Domain
 # from Orange import data
+# from Orange.widgets.gui import OWComponent, hBox
 # isinstance(None, Table)
 # isinstance(None, Domain)
 # isinstance(None, StringVariable)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,6 +35,7 @@ Welcome to Orange3 Text Mining documentation!
    scripting/wikipedia.rst
    scripting/topicmodeling.rst
    scripting/tag.rst
+   scripting/async
 
 Indices and tables
 ==================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,7 +35,7 @@ Welcome to Orange3 Text Mining documentation!
    scripting/wikipedia.rst
    scripting/topicmodeling.rst
    scripting/tag.rst
-   scripting/async
+   scripting/async.rst
 
 Indices and tables
 ==================

--- a/doc/scripting/async.rst
+++ b/doc/scripting/async.rst
@@ -1,0 +1,3 @@
+
+.. automodule:: orangecontrib.text.widgets.utils.concurrent
+

--- a/orangecontrib/text/twitter.py
+++ b/orangecontrib/text/twitter.py
@@ -108,8 +108,8 @@ class TwitterAPI:
         # Callbacks:
         self.on_error = on_error
         self.on_rate_limit = on_rate_limit
-        self.on_progress = on_progress
-        self.should_break = should_break
+        self.on_progress = on_progress or (lambda *args: args)
+        self.should_break = should_break or (lambda *args: False)
 
     @property
     def tweets(self):
@@ -187,11 +187,6 @@ class TwitterAPI:
         return corpus
 
     def fetch(self, cursors, max_tweets):
-        if not self.on_progress:
-            self.on_progress = lambda x, y: (x, y)
-        if not self.should_break:
-            self.should_break = lambda: False
-
         if not isinstance(cursors, list):
             cursors = [cursors]
 

--- a/orangecontrib/text/widgets/ownyt.py
+++ b/orangecontrib/text/widgets/ownyt.py
@@ -10,14 +10,14 @@ from Orange.widgets.widget import OWWidget, Msg, gui
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.nyt import NYT, MIN_DATE
 from orangecontrib.text.widgets.utils import CheckListLayout, DatePickerInterval, QueryBox, \
-    gui_require, OWConcurrentWidget, asynchronous
+    gui_require, asynchronous
 
 
 class IO:
     CORPUS = "Corpus"
 
 
-class OWNYT(OWConcurrentWidget):
+class OWNYT(OWWidget):
     class APICredentialsDialog(OWWidget):
         name = "New York Times API key"
         want_main_area = False
@@ -132,42 +132,48 @@ class OWNYT(OWConcurrentWidget):
                                         focusPolicy=Qt.NoFocus)
 
     def new_query_input(self):
-        if self.running:
-            self.stop()
+        self.search.stop()
         self.search()
 
     def start_stop(self):
-        if self.running:
-            self.stop()
+        if self.search.running:
+            self.search.stop()
         else:
             self.query_box.synchronize(silent=True)
             self.search()
 
     @gui_require('nyt_api', 'no_api')
     @gui_require('recent_queries', 'no_query')
-    @asynchronous(allow_partial_results=True)
-    def search(self, on_progress, should_break):
+    def run_search(self):
+        self.search()
+
+    @asynchronous
+    def search(self):
+        return self.nyt_api.search(self.recent_queries[0], self.date_from, self.date_to,
+                                   on_progress=self.progress_with_info,
+                                   should_break=self.search.should_break)
+
+    @search.callback
+    def progress_with_info(self, n_retrieved, n_all):
+        self.progressBarSet(100 * (n_retrieved / n_all if n_all else 1), None)  # prevent division by 0
+        self.num_all = n_all
+        self.num_retrieved = n_retrieved
+        self.update_info_label()
+
+    @search.on_start
+    def on_start(self):
         self.Error.api_error.clear()
         self.Error.rate_limit.clear()
-        def progress_with_info(n_retrieved, n_all):
-            on_progress(100 * (n_retrieved / n_all if n_all else 1))    # prevent division by 0
-            self.num_all = n_all
-            self.num_retrieved = n_retrieved
-            self.update_info_label()
-
-        self.corpus = self.nyt_api.search(self.recent_queries[0], self.date_from, self.date_to,
-                                          on_progress=progress_with_info,
-                                          should_break=should_break)
-        return self.corpus
-
-    def on_start(self):
+        self.progressBarInit(None)
         self.search_button.setText('Stop')
         self.send(IO.CORPUS, None)
 
+    @search.on_result
     def on_result(self, result):
         self.search_button.setText('Search')
         self.corpus = result
         self.set_text_features()
+        self.progressBarFinished(None)
 
     def update_info_label(self):
         self.output_info = '{}/{}'.format(self.num_retrieved, self.num_all)

--- a/orangecontrib/text/widgets/ownyt.py
+++ b/orangecontrib/text/widgets/ownyt.py
@@ -153,7 +153,7 @@ class OWNYT(OWWidget):
                                    on_progress=self.progress_with_info,
                                    should_break=self.search.should_break)
 
-    @search.callback
+    @search.callback(should_raise=False)
     def progress_with_info(self, n_retrieved, n_all):
         self.progressBarSet(100 * (n_retrieved / n_all if n_all else 1), None)  # prevent division by 0
         self.num_all = n_all

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -633,7 +633,6 @@ class OWPreprocess(OWWidget):
     @preprocess.on_start
     def on_start(self):
         self.progressBarInit(None)
-        self.set_minimal_width()
 
     @preprocess.callback
     def on_progress(self, i):
@@ -657,6 +656,7 @@ class OWPreprocess(OWWidget):
 
     @pyqtSlot()
     def settings_invalidated(self):
+        self.set_minimal_width()
         self.commit()
 
     def send_report(self):

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -258,7 +258,7 @@ class OWTwitter(OWWidget):
         self.set_text_features()
         self.progressBarFinished(None)
 
-    @search.callback
+    @search.callback(should_raise=False)
     def update_tweets_num(self, num=0, progress=None):
         if self.limited_search or self.mode == self.AUTHOR:
             if progress is not None:

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -214,8 +214,6 @@ class OWTwitter(OWWidget):
 
     @asynchronous
     def search(self):
-        self.api.on_progress = self.update_tweets_num
-        self.api.should_break = self.search.should_break
         max_tweets = self.max_tweets if self.limited_search else 0
 
         if self.mode == self.CONTENT:
@@ -237,7 +235,9 @@ class OWTwitter(OWWidget):
             self.Error.key_missing.clear()
             self.api = twitter.TwitterAPI(key,
                                           on_error=self.Error.api,
-                                          on_rate_limit=self.Error.rate_limit)
+                                          on_rate_limit=self.Error.rate_limit,
+                                          should_break=self.search.should_break,
+                                          on_progress=self.update_tweets_num)
         else:
             self.api = None
 

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -9,15 +9,14 @@ from orangecontrib.text import twitter
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.language_codes import lang2code
 from orangecontrib.text.widgets.utils import (ComboBox, ListEdit,
-                                              CheckListLayout, gui_require,
-                                              OWConcurrentWidget, asynchronous)
+                                              CheckListLayout, gui_require, asynchronous)
 
 
 class IO:
     CORPUS = 'Corpus'
 
 
-class OWTwitter(OWConcurrentWidget):
+class OWTwitter(OWWidget):
     class APICredentialsDialog(OWWidget):
         name = 'Twitter API Credentials'
         want_main_area = False
@@ -204,31 +203,19 @@ class OWTwitter(OWConcurrentWidget):
         self.language_combo.setEnabled(self.mode == self.CONTENT)
 
     def start_stop(self):
-        if self.running:
-            self.stop()
+        if self.search.running:
+            self.search.stop()
         else:
-            self.search()
-
-    def update_api(self, key):
-        if key:
-            self.Error.key_missing.clear()
-            self.api = twitter.TwitterAPI(key,
-                                          on_error=self.Error.api,
-                                          on_rate_limit=self.Error.rate_limit)
-        else:
-            self.api = None
+            self.run_search()
 
     @gui_require('api', 'key_missing')
-    @asynchronous(allow_partial_results=True)
-    def search(self, on_progress, should_break):
-        def progress_with_info(total, progress):
-            if self.limited_search or self.mode == self.AUTHOR:
-                on_progress(100 * progress)
-            self.update_tweets_num(total)
+    def run_search(self):
+        self.search()
 
-        self.Error.clear()
-        self.api.on_progress = progress_with_info
-        self.api.should_break = should_break
+    @asynchronous
+    def search(self):
+        self.api.on_progress = self.update_tweets_num
+        self.api.should_break = self.search.should_break
         max_tweets = self.max_tweets if self.limited_search else 0
 
         if self.mode == self.CONTENT:
@@ -245,19 +232,37 @@ class OWTwitter(OWConcurrentWidget):
                                            authors=self.word_list,
                                            collecting=self.collecting)
 
+    def update_api(self, key):
+        if key:
+            self.Error.key_missing.clear()
+            self.api = twitter.TwitterAPI(key,
+                                          on_error=self.Error.api,
+                                          on_rate_limit=self.Error.rate_limit)
+        else:
+            self.api = None
+
+    @search.on_start
     def on_start(self):
+        self.Error.clear()
+        self.progressBarInit(None)
         self.search_button.setText('Stop')
         self.send(IO.CORPUS, None)
         if self.mode == self.CONTENT and not self.limited_search:
             self.progressBarFinished(None)
 
+    @search.on_result
     def on_result(self, result):
         self.search_button.setText('Search')
-        self.update_tweets_num(len(result) if result else 0)
+        self.tweets_info_label.setText(self.tweets_info.format(len(result) if result else 0))
         self.corpus = result
         self.set_text_features()
+        self.progressBarFinished(None)
 
-    def update_tweets_num(self, num=0):
+    @search.callback
+    def update_tweets_num(self, num=0, progress=None):
+        if self.limited_search or self.mode == self.AUTHOR:
+            if progress is not None:
+                self.progressBarSet(100 * progress, None)
         self.tweets_info_label.setText(self.tweets_info.format(num))
 
     def set_text_features(self):

--- a/orangecontrib/text/widgets/owwikipedia.py
+++ b/orangecontrib/text/widgets/owwikipedia.py
@@ -101,7 +101,7 @@ class OWWikipedia(OWWidget):
                                on_progress=self.progress_with_info,
                                should_break=self.search.should_break)
 
-    @search.callback
+    @search.callback(should_raise=False)
     def progress_with_info(self, progress, n_retrieved):
         self.progressBarSet(100 * progress, None)
         self.result_label.setText(self.info_label.format(n_retrieved))

--- a/orangecontrib/text/widgets/utils/__init__.py
+++ b/orangecontrib/text/widgets/utils/__init__.py
@@ -1,3 +1,3 @@
 from .decorators import *
 from .widgets import *
-from .concurrent import OWConcurrentWidget, asynchronous
+from .concurrent import asynchronous

--- a/orangecontrib/text/widgets/utils/concurrent.py
+++ b/orangecontrib/text/widgets/utils/concurrent.py
@@ -200,12 +200,6 @@ class AsyncMethod(QObject):
         self.finish_callback = callback.__name__
         return Slot(object)(callback)
 
-    def join(self):
-        """ Unbounded call. No attention is needed. """
-
-    def stop(self):
-        """ Unbounded call. No attention is needed. """
-
 
 def asynchronous(task):
     """ Wraps method of a QObject and replaces it with :class:`AsyncMethod` instance

--- a/orangecontrib/text/widgets/utils/concurrent.py
+++ b/orangecontrib/text/widgets/utils/concurrent.py
@@ -142,7 +142,6 @@ class BoundAsyncMethod(QObject):
             QMetaObject.invokeMethod(self.im_self, self.im_func.finish_callback,
                                      Qt.QueuedConnection, Q_ARG(object, result))
         self.running = False
-        return result
 
     def stop(self):
         """ Terminates thread execution. """

--- a/orangecontrib/text/widgets/utils/concurrent.py
+++ b/orangecontrib/text/widgets/utils/concurrent.py
@@ -129,7 +129,7 @@ class BoundAsyncMethod(QObject):
 
         if self.im_func.finish_callback:
             QMetaObject.invokeMethod(self.im_self, self.im_func.finish_callback,
-                                     Qt.BlockingQueuedConnection, Q_ARG(object, result))
+                                     Qt.DirectConnection, Q_ARG(object, result))
         self.running = False
         return result
 
@@ -142,6 +142,9 @@ class BoundAsyncMethod(QObject):
         """ Waits till task is completed. """
         if self._thread is not None and self._thread.is_alive():
             self._thread.join()
+
+    def should_break(self):
+        return not self.running
 
 
 class AsyncMethod(QObject):

--- a/orangecontrib/text/widgets/utils/concurrent.py
+++ b/orangecontrib/text/widgets/utils/concurrent.py
@@ -5,7 +5,11 @@ Async Module
 Helper utils for Orange GUI programming.
 
 Provides :func:`asynchronous` decorator for making methods calls in async mode.
-Once method is decorated it will have :func:`task.on_result` and :func:`task.callback` decorators for callback wrapping.
+Once method is decorated it will have :func:`task.on_start`, :func:`task.on_result` and :func:`task.callback` decorators for callbacks wrapping.
+
+ - `on_start` must take no arguments
+ - `on_result` must accept one argument (the result)
+ - `callback` can accept any arguments
 
 For instance::
 
@@ -21,6 +25,10 @@ For instance::
                 self.report_progress(i)
             return 'Done'
 
+        @task.on_start
+        def report_start(self):
+            print('`{}` started'.format(self.name))
+
         @task.on_result
         def report_result(self, result):
             print('`{}` result: {}'.format(self.name, result))
@@ -30,7 +38,7 @@ For instance::
             print('`{}` progress: {}'.format(self.name, i))
 
 
-Calling if an asynchronous method will launch a deamon thread::
+Calling an asynchronous method will launch a daemon thread::
 
     first = Widget(name='First')
     first.task()
@@ -43,6 +51,8 @@ Calling if an asynchronous method will launch a deamon thread::
 
 A possible output::
 
+    `First` started
+    `Second` started
     `Second` progress: 0
     `First` progress: 0
     `First` progress: 1
@@ -53,7 +63,7 @@ A possible output::
     `Second` result: Done
 
 
-In order to terminate execution (only if an inner cycle with callbacks is present) call :meth:`stop` method::
+In order to terminate a thread either call :meth:`stop` method or raise :exc:`StopExecution` exception within :meth:`task`::
 
     first.task.stop()
 
@@ -163,6 +173,7 @@ class AsyncMethod(QObject):
         return bounded
 
     def on_start(self, callback):
+        """ On start callback decorator. """
         self.start_callback = callback.__name__
         return Slot()(callback)
 

--- a/orangecontrib/text/widgets/utils/concurrent.py
+++ b/orangecontrib/text/widgets/utils/concurrent.py
@@ -110,6 +110,7 @@ class BoundAsyncMethod(QObject):
         self._thread = None
 
     def __call__(self, *args, **kwargs):
+        self.stop()
         self.running = True
         self._thread = threading.Thread(target=self.run, args=args, kwargs=kwargs,
                                         daemon=True)
@@ -129,7 +130,7 @@ class BoundAsyncMethod(QObject):
 
         if self.im_func.finish_callback:
             QMetaObject.invokeMethod(self.im_self, self.im_func.finish_callback,
-                                     Qt.DirectConnection, Q_ARG(object, result))
+                                     Qt.QueuedConnection, Q_ARG(object, result))
         self.running = False
         return result
 


### PR DESCRIPTION
As we discussed with @janezd during my visit it's not a good idea to inherit `OWConcurrentWidget` from `OWWidget` and better to make something like `OWConcurrentMixin`. It's not easy though 😄 

Here is a slightly different approach. I moved all functionality into a decorated method, so no inheritance is needed at all.  

Here is an example: 

``` python

from orangecontrib.text.widgets.utils.concurrent import asynchronous
from PyQt4.QtCore import QObject
import time


class Widget(QObject):
    def __init__(self, name):
        super().__init__()
        self.name = name

    @asynchronous
    def task(self):
        for i in range(5):
            time.sleep(0.5)
            self.report_progress(i)
        return 'Done'

    @task.on_result
    def report_result(self, result):
        print('`{}` result: {}'.format(self.name, result))

    @task.callback
    def report_progress(self, i):
        print('`{}` progress: {}'.format(self.name, i))


first = Widget(name='First')
first.task()  # starts a thread
second = Widget(name='Second')
second.task()

time.sleep(1)
first.task.stop()
second.task.join()

```

@janezd, @nikicc, @kernc is this way better?
