### PR TITLE
[FIX] OWPreprocess: Use regex from input, not the default one

### DIFF
--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -388,6 +388,7 @@ class FilteringModule(MultipleMethodModule):
         spin = gui.spin(self.contents, self, 'keep_n', box=False, minv=1, maxv=10**6)
         spin.editingFinished.connect(self.keep_n_changed)
         self.method_layout.addWidget(spin, self.KEEP_N, 1, 1, 1)
+        self.pattern_changed()
 
     @property
     def frequency_filter(self):


### PR DESCRIPTION
When the widget was created, RegexFilter was initialized with the default pattern from the scripting part and not the value showed to the user. This PR propagated the value shown in the input field to the RegexFilter at initialization.

To reporduce, take some tweets, pass them through preprocessing with the Regexp filter on and observe tokens in WordCloud. Many characters, though listed in the filter, still remain among tokens.