### PR TITLE
NYT fixups

### DIFF
--- a/orangecontrib/text/nyt.py
+++ b/orangecontrib/text/nyt.py
@@ -164,6 +164,13 @@ class NYT:
                 with request.urlopen(url) as conn:
                     data = conn.read().decode('utf-8')
             except HTTPError as e:
+                if e.code == 403 and page > 0:
+                    # occasionally some pages return error 403 (Forbidden)
+                    # while all other page numbers seem to work just fine.
+                    # Skip such pages and don't break loading!
+                    warnings.warn('NYT api returned HTTPError with code 403 '
+                                  '(Forbidden)! Skipping this page ...')
+                    return {'response': {'docs': []}}, True
                 if e.code == 429 and callable(self.on_rate_limit):
                     self.on_rate_limit()
                 elif callable(self.on_error):

--- a/orangecontrib/text/tests/test_nyt.py
+++ b/orangecontrib/text/tests/test_nyt.py
@@ -104,8 +104,8 @@ class NYTTests(unittest.TestCase):
 
     def test_nyt_result_caching(self):
         self.nyt._fetch_page('slovenia', None, None, 0)     # assure in cache
-        _, is_cached = self.nyt._fetch_page('slovenia', None, None, 0)
-        self.assertTrue(is_cached)
+        _, go_sleep = self.nyt._fetch_page('slovenia', None, None, 0)
+        self.assertFalse(go_sleep)
 
     def test_on_progress(self):
         n_calls = 0

--- a/orangecontrib/text/tests/test_nyt.py
+++ b/orangecontrib/text/tests/test_nyt.py
@@ -107,6 +107,12 @@ class NYTTests(unittest.TestCase):
         _, go_sleep = self.nyt._fetch_page('slovenia', None, None, 0)
         self.assertFalse(go_sleep)
 
+    def test_nyt_sleep(self):
+        self.nyt.search('slovenia', max_docs=25)
+        with patch('time.sleep', Mock()) as sleep:
+            self.nyt.search('slovenia', max_docs=25)
+            self.assertEqual(sleep.call_count, 0)
+
     def test_on_progress(self):
         n_calls = 0
 
@@ -174,3 +180,16 @@ class NYTTestsErrorRaising(unittest.TestCase):
         c = nyt.search('slovenia', max_docs=25)
         self.assertIsNone(c)
 
+
+class Test403(unittest.TestCase):
+    API_KEY = 'api_key'
+
+    def setUp(self):
+        self.nyt = NYT(self.API_KEY)
+
+    @patch('urllib.request.urlopen',
+           Mock(side_effect=HTTPError('', 403, None, None, None)))
+    def test_nyt_http_error_403(self):
+        data, go_sleep = self.nyt._fetch_page('slovenia', None, None, 1)
+        self.assertEqual(len(data['response']['docs']), 0)
+        self.assertTrue(go_sleep)


### PR DESCRIPTION
Changes:
* Fix sleep issues and set sleep time to 1s as the default rate limit is one request per second.
* Skip HTTPErrors with code 403 (Forbidden) — which occasionally happen just for some page numbers — and continue loading other pages.