### PR TITLE
Requirements: Bump Orange version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 validate_email
 gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git
-Orange3>=3.3.8
+Orange3>=3.3.9
 tweepy
 beautifulsoup4
 simhash


### PR DESCRIPTION
A friendly reminder not to forget bumping Orange version before the next release.

PRs that need the new version:
- #139 since due to a bug fixed in https://github.com/biolab/orange3/pull/1675
