### PR TITLE
Unify Corpus __init__ with Table

### DIFF
--- a/orangecontrib/text/pubmed.py
+++ b/orangecontrib/text/pubmed.py
@@ -155,7 +155,7 @@ def _corpus_from_records(records, includes_metadata):
 
     Y = np.array([class_vars[0].to_val(cv) for cv in class_values])[:, None]
 
-    return Corpus(None, Y, meta_values, domain)
+    return Corpus(domain=domain, Y=Y, metas=meta_values)
 
 
 class Pubmed:

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -206,6 +206,9 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(sel.ngram_range, c.ngram_range)
         self.assertEqual(sel.attributes, c.attributes)
 
+        sel = c[...]
+        self.assertEqual(sel, c)
+
     def test_set_text_features(self):
         c = Corpus.from_file('friends-transcripts')[:100]
         c2 = c.copy()
@@ -226,10 +229,6 @@ class CorpusTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             c.set_text_features([c.domain.metas[0], c.domain.metas[0]])
-
-        c.tokens    # preprocess
-        with self.assertRaises(TypeError):
-            c[..., 0]
 
     def test_has_tokens(self):
         corpus = Corpus.from_file('deerwester')

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -45,7 +45,7 @@ class CorpusTests(unittest.TestCase):
 
     def test_corpus_from_init(self):
         c = Corpus.from_file('bookexcerpts')
-        c2 = Corpus(c.X, c.Y, c.metas, c.domain, c.text_features)
+        c2 = Corpus(c.domain, c.X, c.Y, c.metas, c.text_features)
         self.assertEqual(c, c2)
 
     def test_extend_corpus(self):
@@ -82,23 +82,23 @@ class CorpusTests(unittest.TestCase):
         c = Corpus.from_file('bookexcerpts')
         n_doc = c.X.shape[0]
 
-        c2 = Corpus(c.X, c.Y, c.metas, c.domain, [])
+        c2 = Corpus(c.domain, c.X, c.Y, c.metas, c.W, [])
         self.assertNotEqual(c, c2)
 
-        c2 = Corpus(np.ones((n_doc, 1)), c.Y, c.metas, c.domain, c.text_features)
+        c2 = Corpus(c.domain, np.ones((n_doc, 1)), c.Y, c.metas, c.W, c.text_features)
         self.assertNotEqual(c, c2)
 
-        c2 = Corpus(c.X, np.ones((n_doc, 1)), c.metas, c.domain, c.text_features)
+        c2 = Corpus(c.domain, c.X, np.ones((n_doc, 1)), c.metas, c.W, c.text_features)
         self.assertNotEqual(c, c2)
 
         broken_metas = np.copy(c.metas)
         broken_metas[0, 0] = ''
-        c2 = Corpus(c.X, c.Y, broken_metas, c.domain, c.text_features)
+        c2 = Corpus(c.domain, c.X, c.Y, broken_metas, c.W, c.text_features)
         self.assertNotEqual(c, c2)
 
         new_meta = [StringVariable('text2')]
         broken_domain = Domain(c.domain.attributes, c.domain.class_var, new_meta)
-        c2 = Corpus(c.X, c.Y, c.metas, broken_domain, new_meta)
+        c2 = Corpus(broken_domain, c.X, c.Y, c.metas, c.W, new_meta)
         self.assertNotEqual(c, c2)
 
         c2 = c.copy()
@@ -219,7 +219,7 @@ class CorpusTests(unittest.TestCase):
 
         too_large_x = np.vstack((c.X, c.X))
         with self.assertRaises(ValueError):
-            Corpus(too_large_x, c.Y, c.metas, c.domain, c.text_features)
+            Corpus(c.domain, too_large_x, c.Y, c.metas, c.W, c.text_features)
 
         with self.assertRaises(ValueError):
             c.set_text_features([StringVariable('foobar')])

--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -274,7 +274,7 @@ def main():
     w = OWWordCloud()
     w.on_topic_change(table)
     domain = Domain([], metas=[StringVariable('text')])
-    data = Corpus(None, None, np.array([[' '.join(words.flat)]]), domain)
+    data = Corpus(domain=domain, metas=np.array([[' '.join(words.flat)]]))
     # data = Corpus.from_numpy(domain, X=np.zeros((1, 0)), metas=np.array([[' '.join(words.flat)]]))
     w.on_corpus_change(data)
     w.show()


### PR DESCRIPTION
With desire to retain Corpus's preprocessing when passing it through Orange's widgets `__init__` and `from_table` arguments were unified with Table. Also, `from_table` and `from_corpus` were unified to `from_table` that retains preprocessing when corpus is given.