### PR TITLE
Twitter: Load 100 tweets per page

### DIFF
--- a/orangecontrib/text/twitter.py
+++ b/orangecontrib/text/twitter.py
@@ -223,7 +223,8 @@ class SearchTask(threading.Thread):
     def run(self):
         try:
             for status in tweepy.Cursor(self.master.api.search, q=self.q,
-                                        lang=self.lang, **self.kwargs).items(self.max_tweets):
+                                        lang=self.lang, count=100,
+                                        **self.kwargs).items(self.max_tweets):
                 self.master.add_status(status)
                 self.progress += 1
                 if self.master.on_progress:


### PR DESCRIPTION
For downloading 1000 tweets this speeds the process from ~20s to ~7s. Also since Twitter limits the number of requests per time window this allows us to load more data.