### PR TITLE
[FIX] PreprocessText: Fix frequency filtering bug

### DIFF
--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -396,11 +396,13 @@ class FilteringModule(MultipleMethodModule):
         if self.FREQUENCY in self.checked:
             self.frequency_filter.min_df = self.min_df
             self.frequency_filter.max_df = self.max_df
+        else:
+            checked.append(self.FREQUENCY)
+            self.frequency_filter.min_df = 0
+            self.frequency_filter.max_df = 1.0
 
         if self.KEEP_N in checked:
             checked.pop(checked.index(self.KEEP_N))
-            if self.FREQUENCY not in self.checked:
-                checked.append(self.FREQUENCY)
             self.frequency_filter.keep_n = self.keep_n
         else:
             self.frequency_filter.keep_n = None

--- a/orangecontrib/text/widgets/tests/test_owpreprocess.py
+++ b/orangecontrib/text/widgets/tests/test_owpreprocess.py
@@ -1,0 +1,15 @@
+from Orange.widgets.tests.base import WidgetTest
+from orangecontrib.text.corpus import Corpus
+from orangecontrib.text.widgets.owpreprocess import OWPreprocess
+
+
+class TestConcordanceWidget(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWPreprocess)
+        self.corpus = Corpus.from_file('deerwester')
+
+    def test_set_corpus(self):
+        """
+        Just basic test.
+        """
+        self.send_signal("Corpus", self.corpus)


### PR DESCRIPTION
##### Issue
Fixes #265

##### Description of changes
Set `min_df` and `max_df` to `0` and `1` when filtering by frequency not selected. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
