### PR TITLE
CorpusViewer: Retain Preprocessing & Fix Marking for Reordering

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -228,12 +228,6 @@ class Corpus(Table):
         return Corpus(t.X, t.Y, t.metas, t.domain, None)
 
     @classmethod
-    def from_corpus(cls, domain, source, row_indices=...):
-        c = cls.from_table(domain, source, row_indices)
-        c.text_features = source.text_features
-        return c
-
-    @classmethod
     def from_file(cls, filename):
         if not os.path.exists(filename):    # check the default location
             abs_path = os.path.join(get_sample_corpora_dir(), filename)

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -116,11 +116,6 @@ class CorpusTests(unittest.TestCase):
         np.testing.assert_equal(t.metas, c.metas)
         self.assertEqual(c.text_features, [t.domain.metas[0]])
 
-    def test_from_corpus(self):
-        c = Corpus.from_file('bookexcerpts')
-        c2 = Corpus.from_corpus(c.domain, c, row_indices=list(range(5)))
-        self.assertEqual(len(c2), 5)
-
     def test_infer_text_features(self):
         c = Corpus.from_file('friends-transcripts')
         tf = c.text_features

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -222,12 +222,15 @@ class OWCorpusViewer(OWWidget):
             return 
 
         self.Warning.no_feats_display.clear()
-        if self.corpus is not None and len(self.display_indices) == 0:
+        if len(self.display_indices) == 0:
             self.Warning.no_feats_display()
 
         documents = []
         if self.show_tokens:
             tokens = list(self.corpus.ngrams_iterator(include_postags=True))
+
+        marked_search_features = [f for i, f in enumerate(self.search_features)
+                                  if i in self.search_indices]
 
         for index in self.doc_list.selectionModel().selectedRows():
             html = '<table>'
@@ -235,7 +238,7 @@ class OWCorpusViewer(OWWidget):
             row_ind = index.data(Qt.UserRole).row_index
             for ind in self.display_indices:
                 feature = self.display_features[ind]
-                mark = 'class="mark-area"' if ind in self.search_indices else ''
+                mark = 'class="mark-area"' if feature in marked_search_features else ''
                 value = index.data(Qt.UserRole)[feature.name]
                 html += '<tr><td class="variables"><strong>{}:</strong></td>' \
                         '<td {}>{}</td></tr>'.format(

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -300,11 +300,9 @@ class OWCorpusViewer(OWWidget):
 
     def commit(self):
         if self.corpus is not None:
-            matched = Corpus.from_corpus(self.corpus.domain, self.corpus,
-                                         row_indices=self.output_mask)
+            matched = self.corpus[self.output_mask]
             unmatched_mask = [i for i in range(len(self.corpus)) if i not in self.output_mask]
-            unmatched = Corpus.from_corpus(self.corpus.domain, self.corpus,
-                                           row_indices=unmatched_mask)
+            unmatched = self.corpus[unmatched_mask]
             self.send(IO.MATCHED, matched)
             self.send(IO.UNMATCHED, unmatched)
         else:


### PR DESCRIPTION
Two bug-fixes for CorpusViewer:
- Corpus.from_corpus did not retain preprocessing. It was removed since the same can much simpler be achieved by indexing.
- When display features were reordered marking didn't highlight the correct features.