### PR TITLE
Corpus: Remove __len__, use Table's __len__ instead

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -136,6 +136,9 @@ class Corpus(Table):
             metadata (numpy.ndarray): Meta data
             Y (numpy.ndarray): Class variables
         """
+        if np.prod(self.X.shape) != 0:
+            raise ValueError("Extending corpus only works when X is empty"
+                             "while the shape of X is {}".format(self.X.shape))
 
         self.metas = np.vstack((self.metas, metadata))
 
@@ -146,7 +149,7 @@ class Corpus(Table):
         new_Y = np.array([cv.to_val(i) for i in Y])[:, None]
         self._Y = np.vstack((self._Y, new_Y))
 
-        self.X = self.W = np.zeros((len(self), 0))
+        self.X = self.W = np.zeros((self.metas.shape[0], 0))
         Table._init_ids(self)
 
         self._tokens = None     # invalidate tokens

--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -437,9 +437,6 @@ class Corpus(Table):
             new.attributes = orig.attributes
             new.used_preprocessor = orig.used_preprocessor
 
-    def __len__(self):
-        return len(self.metas)
-
     def __eq__(self, other):
         def arrays_equal(a, b):
             if sp.issparse(a) != sp.issparse(b):

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -98,6 +98,11 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(c.metas.shape[1], c_copy.metas.shape[1])
         self.assertEqual(len(c_copy.domain.class_var.values), n_classes+1)
 
+    def test_extend_corpus_non_empty_X(self):
+        c = Corpus.from_file('election-tweets-2016')[:10]
+        with self.assertRaises(ValueError):
+            c.extend_corpus(c.metas, c.Y)
+
     def test_extend_attributes(self):
         # corpus without features
         c = Corpus.from_file('book-excerpts')


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

After https://github.com/biolab/orange3/pull/2457 using matas for `__len__` can causes problems with `from_table`. E.g. create BoW and set some of BoW features as class in Select Column and the error will be thrown. Since setter of Y calls len, and in `from_table` Y is set before metas, the setter for Y can be given the wrong length.

Not sure why we had to overwrite `__len__` in the first place, but using Table's seems just fine.

##### Description of changes
Remove Corpus's `__len__`, use Table's instead.


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation