### PR TITLE
owconcordance: Proper coloring of documents

### DIFF
--- a/orangecontrib/text/widgets/owconcordance.py
+++ b/orangecontrib/text/widgets/owconcordance.py
@@ -59,6 +59,7 @@ class ConcordanceModel(QAbstractTableModel):
         self.indices = None
         self.word_index = None
         self.width = 8
+        self.colored_rows = None
 
     def set_word(self, word):
         self.modelAboutToBeReset.emit()
@@ -107,7 +108,7 @@ class ConcordanceModel(QAbstractTableModel):
                     Qt.AlignLeft | Qt.AlignVCenter][col]
 
         elif role == Qt.BackgroundRole:
-            const = self.word_index[row][0] % 2
+            const = self.word_index[row][0] in self.colored_rows
             return QColor(236 + 19 * const, 243 + 12 * const, 255)
 
     def _compute_indices(self):  # type: () -> Optional[None, list]
@@ -122,11 +123,12 @@ class ConcordanceModel(QAbstractTableModel):
 
     def _compute_word_index(self):
         if self.indices is None or self.word is None:
-            self.word_index = None
+            self.word_index = self.colored_rows = None
         else:
             self.word_index = [
                 (doc_idx, offset) for doc_idx, doc in enumerate(self.indices)
                 for offset in doc.offsets(self.word)]
+            self.colored_rows = set(sorted({d[0] for d in self.word_index})[::2])
 
     def matching_docs(self):
         if self.indices and self.word:

--- a/orangecontrib/text/widgets/tests/test_concordances.py
+++ b/orangecontrib/text/widgets/tests/test_concordances.py
@@ -57,6 +57,19 @@ class TestConcordanceModel(unittest.TestCase):
         self.assertIsInstance(model.data(ind00, Qt.TextAlignmentRole),
                               (Qt.Alignment, type(None)))
 
+    def test_color_proper_rows(self):
+        """Rows are colored corresponding to the document"""
+        model = ConcordanceModel()
+        model.set_width(2)
+        model.set_corpus(self.corpus)
+        model.set_word("of")
+
+        color1 = model.data(model.index(0, 0), Qt.BackgroundRole)
+        self.assertEqual(model.data(model.index(1, 0), Qt.BackgroundRole),
+                         color1)
+        self.assertNotEqual(model.data(model.index(2, 0), Qt.BackgroundRole),
+                            color1)
+
     def test_order_doesnt_matter(self):
         """Setting the word or the corpus first works"""
         model = ConcordanceModel()


### PR DESCRIPTION
Documents were colored by document index, instead of matching documents. This caused several documents to be colored the same.