### PR TITLE
[FIX] Corpus: Use given X even if empty

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -51,7 +51,7 @@ class Corpus(Table):
         """
         n_doc = _check_arrays(X, Y, metas)
 
-        self.X = X if X is not None and X.size else sp.csr_matrix((n_doc, 0))   # prefer sparse (BoW compute values)
+        self.X = X if X is not None else sp.csr_matrix((n_doc, 0))   # prefer sparse (BoW compute values)
         self.Y = Y if Y is not None else np.zeros((n_doc, 0))
         self.metas = metas if metas is not None else np.zeros((n_doc, 0))
         self.W = W if W is not None else np.zeros((n_doc, 0))
@@ -386,7 +386,10 @@ class Corpus(Table):
                 filename = abs_path
 
         table = Table.from_file(filename)
-        return cls(table.domain, table.X, table.Y, table.metas, table.W)
+        X = table.X
+        if not sp.issparse(X) and X.size == 0:
+            X = sp.csr_matrix(X)        # prefer sparse (BoW compute values)
+        return cls(table.domain, X, table.Y, table.metas, table.W)
 
     @staticmethod
     def retain_preprocessing(orig, new, key=...):

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -14,6 +14,17 @@ from orangecontrib.text.tag import pos_tagger
 
 
 class CorpusTests(unittest.TestCase):
+    def test_init_preserve_shape_of_empty_x(self):
+        c = Corpus.from_file('bookexcerpts')
+        d = c.domain
+        new_domain = Domain((ContinuousVariable('c1'),), d.class_vars, d.metas)
+
+        empty_X = csr_matrix((len(c), 1))
+        new = Corpus(new_domain, X=empty_X, Y=c.Y, metas=c.metas)
+
+        self.assertEqual(empty_X.nnz, 0)
+        self.assertEqual(new.X.shape, empty_X.shape)
+
     def test_corpus_from_file(self):
         c = Corpus.from_file('bookexcerpts')
         self.assertEqual(len(c), 140)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
If X is given use it no matter if it contains data or not. This is required for applying a BoW classfifer on new data. Classifiers use `from_table` (which creates a new corpus) and if no classifier's tokens appear in the new data documents, then X is an empty sparse matrix of the correct shape. In this case, we currently replaced this empty X with a sparse matrix without columns which caused classifiers to crash with shape mismatch (but only when there was no words overlap).


##### Description of changes
Corpus's `__init__` uses provided X if it is given without checking for its size.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
