### PR TITLE
OWWordCloud: Make Corpus a default input

### DIFF
--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -27,8 +27,8 @@ class OWWordCloud(widget.OWWidget):
     priority = 10000
     icon = "icons/WordCloud.svg"
     inputs = [
+        (IO.CORPUS, Corpus, 'on_corpus_change', widget.Default),
         (IO.TOPIC, Topic, 'on_topic_change'),
-        (IO.CORPUS, Corpus, 'on_corpus_change'),
     ]
     outputs = [
         (IO.CORPUS, Corpus),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When connecting an output of some widget with dynamic outputs (e.g. SelectColumns) to WordCloud it was connected as s Topic by default, since Corpus and Topic are both instances of Table.

##### Description of changes
Make Corpus a default input. Since Topic only comes from Topic Modelling widget which does not have dynamic outputs, this change causes no problems there — i.e. when connecting Topic to WordCloud is correctly connected as a Topic. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation