### PR TITLE
OWWikipedia: Fix ListEdit init according to #149

### DIFF
--- a/orangecontrib/text/widgets/owwikipedia.py
+++ b/orangecontrib/text/widgets/owwikipedia.py
@@ -54,7 +54,7 @@ class OWWikipedia(OWConcurrentWidget):
         layout.setSpacing(7)
 
         row = 0
-        query_edit = ListEdit(self, 'query_list', "Each line represents a separate query.", self)
+        query_edit = ListEdit(self, 'query_list', "Each line represents a separate query.", None, self)
         layout.addWidget(QtGui.QLabel('Query word list:'), row, 0, 1, self.label_width)
         layout.addWidget(query_edit, row, self.label_width, 1, self.widgets_width)
 


### PR DESCRIPTION
In #149 `fixed_height` argument was added to `ListEdit` which broke initialization of OWWikipedia.