### PR TITLE
Make biopython an optional dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 
 install:
     - travis_wait pip install -r requirements.txt
+    - travis_wait pip install -r requirements-opt.txt
     - python setup.py develop   # assure version.py is present; required for imports
 
 script:

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -1,0 +1,1 @@
+biopython # Enables Pubmed widget.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ scipy
 nltk
 scikit-learn
 numpy
-biopython
 validate_email
 gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git


### PR DESCRIPTION
Prevents installation problems on Windows (hopefully).