### PR TITLE
[FIX] CorpusViewer: Remove Unnecessary Bride from WebViewWidget

### DIFF
--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -109,7 +109,7 @@ class OWCorpusViewer(OWWidget):
         self.doc_list.selectionModel().selectionChanged.connect(self.show_docs)
 
         # Document contents
-        self.doc_webview = gui.WebviewWidget(self.splitter, self, debug=True)
+        self.doc_webview = gui.WebviewWidget(self.splitter, debug=True)
 
         self.mainArea.layout().addWidget(self.splitter)
 


### PR DESCRIPTION
#### Issue
When using CorpusViewer we get a lot of console messages like `Property 'X' of object 'OWCorpusViewer' has no notify signal and is not constant, value updates in HTML will be broken!`

#### Changes
Remove the bridge. I thinks CorpusViewer does not need it at all. 