### PR TITLE
[FIX] CorpusViewer: Don't Disable WebviewWidget for PyQt5

### DIFF
--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -109,11 +109,7 @@ class OWCorpusViewer(OWWidget):
         self.doc_list.selectionModel().selectionChanged.connect(self.show_docs)
 
         # Document contents
-        # For PyQt5 WebEngine's setHtml grabs the focus and makes typing hard
-        # More info: http://stackoverflow.com/questions/36609489
-        # To bypass the annoying behaviour disable the widget for WebEngine
-        self.doc_webview = gui.WebviewWidget(self.splitter, self,
-                                             debug=True, enabled=HAVE_WEBKIT)
+        self.doc_webview = gui.WebviewWidget(self.splitter, self, debug=True)
 
         self.mainArea.layout().addWidget(self.splitter)
 


### PR DESCRIPTION
#### Issue
In CorpusViewer scrolling didn't work on PyQt5.

#### Changes
Don't disable WebviewWidget when on PyQt5, since the issue will be solved in Orange. Blocked on https://github.com/biolab/orange3/pull/1983.