### PR TITLE
[MNT] Install PyQt on Travis to Enable Widget Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,11 @@ install:
     - source $TRAVIS_BUILD_DIR/.travis/install_pyqt.sh
     - python setup.py develop   # assure version.py is present; required for imports
 
+before_script:  # required for widget tests
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
+    - sleep 3 # give xvfb some time to start
+
 script:
     - coverage run setup.py test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
               - source $TRAVIS_BUILD_DIR/.travis/create_conda_env.sh
               - python setup.py develop
           script: source $TRAVIS_BUILD_DIR/.travis/build_doc.sh
+        - &pyqt5
+          python: '3.5'
+          env: PYQT5=true
+          dist: trusty
+          addons: { apt: { packages: [] } }
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,13 @@ cache:
         - $HOME/.cache/pip
         - $HOME/.ccache
         - $HOME/nltk_data
+        - $TRAVIS_BUILD_DIR/pyqt
 
 before_cache:   # prevent logs from caching
     - rm -f $HOME/.cache/pip/log/debug.log
 
 before_install:
+    - source $TRAVIS_BUILD_DIR/.travis/util.sh
     - pip install -U setuptools pip wheel
     - pip install codecov
     - mkdir -p /home/travis/.local/share/Orange  # create orange app dir
@@ -42,6 +44,7 @@ before_install:
 install:
     - travis_wait pip install -r requirements.txt
     - travis_wait pip install -r requirements-opt.txt
+    - source $TRAVIS_BUILD_DIR/.travis/install_pyqt.sh
     - python setup.py develop   # assure version.py is present; required for imports
 
 script:

--- a/.travis/install_pyqt.sh
+++ b/.travis/install_pyqt.sh
@@ -1,0 +1,40 @@
+if [ "$PYQT5" ]; then
+    foldable pip install sip pyqt5
+    return $?;
+fi
+
+PYQT=$TRAVIS_BUILD_DIR/pyqt
+
+SIP_VERSION=4.16.9
+PYQT_VERSION=4.11.4
+
+if [ ! "$(ls $PYQT)" ]; then
+    mkdir -p $PYQT
+    cd $PYQT
+
+    wget -O sip.tar.gz http://sourceforge.net/projects/pyqt/files/sip/sip-$SIP_VERSION/sip-$SIP_VERSION.tar.gz
+    mkdir -p sip
+    tar xzf sip.tar.gz -C sip --strip-component=1
+
+    wget -O PyQt.tar.gz  http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-$PYQT_VERSION/PyQt-x11-gpl-$PYQT_VERSION.tar.gz
+    mkdir -p PyQt
+    tar xzf PyQt.tar.gz -C PyQt --strip-components=1
+
+    cd $PYQT/sip
+    python configure.py -e $PYQT/include
+    make
+    make install
+
+    cd $PYQT/PyQt
+    pwd
+    python configure.py --confirm-license --no-designer-plugin
+    make
+fi
+
+cd $PYQT/sip
+make install
+
+cd $PYQT/PyQt
+make install
+
+cd $TRAVIS_BUILD_DIR

--- a/.travis/util.sh
+++ b/.travis/util.sh
@@ -1,0 +1,14 @@
+
+foldable ()
+{
+    # As documented in:
+    # https://github.com/travis-ci/travis-ci/issues/2158#issuecomment-42726890
+    # https://github.com/travis-ci/travis-ci/issues/2285#issuecomment-42724719
+    local _id="$RANDOM$RANDOM$RANDOM"
+    echo "travis_fold:start:$_id"
+    echo "$*"
+    "$@"
+    local _estatus="$?"
+    echo "travis_fold:end:$_id"
+    return $_estatus
+}

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import unittest
 from setuptools import setup, find_packages
 
 NAME = 'Orange3-Text'
@@ -133,8 +134,15 @@ INSTALL_REQUIRES = sorted(set(
 ) - {''})
 
 if 'test' in sys.argv:
+    # http://stackoverflow.com/a/37033551/892987
+    def discover_tests():
+        return unittest.defaultTestLoader.discover(
+            'orangecontrib.text',
+            pattern='test_*.py',
+            top_level_dir='.')
+
     extra_setuptools_args = dict(
-        test_suite='orangecontrib.text.tests',
+        test_suite='setup.discover_tests'
     )
 else:
     extra_setuptools_args = dict()


### PR DESCRIPTION
##### Issue
PyQt was not yet installed on Travis.

##### Changes
* Install PyQt to enable widget tests.
* Run tests on PyQt5.
* Change `setup.py tests` to discover tests instead of hardcoding its location.