### PR TITLE
[FIX] Use QObject Classes as WebView Bridges

### DIFF
--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -109,7 +109,7 @@ class OWCorpusViewer(OWWidget):
         self.doc_list.selectionModel().selectionChanged.connect(self.show_docs)
 
         # Document contents
-        self.doc_webview = gui.WebviewWidget(self.splitter, self, debug=True)
+        self.doc_webview = gui.WebviewWidget(self.splitter, debug=False)
 
         self.mainArea.layout().addWidget(self.splitter)
 

--- a/orangecontrib/text/widgets/owgeomap.py
+++ b/orangecontrib/text/widgets/owgeomap.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 from urllib.request import pathname2url
 
 import numpy as np
-from AnyQt.QtCore import Qt, QTimer, pyqtSlot, QUrl
+from AnyQt.QtCore import Qt, QTimer, pyqtSlot, QUrl, QObject
 from AnyQt.QtWidgets import QApplication, QSizePolicy
 
 from Orange.data import Table
@@ -49,7 +49,6 @@ class OWGeoMap(widget.OWWidget):
         self.data = None
         self._create_layout()
 
-    @pyqtSlot(str)
     def region_selected(self, regions):
         """Called from JavaScript"""
         if not regions:
@@ -88,7 +87,13 @@ class OWGeoMap(widget.OWWidget):
                           os.path.dirname(__file__),
                           'resources',
                          'owgeomap.html')))
-        self.webview = gui.WebviewWidget(self.controlArea, self, url=QUrl(url))
+
+        class Bridge(QObject):
+            @pyqtSlot(str)
+            def region_selected(_, regions):
+                return self.region_selected(regions)
+
+        self.webview = gui.WebviewWidget(self.controlArea, Bridge(), url=QUrl(url), debug=False)
         self.controlArea.layout().addWidget(self.webview)
 
         QTimer.singleShot(


### PR DESCRIPTION
#### Issue
QWidget instances should not be used as WebViewWidget's bridges. This results in log messages like:
`Property 'X'' of object 'OWWordCloud' has no notify signal and is not constant, value updates in HTML will be broken!`

#### Changes
Change CorpusViewer, GeoMap and WordCloud to use QObject classes as bridges instead.