### PR TITLE
OWWordCloud: Fix selection by clicking

### DIFF
--- a/orangecontrib/text/widgets/resources/wordcloud-script.js
+++ b/orangecontrib/text/widgets/resources/wordcloud-script.js
@@ -30,7 +30,7 @@ window.addEventListener('click', function(event) {
         if (! (event.ctrlKey || event.shiftKey)) {
             clearSelection();
         }
-        cls = pybridge.word_clicked(span.innerHTML);
+        var cls = pybridge.word_clicked(span.innerHTML);
         console.log(cls);
         span.className = cls;
     } else if (span.tagName == 'BODY') {


### PR DESCRIPTION
Selection by clicking on words was broken due to use of `use strict` mode in JS and becuase the `cls` variable was declared implicitly. This threw an error `Strict mode forbids implicit creation of global property 'cls'` which broke selecting. Declaring `cls` should fix the issue.