### PR TITLE
CorpusViewer: Corpus input backwards compatibility

### DIFF
--- a/doc/widgets/corpusviewer.rst
+++ b/doc/widgets/corpusviewer.rst
@@ -11,9 +11,9 @@ Signals
 
 **Inputs**:
 
--  **Data**
+-  **Corpus**
 
-   Data instance.
+   Corpus instance.
 
 **Outputs**:
 
@@ -24,8 +24,7 @@ Signals
 Description
 -----------
 
-**Corpus Viewer** is primarily meant for viewing text files (instances of :ref:`Corpus <corpus>`), but
-it can also display other data files from **File** widget. **Corpus Viewer** will always output an instance
+**Corpus Viewer** is meant for viewing text files (instances of :ref:`Corpus <corpus>`). It will always output an instance
 of corpus. If *RegExp* filtering is used, the widget will output only matching documents.
 
 .. figure:: images/Corpus-Viewer-stamped.png

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -23,7 +23,7 @@ class OWCorpusViewer(OWWidget):
     priority = 500
 
     class Inputs:
-        corpus = Input("Corpus", Corpus)
+        corpus = Input("Corpus", Corpus, replaces=["Data"])
 
     class Outputs:
         matching_docs = Output("Matching Docs", Corpus, default=True)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
After renaming CorpusViewer input from Data to Corpus, old schemas couldn't be loaded any more.

##### Description of changes
Mark that Corpus input replaces the old Data input.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
