### PR TITLE
[FIX] Fix Scripting Part Documentation Building on RTD

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -12,11 +12,11 @@ dependencies:
 - setuptools-git
 - Orange3>=3.3.9
 - beautifulsoup4
+- pyqt=5.6.0
 
 - pip:
   - validate_email
   - tweepy
   - simhash
   - wikipedia
-  - PyQt5
   - Sphinx

--- a/orangecontrib/text/misc/environ.py
+++ b/orangecontrib/text/misc/environ.py
@@ -5,4 +5,7 @@ from Orange.misc.environ import data_dir_base
 
 def nltk_data_dir():
     """ Location where the NLTK data is stored. """
-    return os.path.join(data_dir_base(), 'Orange', 'nltk_data')
+    dir_ = os.path.join(data_dir_base(), 'Orange', 'nltk_data')
+    # make sure folder exists for ReadTheDocs
+    os.makedirs(dir_, exist_ok=True)
+    return dir_


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Documentation for the scripting part did not properly build on RTD.

##### Description of changes
Install PyQt with conda and not pip. Assure `nltk_data_dir` exists. 