### PR TITLE
[FIX] Utils.chunkable: Report Progress as Fraction

### DIFF
--- a/orangecontrib/text/util.py
+++ b/orangecontrib/text/util.py
@@ -40,7 +40,7 @@ def chunkable(method):
                     res.extend(chunk_res)
 
                 progress += len(chunk)
-                on_progress(progress)
+                on_progress(progress/len(data))
         else:
             res = method(self, data, *args, **kwargs)
 

--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -215,7 +215,7 @@ class OWTopicModeling(OWWidget):
 
     @learning_task.callback
     def on_progress(self, p):
-        self.progressBarSet(100 * p / len(self.corpus), processEvents=None)
+        self.progressBarSet(100 * p, processEvents=None)
 
     def send_report(self):
         self.report_items(*self.widgets[self.method_index].report_model())


### PR DESCRIPTION
Change `Utils.chunkable` to report progress as fraction rather than the number of processed instances. Should fix https://sentry.io/biolab/orange3-text-bl/issues/210464520/ (though I'm not quite sure how this even happened).