### PR TITLE
Run FrequencyFilter only when necessary

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -38,7 +38,7 @@ class WordListMixin:
             self.word_list = []
         else:
             with open(path) as f:
-                self.word_list = [line.strip() for line in f]
+                self.word_list = set([line.strip() for line in f])
 
 
 class StopwordsFilter(BaseTokenFilter, WordListMixin):

--- a/orangecontrib/text/preprocess/preprocess.py
+++ b/orangecontrib/text/preprocess/preprocess.py
@@ -51,10 +51,9 @@ class Preprocessor:
         self.on_progress(80)
         if self.ngrams_range is not None:
             corpus.ngram_range = self.ngrams_range
-        tokens, dictionary = self.freq_filter.fit_filter(corpus)
-        # corpus._ngrams = tokens
-        # corpus._ngrams_dict = dictionary
-        corpus.store_tokens(tokens, dictionary)
+        if self.freq_filter is not None:
+            tokens, dictionary = self.freq_filter.fit_filter(corpus)
+            corpus.store_tokens(tokens, dictionary)
 
         if self.pos_tagger:
             self.pos_tagger.tag_corpus(corpus)
@@ -69,7 +68,7 @@ class Preprocessor:
     @filters.setter
     def filters(self, filters):
         self._filters = []
-        self.freq_filter = FrequencyFilter()
+        self.freq_filter = None
 
         for f in filters:
             if isinstance(f, FrequencyFilter):

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -405,13 +405,11 @@ class FilteringModule(MultipleMethodModule):
         if self.FREQUENCY in self.checked:
             self.frequency_filter.min_df = self.min_df
             self.frequency_filter.max_df = self.max_df
-        else:
-            checked.append(self.FREQUENCY)
-            self.frequency_filter.min_df = 0.
-            self.frequency_filter.max_df = 1.
 
         if self.KEEP_N in checked:
             checked.pop(checked.index(self.KEEP_N))
+            if self.FREQUENCY not in self.checked:
+                checked.append(self.FREQUENCY)
             self.frequency_filter.keep_n = self.keep_n
         else:
             self.frequency_filter.keep_n = None


### PR DESCRIPTION
`FrequencyFilter` seems to be quite slow so its wasteful to run it every time in preprocessing. Currently we run it (with min_df=0, max_df=1 so no tokens are filtered out) even it the user did not provide any `FrequencyFilter`. 

```py
>>> p = Preprocessor(tokenizer=WordPunctTokenizer())
>>> p2 = Preprocessor(tokenizer=WordPunctTokenizer(), filters=[FrequencyFilter()])
>>> books = Corpus.from_file('bookexcerpts')
>>> friends = Corpus.from_file('friends-transcripts')

# On master:
>>> %timeit -n10 p(books)
10 loops, best of 3: 411 ms per loop
>>> %timeit -n10 p2(books)
10 loops, best of 3: 437 ms per loop

>>> %timeit -n10 p(friends)
10 loops, best of 3: 4.63 s per loop
>>> %timeit -n10 p2(friends)
10 loops, best of 3: 4.98 s per loop

# On this PR:
>>> %timeit -n10 p(books)
10 loops, best of 3: 210 ms per loop     #<- no filtering here; 1x faster
>>> %timeit -n10 p2(books)
10 loops, best of 3: 418 ms per loop

>>> %timeit -n10 p(friends)
10 loops, best of 3: 2.63 s per loop     #<- no filtering here; 1x faster
>>> %timeit -n10 p2(friends)
10 loops, best of 3: 4.95 s per loop
```