### PR TITLE
[FIX] Concordance: word settings

### DIFF
--- a/orangecontrib/text/widgets/tests/test_concordances.py
+++ b/orangecontrib/text/widgets/tests/test_concordances.py
@@ -217,7 +217,7 @@ class TestConcordanceWidget(WidgetTest):
         self.send_signal("Corpus", None)
         self.assertIsNone(self.get_output("Selected Documents"))
         self.assertEqual(widget.model.rowCount(), 0)
-        self.assertEqual(widget.controls.word.text(), "of")
+        self.assertEqual(widget.controls.word.text(), "")
 
         self.send_signal("Corpus", self.corpus)
         self.assertEqual(widget.model.rowCount(), nrows)


### PR DESCRIPTION
##### Issue
#217

##### Description of changes
Save filter word as context setting and reuse it when no word on input.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation