### PR TITLE
[FIX] preprocess: Use default tokenizer when None

### DIFF
--- a/orangecontrib/text/preprocess/__init__.py
+++ b/orangecontrib/text/preprocess/__init__.py
@@ -39,6 +39,3 @@ from .normalize import *
 from .tokenize import *
 from .transform import *
 from .preprocess import *
-
-base_preprocessor = Preprocessor(transformers=[LowercaseTransformer()],
-                                 tokenizer=WordPunctTokenizer())

--- a/orangecontrib/text/preprocess/preprocess.py
+++ b/orangecontrib/text/preprocess/preprocess.py
@@ -1,6 +1,12 @@
-from orangecontrib.text.preprocess import FrequencyFilter
+from orangecontrib.text.preprocess import (
+    FrequencyFilter, LowercaseTransformer, WordPunctTokenizer)
 
-__all__ = ['Preprocessor']
+
+__all__ = ['Preprocessor', 'base_preprocessor']
+
+
+BASE_TOKENIZER = WordPunctTokenizer()
+BASE_TRANSFORMERS = [LowercaseTransformer()]
 
 
 class Preprocessor:
@@ -87,7 +93,7 @@ class Preprocessor:
         if self.tokenizer:
             tokens = self.tokenizer.tokenize(document)
         else:
-            tokens = [document]
+            tokens = BASE_TOKENIZER.tokenize(document)
 
         if self.normalizer:
             tokens = self.normalizer(tokens)
@@ -133,3 +139,7 @@ class Preprocessor:
             ('Frequency filter', str(self.freq_filter)),
             ('Pos tagger', str(self.pos_tagger)),
         )
+
+
+base_preprocessor = Preprocessor(transformers=BASE_TRANSFORMERS,
+                                 tokenizer=BASE_TOKENIZER)

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -26,20 +26,13 @@ class PreprocessTests(unittest.TestCase):
         self.corpus = Corpus.from_file('deerwester')
 
     def test_string_processor(self):
-        class StripStringTransformer(preprocess.BaseTransformer):
-            @classmethod
-            def transform(cls, string):
-                return string[:-1]
-        p = Preprocessor(transformers=StripStringTransformer())
+        p = Preprocessor(transformers=preprocess.LowercaseTransformer())
+        tokens = p(self.corpus).tokens
+        p2 = Preprocessor(transformers=[])
+        tokens2 = p2(self.corpus).tokens
 
-        np.testing.assert_equal(p(self.corpus).tokens,
-                                np.array([[doc[:-1]] for doc in self.corpus.documents]))
-
-        p = Preprocessor(transformers=[StripStringTransformer(),
-                                       preprocess.LowercaseTransformer()])
-
-        np.testing.assert_equal(p(self.corpus).tokens,
-                                np.array([[doc[:-1].lower()] for doc in self.corpus.documents]))
+        np.testing.assert_equal(tokens,
+                                [[t.lower() for t in doc] for doc in tokens2])
 
         self.assertRaises(TypeError, Preprocessor, string_transformers=1)
 
@@ -59,9 +52,12 @@ class PreprocessTests(unittest.TestCase):
             def normalize(cls, token):
                 return token.capitalize()
         p = Preprocessor(normalizer=CapTokenNormalizer())
+        tokens = p(self.corpus).tokens
+        p2 = Preprocessor(normalizer=None)
+        tokens2 = p2(self.corpus).tokens
 
-        np.testing.assert_equal(p(self.corpus).tokens,
-                                np.array([[sent.capitalize()] for sent in self.corpus.documents]))
+        np.testing.assert_equal(
+            tokens, [[t.capitalize() for t in doc] for doc in tokens2])
 
     def test_token_filter(self):
         class SpaceTokenizer(preprocess.BaseTokenizer):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
A preprocessor can be constructed with tokenizer=None (actually, this is the default!).
In this case preprocessing produces a single token with the complete text. This can cause many problems and is probably never desired/useful.

##### Description of changes
1. If tokenizer=None, use the same default tokenizer as is used in base_preprocessor, which is called when accessing Corpus.tokens without previous explicit preprocessing.
2. Move base_preprocessor into the preprocess.py module, right after the class Preprocess (of which it is an instance).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
