### PR TITLE
[FIX] GeoMap: Don't crash when changing map without data

### DIFF
--- a/orangecontrib/text/widgets/owgeomap.py
+++ b/orangecontrib/text/widgets/owgeomap.py
@@ -159,12 +159,13 @@ class OWGeoMap(widget.OWWidget):
     def _iter_locations(self):
         """ Iterator that yields an iterable per documents with all its's
         locations. """
-        attr = self.data.domain[self.selected_attr]
-        for i in self.data.get_column_view(self.data.domain.index(attr))[0]:
-            if len(i) > 3:
-                yield map(lambda x: x.strip(), CC_NAMES.findall(i.lower()))
-            else:
-                yield (i, )
+        if self.data is not None:
+            attr = self.data.domain[self.selected_attr]
+            for i in self.data.get_column_view(self.data.domain.index(attr))[0]:
+                if len(i) > 3:
+                    yield map(lambda x: x.strip(), CC_NAMES.findall(i.lower()))
+                else:
+                    yield (i, )
 
 
 def main():


### PR DESCRIPTION
##### Issue
GeoMap crashes when no data is provided and the map is changed (e.g. World -> EU).

#### Changes
Iterator for locations is modified to iterate over data only when it is present.