### PR TITLE
[FIX] Corpus.from_documents: Assure Correct Shapes When no Docs

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -331,12 +331,17 @@ class Corpus(Table):
                 attr.val_from_str_add(val)
             return attr.to_val(val)
 
-        X = np.array([[to_val(attr, func(doc)) for attr, func in attributes]
-                      for doc in documents])
-        Y = np.array([[to_val(attr, func(doc)) for attr, func in class_vars]
-                      for doc in documents])
-        metas = np.array([[to_val(attr, func(doc)) for attr, func in metas]
-                          for doc in documents], dtype=object)
+        if documents:
+            X = np.array([[to_val(attr, func(doc)) for attr, func in attributes]
+                          for doc in documents])
+            Y = np.array([[to_val(attr, func(doc)) for attr, func in class_vars]
+                          for doc in documents])
+            metas = np.array([[to_val(attr, func(doc)) for attr, func in metas]
+                              for doc in documents], dtype=object)
+        else:   # assure shapes match the number of columns
+            X = np.empty((0, len(attributes)))
+            Y = np.empty((0, len(class_vars)))
+            metas = np.empty((0, len(metas)))
 
         corpus = Corpus(X=X, Y=Y, metas=metas, domain=domain, text_features=[])
         corpus.name = name


### PR DESCRIPTION
Even when no documents are present the shapes of empty matrices should match the number of columns. Otherwise, `Table.from_table` can fail. To reproduce the bug, use Wikipedia and connect it to CorpusViewer. Search for something that will return zero documents and then in CorpusViewer click on one Search Feature. This will re-trigger `Corpus.from_documents` and the `Table.from_table` will fail with `ValueError: total size of new array must be unchanged`.