### PR TITLE
Better defaults for DF in Preprocess Text

### DIFF
--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -329,8 +329,8 @@ class FilteringModule(MultipleMethodModule):
 
     pattern = settings.Setting('\.|,|:|;|!|\?|\(|\)|\||\+|\'|\"|‘|’|“|”|\'|\’'
                                '|…|\-|–|—|\$|&|\*|>|<')
-    min_df = settings.Setting(0.)
-    max_df = settings.Setting(1.)
+    min_df = settings.Setting(0.1)
+    max_df = settings.Setting(0.9)
     keep_n = settings.Setting(100)
     use_keep_n = settings.Setting(False)
     use_df = settings.Setting(False)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Default for DF in Preprocess Text was meaningless as it output all the documents.

##### Description of changes
Set the new default to filter out tokens in less then 10% and more than 90% of the documents.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
