### PR TITLE
OWCorpusViewer: Disable show tokens before show_docs

### DIFF
--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -134,6 +134,10 @@ class OWCorpusViewer(OWWidget):
             if not isinstance(data, Corpus):
                 self.corpus = Corpus.from_table(data.domain, data)
             domain = self.corpus.domain
+            # Enable/disable tokens checkbox
+            if not self.corpus.has_tokens():
+                self.show_tokens_checkbox.setCheckState(False)
+            self.show_tokens_checkbox.setEnabled(self.corpus.has_tokens())
 
             self.search_features = list(filter_visible(chain(domain.variables, domain.metas)))
             self.display_features = list(filter_visible(chain(domain.variables, domain.metas)))
@@ -147,10 +151,6 @@ class OWCorpusViewer(OWWidget):
             self.update_info()
             self.set_selection()
             self.show_docs()
-            # Enable/disable tokens checkbox
-            if not self.corpus.has_tokens():
-                self.show_tokens_checkbox.setCheckState(False)
-            self.show_tokens_checkbox.setEnabled(self.corpus.has_tokens())
         self.commit()
 
     def reset_widget(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
If one passes data with tokens & tags, mark the checkbox to display tokens & tags and then replaces the data set with the one without tags it crashed. The problem was that `show_docs` was called before the checkbox was disabled.

##### Description of changes
Disable the checkbox before calling `show_docs`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation