### PR TITLE
[FIX] Corpus.titles: Skip BoW features

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -189,7 +189,8 @@ class Corpus(Table):
             for var in sorted(chain(self.domain.metas, self.domain),
                               key=lambda var: var.name,
                               reverse=True):  # reverse so that title < heading < filename
-                if var.name.lower() in ('title', 'heading', 'h1', 'filename'):
+                if var.name.lower() in ('title', 'heading', 'h1', 'filename') \
+                        and not var.attributes.get('hidden', False):    # skip BoW features
                     attrs = [var]
                     break
         if attrs:


### PR DESCRIPTION
`Corpus.titles` should not search for titles among bag of words features. To reproduce pass bookexcerpts through BoW and pass it to CorpusViewer. Since bookexcerpts contain token `title` we get counts (`0.000`, `1.000`, etc) as document titles instead of the default `Document {}` titles.