### PR TITLE
[FIX] TweetProfiler: Return None When Servers Down

### DIFF
--- a/orangecontrib/text/tests/test_tweetprofiler.py
+++ b/orangecontrib/text/tests/test_tweetprofiler.py
@@ -61,6 +61,16 @@ class MockServerCall(unittest.TestCase):
                 }
 
 
+class MockServerCallSuddenlyUnavailable(MockServerCall):
+    # Mock server that becomes unavailable during execution
+    def __call__(self, *args, **kwargs):
+        url = args[0]
+        if url == 'tweet_profiler':
+            return None
+        else:
+            return super().__call__(*args, **kwargs)
+
+
 class TestTweetProfiler(unittest.TestCase):
     @patch(SERVER_CALL, MockServerCall())
     @patch(CHECK_ALIVE, Mock(return_value=True))
@@ -142,8 +152,23 @@ class TestTweetProfiler(unittest.TestCase):
         text_var = self.data.domain.metas[1]
         corp = self.profiler.transform(self.data, text_var,
                                        MODELS[0], 'Classes')
-        self.assertIs(corp, self.data)
+        self.assertIsNone(corp)
 
+    @patch(SERVER_CALL, MockServerCall())
+    @patch(CHECK_ALIVE, Mock(return_value=True))
+    def test_transform_empty_corpus(self):
+        text_var = self.data.domain.metas[1]
+        corp = self.profiler.transform(self.data[:0], text_var,
+                                       'model-mc', 'Classes')
+        self.assertIsNone(corp)
+
+    @patch(SERVER_CALL, MockServerCallSuddenlyUnavailable())
+    @patch(CHECK_ALIVE, Mock(return_value=True))
+    def test_transform_server_call_error(self):
+        text_var = self.data.domain.metas[1]
+        corp = self.profiler.transform(self.data, text_var,
+                                       'model-mc', 'Classes')
+        self.assertIsNone(corp)
 
 response_mock = Mock()
 response_mock.status_code = 200

--- a/orangecontrib/text/tests/test_tweetprofiler.py
+++ b/orangecontrib/text/tests/test_tweetprofiler.py
@@ -208,7 +208,7 @@ class TestErrorsRaising(unittest.TestCase):
 
     @patch(CHECK_ALIVE, Mock(return_value=True))
     @patch(TOKEN_VALID, Mock(return_value=False))
-    def test_assure_server_and_tokens_invlid_token(self):
+    def test_assure_server_and_tokens_invalid_token(self):
         self.profiler.on_invalid_token = Mock()
         r = self.profiler.assure_server_and_tokens()
         self.assertFalse(r)
@@ -221,6 +221,12 @@ class TestErrorsRaising(unittest.TestCase):
         r = self.profiler.assure_server_and_tokens(need_coins=COINS+1)
         self.assertFalse(r)
         self.assertEqual(self.profiler.on_too_little_credit.call_count, 1)
+
+    @patch(TOKEN_VALID, Mock(return_value=True))
+    def test_assure_server_and_tokens_get_server(self):
+        self.profiler.server = None
+        r = self.profiler.assure_server_and_tokens()
+        self.assertTrue(r)
 
     def test_server_call_server_missing(self):
         self.profiler.server = None

--- a/orangecontrib/text/tweet_profiler.py
+++ b/orangecontrib/text/tweet_profiler.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 
 class TweetProfiler:
     BATCH_SIZE = 50
+    TIMEOUT = 15    # how many seconds to wait for a server to respond
     SERVER_LIST = 'https://raw.githubusercontent.com/biolab/' \
                   'orange3-text/master/SERVERS.txt'
 
@@ -129,7 +130,8 @@ class TweetProfiler:
             return None
 
         try:
-            res = requests.post(self.server + '/' + url, json=json)
+            res = requests.post(self.server + '/' + url, json=json,
+                                timeout=self.TIMEOUT)
             return res.json()
         except requests.exceptions.RequestException as e:
             if callable(self.on_server_down):

--- a/orangecontrib/text/tweet_profiler.py
+++ b/orangecontrib/text/tweet_profiler.py
@@ -29,7 +29,7 @@ class TweetProfiler:
     def transform(self, corpus, meta_var, model_name, output_mode,
                   on_advance=None):
         if not self.assure_server_and_tokens(len(corpus)):
-            return corpus
+            return None
 
         corpus = corpus.copy()
         metas_ind = corpus.domain.metas.index(meta_var)
@@ -46,6 +46,9 @@ class TweetProfiler:
             }
 
             json = self.server_call('tweet_profiler', json=json)
+
+            if json is None:    # something went wrong
+                return None
 
             class_vars = json['classes']
             profile = np.array(json['profile'])
@@ -75,7 +78,9 @@ class TweetProfiler:
                                      feature_names=feature_names,
                                      feature_values=feature_values,
                                      var_attrs=var_attrs)
-        return corpus
+            return corpus
+        else:
+            return None
 
     def get_server_address(self):
         # return 'http://127.0.0.1:8081/'

--- a/orangecontrib/text/tweet_profiler.py
+++ b/orangecontrib/text/tweet_profiler.py
@@ -110,6 +110,9 @@ class TweetProfiler:
             return False
 
     def assure_server_and_tokens(self, need_coins=0):
+        if not self.server:     # try to obtain server address
+            self.server = self.get_server_address()
+
         if not self.server or not self.check_server_alive(self.server):
             if callable(self.on_server_down):
                 self.on_server_down()


### PR DESCRIPTION
##### Issue
Server call can return None when servers are down which causes the code to crash.

##### Changes
`tweetProfiler.transform` returns None when something goes wrong.