### PR TITLE
[FIX] Topic Modelling: do not call get all topics table when no corpus

### DIFF
--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -210,13 +210,13 @@ class OWTopicModeling(OWWidget):
     def on_result(self, corpus):
         self.progressBarFinished(None)
         self.Outputs.corpus.send(corpus)
-        self.Outputs.all_topics.send(self.model.get_all_topics_table())
         if corpus is None:
             self.topic_desc.clear()
             self.Outputs.selected_topic.send(None)
             self.Outputs.all_topics.send(None)
         else:
             self.topic_desc.show_model(self.model)
+            self.Outputs.all_topics.send(self.model.get_all_topics_table())
 
     @learning_task.callback
     def on_progress(self, p):


### PR DESCRIPTION
##### Issue
Topic Modelling crashes when there is no Corpus.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
