### PR TITLE
Corpus.extend_attributes: Add parent reference to compute_values

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -164,6 +164,8 @@ class Corpus(Table):
                 var = DiscreteVariable(f, values=values, compute_value=cv)
             else:
                 var = ContinuousVariable(f, compute_value=cv)
+            if cv is not None:  # set original variable for cv
+                cv.variable = var
             if isinstance(var_attrs, dict):
                 var.attributes.update(var_attrs)
             new_attr += (var, )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #224.

##### Description of changes
Store reference to the original variable to compute values.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
