### PR TITLE
[FIX] StopwordsFilter: Don't Crash When no NLTK Data

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -50,13 +50,20 @@ class WordListMixin:
             with open(path, encoding=enc) as f:
                 self.word_list = set([line.strip() for line in f])
 
+# get NLTK list of stopwords
+stopwords_listdir = []
+try:
+    stopwords_listdir = [file for file in os.listdir(stopwords._get_root())
+                         if file.islower()]
+except LookupError:     # when no NLTK data is available
+    pass
+
 
 class StopwordsFilter(BaseTokenFilter, WordListMixin):
     """ Remove tokens present in NLTK's language specific lists or a file. """
     name = 'Stopwords'
 
-    supported_languages = [file.capitalize() for file in os.listdir(stopwords._get_root())
-                           if file.islower()]
+    supported_languages = [file.capitalize() for file in stopwords_listdir]
 
     def __init__(self, language='English', word_list=None):
         WordListMixin.__init__(self, word_list)


### PR DESCRIPTION
##### Issue
https://sentry.io/biolab/orange3-text-bl/issues/209427889/
If Orange was started without internet connection NLTK data was not downloaded. When the data is missing, importing anything from `orangecontrib.text.preprocess` crashed with a `LookupError` since `StopwordsFilter` assumed the data is alredy downloaded.

#### Changes 
Use empy list as a list of supported stopwords languages in `StopwordsFilter` when NLTK data is missing.