### PR TITLE
NYT: TimeVariable as Class Var

### DIFF
--- a/orangecontrib/text/nyt.py
+++ b/orangecontrib/text/nyt.py
@@ -35,6 +35,7 @@ class NYT:
         (data.DiscreteVariable('Section'), lambda doc: doc.get('section_name', None)),
     ]
 
+    tv = data.TimeVariable('Publication Date')
     metas = [
         (data.StringVariable('Headline'), lambda doc: doc.get('headline', {}).get('main') or ''),
         (data.StringVariable('Abstract'), lambda doc: doc.get('abstract') or ''),
@@ -46,8 +47,7 @@ class NYT:
         (data.StringVariable('Persons'), lambda doc: NYT.keywords(doc, 'persons')),
         (data.StringVariable('Organizations'), lambda doc: NYT.keywords(doc, 'organizations')),
         (data.StringVariable('Creative Works'), lambda doc: NYT.keywords(doc, 'creative_works')),
-        (data.TimeVariable('Publication Date'),
-            lambda doc: data.TimeVariable().parse(doc.get('pub_date'))),
+        (tv, lambda doc: NYT.tv.parse(doc.get('pub_date'))),
         (data.DiscreteVariable('Article Type'), lambda doc: doc.get('type_of_material', None)),
         (data.DiscreteVariable('Word Count'), lambda doc: doc.get('word_count', None)),
     ]


### PR DESCRIPTION
This fixed tests for Orange's versions above 3.3.8. Due to using different instaces for parsing, the instace in domain did not have `have_time` nor `have_date` attribute set which caused `repr_val` function to just return string representation of the float. To fix the problem, we now use the same instance in domain as for parsing.