### PR TITLE
[ENH] Add Table Input to Corpus

### DIFF
--- a/orangecontrib/text/widgets/owcorpus.py
+++ b/orangecontrib/text/widgets/owcorpus.py
@@ -49,6 +49,7 @@ class OWCorpus(OWWidget):
 
     class Error(OWWidget.Error):
         read_file = Msg("Can't read file {} ({})")
+        corpus_without_text_features = Msg("Corpus doesn't have any textual features.")
 
     def __init__(self):
         super().__init__()
@@ -119,7 +120,7 @@ class OWCorpus(OWWidget):
 
     def open_file(self, path=None, data=None):
         self.closeContext()
-        self.Error.read_file.clear()
+        self.Error.clear()
         self.used_attrs_model[:] = []
         self.unused_attrs_model[:] = []
         if data:
@@ -135,6 +136,10 @@ class OWCorpus(OWWidget):
 
         self.update_info()
         self.used_attrs = list(self.corpus.text_features)
+        if not self.corpus.text_features:
+            self.Error.corpus_without_text_features()
+            self.Outputs.corpus.send(None)
+            return
         self.openContext(self.corpus)
         self.used_attrs_model.extend(self.used_attrs)
         self.unused_attrs_model.extend(

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -9,7 +9,6 @@ from AnyQt.QtWidgets import (QListView, QSizePolicy, QTableView,
                              QAbstractItemView, QHeaderView, QSplitter,
                              QApplication)
 
-from Orange.data import Table
 from Orange.data.domain import filter_visible
 from Orange.widgets import gui, widget
 from Orange.widgets.settings import Setting, ContextSetting, PerfectDomainContextHandler
@@ -24,7 +23,7 @@ class OWCorpusViewer(OWWidget):
     priority = 500
 
     class Inputs:
-        data = Input("Data", Table)
+        corpus = Input("Corpus", Corpus)
 
     class Outputs:
         matching_docs = Output("Matching Docs", Corpus, default=True)
@@ -123,15 +122,13 @@ class OWCorpusViewer(OWWidget):
         text = self.doc_webview.selectedText()
         QApplication.clipboard().setText(text)
 
-    @Inputs.data
-    def set_data(self, data=None):
+    @Inputs.corpus
+    def set_data(self, corpus=None):
         self.closeContext()
         self.reset_widget()
-        self.corpus = data
+        self.corpus = corpus
         self.search_features = []
-        if data is not None:
-            if not isinstance(data, Corpus):
-                self.corpus = Corpus.from_table(data.domain, data)
+        if corpus is not None:
             domain = self.corpus.domain
             # Enable/disable tokens checkbox
             if not self.corpus.has_tokens():


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
One cannot convert Orange's data table to Corpus instance.

##### Description of changes
* `OWCorpus` now has `Table` input. When present, some GUI elements are frozen and the data from the input is considered.
* Raise an error when corpus has not textual features.
* Raise an error when no text features are selected.
* CorpusViewer now accepts Corpus, not Table.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
