### PR TITLE
Request higher version of scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy
+scipy>=0.18.1
 nltk
 scikit-learn
 numpy


### PR DESCRIPTION
Avoid Word Enrichment crash with scipy==0.17.1.