### PR TITLE
Move biopython back to requirements

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -1,1 +1,1 @@
-biopython # Enables Pubmed widget.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pdfminer3k>=1.3.1
 odfpy>=1.3.5
 docx2txt>=0.6
 lxml
+biopython # Enables Pubmed widget.


### PR DESCRIPTION
##### Issue
Biopython failed to install without proper compiler.
Since version 1.70 they included pre-compiled binary wheel packages on PyPI for Linux, Mac and Windows.

source: https://github.com/biopython/biopython

##### Description of changes
Add biopython library to requirements. Pubmed widget is now available without manually installing biopython.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
