### PR TITLE
Scipy: Remove pinned version

### DIFF
--- a/orangecontrib/text/tests/test_utils.py
+++ b/orangecontrib/text/tests/test_utils.py
@@ -1,6 +1,9 @@
 import unittest
 
-from orangecontrib.text.util import chunks
+import numpy as np
+import scipy.sparse as sp
+
+from orangecontrib.text.util import chunks, np_sp_sum
 
 
 class ChunksTest(unittest.TestCase):
@@ -17,3 +20,11 @@ class ChunksTest(unittest.TestCase):
         for chunk in chunks(range(10), 3):
             pass
         self.assertEqual(len(chunk), 1)
+
+
+class TestNpSpSum(unittest.TestCase):
+    def test_np_sp_sum(self):
+        for data in [np.eye(10), sp.csr_matrix(np.eye(10))]:
+            self.assertEqual(np_sp_sum(data), 10)
+            np.testing.assert_equal(np_sp_sum(data, axis=1), np.ones(10))
+            np.testing.assert_equal(np_sp_sum(data, axis=0), np.ones(10))

--- a/orangecontrib/text/util.py
+++ b/orangecontrib/text/util.py
@@ -1,6 +1,8 @@
 from functools import wraps
 from math import ceil
 
+import numpy as np
+import scipy.sparse as sp
 
 def chunks(iterable, chunk_size):
     """ Splits iterable objects into chunk of fixed size.
@@ -45,3 +47,15 @@ def chunkable(method):
         return res
 
     return wrapper
+
+
+def np_sp_sum(x, axis=None):
+    """ Wrapper for summing either sparse or dense matrices.
+    Required since with scipy==0.17.1 np.sum() crashes."""
+    if sp.issparse(x):
+        r = x.sum(axis=axis)
+        if axis is not None:
+            r = np.array(r).ravel()
+        return r
+    else:
+        return np.sum(x, axis=axis)

--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -5,6 +5,7 @@ from Orange.data import Table
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.widget import OWWidget, Msg
+from orangecontrib.text.util import np_sp_sum
 from orangecontrib.text.stats import false_discovery_rate, hypergeom_p_values
 
 
@@ -108,7 +109,7 @@ class OWWordEnrichment(OWWidget):
             self.selected_data_transformed = Table.from_table(
                 self.data.domain, self.selected_data)
 
-            if np.sum(self.selected_data_transformed.X) == 0:
+            if np_sp_sum(self.selected_data_transformed.X) == 0:
                 self.Error.no_words_overlap()
                 self.clear()
             elif len(self.data) == len(self.selected_data):
@@ -148,7 +149,7 @@ class OWWordEnrichment(OWWidget):
             self.sig_words.resizeColumnToContents(i)
 
         self.info_all.setText('Cluster words: {}'.format(len(self.selected_data_transformed.domain.attributes)))
-        self.info_sel.setText('Selected words: {}'.format(np.count_nonzero(np.sum(self.selected_data_transformed.X, axis=0))))
+        self.info_sel.setText('Selected words: {}'.format(np.count_nonzero(np_sp_sum(self.selected_data_transformed.X, axis=0))))
         if not self.filter_by_p and not self.filter_by_fdr:
             self.info_fil.setText('After filtering:')
             self.info_fil.setEnabled(False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy>=0.18.1
+scipy
 nltk
 scikit-learn
 numpy


### PR DESCRIPTION
OWWordEnrichment that crashed with version 0.17.1 of Scipy was reformatted to also work on 0.17.1 hence the version pinning is not required any more.

Pinning the version to 0.18.1 caused some problems with installation on Windows which should now, hopefully, be resolved.