### PR TITLE
[FIX] utils.widgets.RangeWidget: Synchronize only on editingFinished

### DIFF
--- a/orangecontrib/text/widgets/utils/widgets.py
+++ b/orangecontrib/text/widgets/utils/widgets.py
@@ -471,10 +471,8 @@ class RangeWidget(QWidget):
         layout.addWidget(self.max_spin)
 
         self.set_range()
-        self.min_spin.valueChanged.connect(self.synchronize)
-        self.min_spin.editingFinished.connect(self.editingFinished)
-        self.max_spin.valueChanged.connect(self.synchronize)
-        self.max_spin.editingFinished.connect(self.editingFinished)
+        self.min_spin.editingFinished.connect(self._editing_finished)
+        self.max_spin.editingFinished.connect(self._editing_finished)
         if callback:
             self.valueChanged.connect(callback)
 
@@ -486,7 +484,12 @@ class RangeWidget(QWidget):
             setattr(self.master, self.attribute[0], a)
             setattr(self.master, self.attribute[1], b)
         self.set_range()
-        self.valueChanged.emit()
+
+    def _editing_finished(self):
+        value_before = self.master_value()
+        self.synchronize()
+        if value_before != self.master_value():
+            self.editingFinished.emit()
 
     def master_value(self):
         if isinstance(self.attribute, str):


### PR DESCRIPTION
##### Issue
When editing the min_df number in Preprocess Text and pressing Enter the changed values was not propagated to the filter. Hence even when changing the min_df value the number of tokens remained the same.

The bug is in `RangeWidget` who simply triggered `editingFinished` signal but did not set the new value to the master's attribute.

##### Changes
When editingFinished signal is triggered (e.g. when pressing Enter) the value is now updated to the master's attribute. Also we send `editingFinished` signal only when there actually was a change to the master's attributes.