### PR TITLE
Twitter: Fix TimeVariable parsing

### DIFF
--- a/orangecontrib/text/twitter.py
+++ b/orangecontrib/text/twitter.py
@@ -69,10 +69,11 @@ class TwitterAPI:
     attributes = []
     class_vars = []
 
+    tv = data.TimeVariable('Date')
     metas = [
         (data.DiscreteVariable('Author'), lambda doc: '@'+doc.author.screen_name),
         (data.StringVariable('Content'), lambda doc: doc.text),
-        (data.TimeVariable('Date'), lambda doc: doc.created_at.timestamp()),
+        (tv, lambda doc: TwitterAPI.tv.parse(doc.created_at.isoformat())),
         (data.DiscreteVariable('Language'), lambda doc: doc.lang),
         (data.DiscreteVariable('Location'), lambda doc: getattr(doc.place, 'country_code', None)),
         (data.ContinuousVariable('Number of Likes'), lambda doc: doc.favorite_count),


### PR DESCRIPTION
Python's `datetime.timestamp()` assumes to represent local time while Twitter's `created_at` is in UTC. For us this caused times to be off by two hours. To fix this we now store and show the Date in UTC format.