### PR TITLE
[ENH] Corpus & Bow: Improve sparsity handling according to Orange>=3.8.0

### DIFF
--- a/orangecontrib/text/vectorization/base.py
+++ b/orangecontrib/text/vectorization/base.py
@@ -39,7 +39,8 @@ class BaseVectorizer:
         corpus.extend_attributes(X[:, order],
                                  feature_names=(dictionary[i] for i in order),
                                  var_attrs=variable_attrs,
-                                 compute_values=compute_values)
+                                 compute_values=compute_values,
+                                 sparse=True)
         corpus.ngrams_corpus = matutils.Sparse2Corpus(X.T)
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
BoW features when comming from compute values were dense, when some features already existed in the corpus. The core of the problems is bad logic for deciding on the sparsity, which was fixed in https://github.com/biolab/orange3/pull/2341 and released in `Orange=3.8.0`.

##### Description of changes
* Remove the preference for sparse matrix when X is empty.
* Mark all BoW features as sparse — this assures that X becomes sparse even when data comes from compute values.
* This also fixes the currently failing tests on the master which failed due to updates in `Orange=3.8.0`.

**IMPORTANT:** Orange version in `requirements.txt` wasn't bumped to `3.8.0` on purpuse and the code was written in a backwards comparible manner so that the addon can also work with older versions of Orange. Note, however, that it is higly recommended to update Orange to `>=3.8.0` since as of this PR the BoW data on older Orange versions will become dense!

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation