### PR TITLE
Introduce Titles to Corpus

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -168,6 +168,16 @@ class Corpus(Table):
         """
         return self.documents_from_features(self.text_features)
 
+    @property
+    def titles(self):
+        """ Returns a list of titles. """
+        attrs = [attr for attr in chain(self.domain.variables, self.domain.metas)
+                 if attr.attributes.get('title', False)]
+        if attrs:
+            return self.documents_from_features(attrs)
+        else:
+            return ['Document {}'.format(i+1) for i in range(len(self))]
+
     def documents_from_features(self, feats):
         """
         Args:
@@ -271,7 +281,8 @@ class Corpus(Table):
         return c
 
     @staticmethod
-    def from_documents(documents, name, attributes=None, class_vars=None, metas=None):
+    def from_documents(documents, name, attributes=None, class_vars=None, metas=None,
+                       title_indices=None):
         """
         Create corpus from documents.
 
@@ -281,6 +292,8 @@ class Corpus(Table):
             attributes (list): List of tuples (Variable, getter) for attributes.
             class_vars (list): List of tuples (Variable, getter) for class vars.
             metas (list): List of tuples (Variable, getter) for metas.
+            title_indices (list): List of indices into domain corresponding to features which will
+                be used as titles.
 
         Returns:
             Corpus.
@@ -288,10 +301,14 @@ class Corpus(Table):
         attributes = attributes or []
         class_vars = class_vars or []
         metas = metas or []
+        title_indices = title_indices or []
 
         domain = Domain(attributes=[attr for attr, _ in attributes],
                         class_vars=[attr for attr, _ in class_vars],
                         metas=[attr for attr, _ in metas])
+
+        for ind in title_indices:
+            domain[ind].attributes['title'] = True
 
         for attr in domain.attributes:
             if isinstance(attr, DiscreteVariable):

--- a/orangecontrib/text/nyt.py
+++ b/orangecontrib/text/nyt.py
@@ -105,7 +105,7 @@ class NYT:
         for page in range(1, math.ceil(max_docs/BATCH_SIZE)):
             if callable(should_break) and should_break():
                 return Corpus.from_documents(records, 'NY Times', self.attributes,
-                                             self.class_vars, self.metas)
+                                             self.class_vars, self.metas, title_indices=[-1])
 
             data, cached = self._fetch_page(query, date_from, date_to, page)
             records.extend(data['response']['docs'])
@@ -120,7 +120,7 @@ class NYT:
             records = records[:max_docs]
 
         return Corpus.from_documents(records, 'NY Times', self.attributes,
-                                     self.class_vars, self.metas)
+                                     self.class_vars, self.metas, title_indices=[-1])
 
     def _cache_init(self):
         """ Initialize cache in Orange environment buffer dir. """

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -135,6 +135,22 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(types), 1)
         self.assertIn(str, types)
 
+    def test_titles(self):
+        c = Corpus.from_file('bookexcerpts')
+
+        # no title feature set
+        titles = c.titles
+        self.assertEqual(len(titles), len(c))
+        for title in titles:
+            self.assertIn('Document ', title)
+
+        # title feature set
+        c.domain[0].attributes['title'] = True
+        titles = c.titles
+        self.assertEqual(len(titles), len(c))
+        for title in titles:
+            self.assertIn(title, c.domain.class_var.values)
+
     def test_documents_from_features(self):
         c = Corpus.from_file('bookexcerpts')
         docs = c.documents_from_features([c.domain.class_var])

--- a/orangecontrib/text/twitter.py
+++ b/orangecontrib/text/twitter.py
@@ -187,7 +187,7 @@ class TwitterAPI:
         """ Creates a corpus with collected tweets. """
         self.statuses_lock.acquire()
         corpus = Corpus.from_documents(self.tweets, 'Twitter', self.attributes,
-                                       self.class_vars, self.metas)
+                                       self.class_vars, self.metas, title_indices=[-2])
         self.statuses_lock.release()
         return corpus
 

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -85,8 +85,12 @@ class OWCorpusViewer(OWWidget):
                                          label='RegExp Filter:')
         self.filter_input.textChanged.connect(self.refresh_search)
 
-        h_box = gui.widgetBox(self.mainArea, orientation=Qt.Horizontal, addSpace=True)
-        h_box.layout().setSpacing(0)
+        # Main area
+        self.splitter = QtGui.QSplitter(
+            orientation=Qt.Horizontal,
+            childrenCollapsible=False,
+            handleWidth=2,
+        )
 
         # Document list
         self.doc_list = QTableView()
@@ -95,16 +99,16 @@ class OWCorpusViewer(OWWidget):
         self.doc_list.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
         self.doc_list.horizontalHeader().setResizeMode(QtGui.QHeaderView.Stretch)
         self.doc_list.horizontalHeader().setVisible(False)
-        h_box.layout().addWidget(self.doc_list)
+        self.splitter.addWidget(self.doc_list)
 
         self.doc_list_model = QStandardItemModel(self)
-
         self.doc_list.setModel(self.doc_list_model)
-        self.doc_list.setFixedWidth(200)
         self.doc_list.selectionModel().selectionChanged.connect(self.show_docs)
 
         # Document contents
-        self.doc_webview = gui.WebviewWidget(h_box, self, debug=True)
+        self.doc_webview = gui.WebviewWidget(self.splitter, self, debug=True)
+
+        self.mainArea.layout().addWidget(self.splitter)
 
     def set_data(self, data=None):
         self.reset_widget()
@@ -167,10 +171,11 @@ class OWCorpusViewer(OWWidget):
         self.output_mask.clear()
         self.doc_list_model.clear()
 
-        for i, (doc, content) in enumerate(zip(self.corpus, self.corpus_docs)):
+        for i, (doc, title, content) in enumerate(zip(self.corpus, self.corpus.titles,
+                                                      self.corpus_docs)):
             if is_match(content):
                 item = QStandardItem()
-                item.setData('Document {}'.format(i+1), Qt.DisplayRole)
+                item.setData(title, Qt.DisplayRole)
                 item.setData(doc, Qt.UserRole)
                 self.doc_list_model.appendRow(item)
                 self.output_mask.append(i)

--- a/orangecontrib/text/wikipedia.py
+++ b/orangecontrib/text/wikipedia.py
@@ -73,7 +73,7 @@ class WikipediaAPI:
                 self.on_error(NetworkException(e))
 
         corpus = Corpus.from_documents(results, 'Wikipedia', self.attributes,
-                                       self.class_vars, self.metas)
+                                       self.class_vars, self.metas, title_indices=[-1])
         self.on_finish(corpus)
         self.running = False
         return corpus


### PR DESCRIPTION
Corpus now has `titles` property which returns short documents representations. This is used in Corpus Viewer in the left scrolling area — where Document 1, Document 2, ... used to be. 