### PR TITLE
[FIX] Requirements: NLTK >= 3.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scipy
-nltk
+nltk>=3.0.5     # TweetTokenizer introduces in 3.0.5
 scikit-learn
 numpy
 validate_email


### PR DESCRIPTION
Before 3.0.5 NLTK did not have TweetTokenizer that we use.