### PR TITLE
[FIX] Corpus.extend_corpus: Remove Nones from discrete values

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -140,7 +140,7 @@ class Corpus(Table):
         self.metas = np.vstack((self.metas, metadata))
 
         cv = self.domain.class_var
-        for val in set(Y):
+        for val in set(filter(None, Y)):
             if val not in cv.values:
                 cv.add_value(val)
         new_Y = np.array([cv.to_val(i) for i in Y])[:, None]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
PubMed can crash when missing values are among class variables.
![screen shot 2017-07-25 at 13 06 20](https://user-images.githubusercontent.com/713026/28569464-2e690f2e-713a-11e7-973d-44e70fc26112.png)


##### Description of changes
`Corpus.extend_corpus` doesn't add `None` to Discrete variable values any more.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
