### PR TITLE
[FIX] OWWordEnrichment: Fix Overlap Check for All Nan Columns

### DIFF
--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from AnyQt.QtWidgets import QTreeWidget, QTreeView, QTreeWidgetItem
 
@@ -109,7 +111,8 @@ class OWWordEnrichment(OWWidget):
             self.selected_data_transformed = Table.from_table(
                 self.data.domain, self.selected_data)
 
-            if np_sp_sum(self.selected_data_transformed.X) == 0:
+            sum_X = np_sp_sum(self.selected_data_transformed.X)
+            if sum_X == 0 or math.isnan(sum_X):
                 self.Error.no_words_overlap()
                 self.clear()
             elif len(self.data) == len(self.selected_data):


### PR DESCRIPTION
##### Issue 
OWWordEnrichment crashes when data from Tweet Profiler is sent to it and when selection is made with Select Rows and remove unused features is on.
https://sentry.io/biolab/orange3-text-bl/issues/204513439/

##### Changes
Fix check for features overlap to report not overlap when only columns with nans are present.