### PR TITLE
OWPreprocessing: Shrink FileWidget

### DIFF
--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -359,8 +359,8 @@ class FilteringModule(MultipleMethodModule):
                                  dialog_title='Open a stop words source',
                                  dialog_format=self.dlgFormats,
                                  on_open=self.read_stopwords_file,
-                                 browse_label='',
-                                 reload_label='')
+                                 browse_label='', reload_label='',
+                                 minimal_width=100)
         box.select(0)
         self.method_layout.addWidget(box, self.STOPWORDS, 2, 1, 1)
 
@@ -368,8 +368,8 @@ class FilteringModule(MultipleMethodModule):
                                  dialog_title='Open a lexicon words source',
                                  dialog_format=self.dlgFormats,
                                  on_open=self.read_lexicon_file,
-                                 browse_label='',
-                                 reload_label='')
+                                 browse_label='', reload_label='',
+                                 minimal_width=100)
         box.select(0)
         self.method_layout.addWidget(box, self.LEXICON, 2, 1, 1)
 

--- a/orangecontrib/text/widgets/utils/widgets.py
+++ b/orangecontrib/text/widgets/utils/widgets.py
@@ -268,7 +268,8 @@ class FileWidget(QtGui.QWidget):
     on_open = QtCore.pyqtSignal(str)
 
     def __init__(self, dialog_title='', dialog_format='',
-                 start_dir=os.path.expanduser('~/'), icon_size=(12, 20),
+                 start_dir=os.path.expanduser('~/'),
+                 icon_size=(12, 20), minimal_width=200,
                  browse_label='Browse', on_open=None,
                  reload_button=True, reload_label='Reload',
                  recent_files=None, directory_aliases=None,
@@ -306,7 +307,7 @@ class FileWidget(QtGui.QWidget):
 
         if recent_files is not None:
             self.file_combo = QtGui.QComboBox()
-            self.file_combo.setMinimumWidth(200)
+            self.file_combo.setMinimumWidth(minimal_width)
             self.file_combo.activated[int].connect(self.select)
             self.update_combo()
             layout.addWidget(self.file_combo)


### PR DESCRIPTION
This makes Preprocessing widget a bit thinner at expense of shorter dropdowns for loading custom stopwords and lexicon.