### PR TITLE
Fix Wikipedia Tests

### DIFF
--- a/orangecontrib/text/tests/test_wikipedia.py
+++ b/orangecontrib/text/tests/test_wikipedia.py
@@ -7,7 +7,7 @@ from orangecontrib.text.wikipedia import WikipediaAPI
 from orangecontrib.text.corpus import Corpus
 
 
-class StopingMock(mock.Mock):
+class StoppingMock(mock.Mock):
     def __init__(self, allow_calls=0):
         super().__init__()
         self.allow_calls = allow_calls
@@ -56,7 +56,7 @@ class WikipediaTests(unittest.TestCase):
 
         # stop inside recursion
         result = api.search('en', ['Scarf'], articles_per_query=3,
-                            should_break=StopingMock(allow_calls=4))
+                            should_break=StoppingMock(allow_calls=4))
         self.assertEqual(len(result), 2)
 
     def page(*args, **kwargs):

--- a/orangecontrib/text/tests/test_wikipedia.py
+++ b/orangecontrib/text/tests/test_wikipedia.py
@@ -55,9 +55,10 @@ class WikipediaTests(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
         # stop inside recursion
-        result = api.search('en', ['Scarf'], articles_per_query=3,
-                            should_break=StoppingMock(allow_calls=4))
-        self.assertEqual(len(result), 2)
+        result_all = api.search('en', ['Scarf'], articles_per_query=3)
+        result_stopped = api.search('en', ['Scarf'], articles_per_query=3,
+                                    should_break=StoppingMock(allow_calls=4))
+        self.assertLess(len(result_stopped), len(result_all))
 
     def page(*args, **kwargs):
         raise wikipedia.exceptions.PageError('1')


### PR DESCRIPTION
Wiki tests run live on Wikipedia and they broke a few days ago. This PR makes them a bit more robust but we should totally refactor this soon.