### PR TITLE
Travis: Remove py35 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false   # use container-based infrastructure
 matrix:
     include:
         - python: '3.4'
-        - python: '3.5'
         - &docs
           env: BUILD_DOCS=true
           python: '3.5'


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Builds fail on py35 and PyQt4.

##### Description of changes
Remove py35 from Travis.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
