### PR TITLE
[FIX] Preprocess: Detect File Encoding for Stopwords

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -1,6 +1,7 @@
 import os
-
 import re
+
+from Orange.data.io import detect_encoding
 from gensim import corpora
 from nltk.corpus import stopwords
 
@@ -45,7 +46,8 @@ class WordListMixin:
         if not path:
             self.word_list = []
         else:
-            with open(path) as f:
+            enc = detect_encoding(path)
+            with open(path, encoding=enc) as f:
                 self.word_list = set([line.strip() for line in f])
 
 


### PR DESCRIPTION
**Issue**
Stopwords were loaded with platform default encoding which can cause encoding errors (issue #175).

**Changes**
Detect encoding of the stopwords file with Orange and use it instead of the default one.