### PR TITLE
Travis: Disable Python 3.6 Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
     include:
         - python: '3.4'
         - python: '3.5'
-        - python: '3.6'
         - &docs
           env: BUILD_DOCS=true
           python: '3.5'


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests started failing for python 3.6 due to problems with PyQt4 installation. 

##### Description of changes
Temporarily disable Python 3.6 tests.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
