### PR TITLE
[FIX] Word Cloud: test and prevention empty data

### DIFF
--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -233,7 +233,7 @@ span.selected {color:red !important}
     def handleNewSignals(self):
         if self.topic is not None:
             self._apply_topic()
-        elif self.corpus is not None:
+        elif self.corpus is not None and len(self.corpus):
             self._apply_corpus()
         else:
             self.clear()

--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -231,7 +231,7 @@ span.selected {color:red !important}
                                    if data else '(no documents on input)')
 
     def handleNewSignals(self):
-        if self.topic is not None:
+        if self.topic is not None and len(self.topic):
             self._apply_topic()
         elif self.corpus is not None and len(self.corpus):
             self._apply_corpus()

--- a/orangecontrib/text/widgets/tests/test_owworldclooud.py
+++ b/orangecontrib/text/widgets/tests/test_owworldclooud.py
@@ -1,0 +1,23 @@
+import unittest
+
+from Orange.widgets.tests.base import WidgetTest
+from orangecontrib.text.corpus import Corpus
+from orangecontrib.text.widgets.owwordcloud import OWWordCloud
+
+
+class TestWorldCloudWidget(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWWordCloud)
+        self.corpus = Corpus.from_file('deerwester')
+
+    def test_data(self):
+        """
+        Just basic test.
+        GH-244
+        """
+        self.send_signal("Corpus", self.corpus)
+        self.send_signal("Corpus", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/widgets/tests/test_owworldclooud.py
+++ b/orangecontrib/text/widgets/tests/test_owworldclooud.py
@@ -18,6 +18,17 @@ class TestWorldCloudWidget(WidgetTest):
         self.send_signal("Corpus", self.corpus)
         self.send_signal("Corpus", None)
 
+    def test_empty_data(self):
+        """
+        Widget crashes when receives zero length data.
+        GH-244
+        """
+        self.assertTrue(self.widget.documents_info_str == "(no documents on input)")
+        self.send_signal("Corpus", self.corpus)
+        self.assertTrue(self.widget.documents_info_str == "9 documents with 42 words")
+        self.send_signal("Corpus", self.corpus[:0])
+        self.assertTrue(self.widget.documents_info_str == "(no documents on input)")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
WordCloud crashes on empty corpus and empty topic.


##### Description of changes
Do not plot when corpus/topic is empty.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
