### PR TITLE
PreprocessText: handle encoding errors reading stopwords/lexicon files

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -45,12 +45,21 @@ class WordListMixin:
 
     def from_file(self, path):
         self.file_path = path
+        self.word_list = []
         if not path:
-            self.word_list = []
-        else:
-            enc = detect_encoding(path)
-            with open(path, encoding=enc) as f:
-                self.word_list = set([line.strip() for line in f])
+            return
+
+        for encoding in ('utf-8',
+                         None,  # sys.getdefaultencoding()
+                         detect_encoding(path)):
+            try:
+                with open(path, encoding=encoding) as f:
+                    self.word_list = set(line.strip() for line in f)
+            except UnicodeDecodeError:
+                continue
+            return
+        # No encoding worked, raise
+        raise UnicodeError("Couldn't determine file encoding")
 
 # get NLTK list of stopwords
 stopwords_listdir = []

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -418,23 +418,29 @@ class FilteringModule(MultipleMethodModule):
             self.frequency_filter.keep_n = self.keep_n
             self.change_signal.emit()
 
-    def _read_file(self, method, path):
-        self.master.Error.encoding.clear()
-        self.master.Error.error_reading_file.clear()
-        try:
-            self.methods[method].from_file(path)
-        except UnicodeError:
-            self.master.Error.encoding()
-        except Exception as e:
-            self.master.Error.error_reading_file(e)
-
     def read_stopwords_file(self, path):
-        self._read_file(self.STOPWORDS, path)
+        self.master.Error.stopwords_encoding.clear()
+        self.master.Error.error_reading_stopwords.clear()
+        try:
+            self.methods[self.STOPWORDS].from_file(path)
+        except UnicodeError:
+            self.master.Error.stopwords_encoding()
+        except Exception as e:
+            self.master.Error.error_reading_stopwords(e)
+
         if self.STOPWORDS in self.checked:
             self.change_signal.emit()
 
     def read_lexicon_file(self, path):
-        self._read_file(self.LEXICON, path)
+        self.master.Error.lexicon_encoding.clear()
+        self.master.Error.error_reading_lexicon.clear()
+        try:
+            self.methods[self.LEXICON].from_file(path)
+        except UnicodeError:
+            self.master.Error.lexicon_encoding()
+        except Exception as e:
+            self.master.Error.error_reading_lexicon(e)
+
         if self.LEXICON in self.checked:
             self.change_signal.emit()
 
@@ -553,8 +559,10 @@ class OWPreprocess(OWWidget):
 
     class Error(OWWidget.Error):
         stanford_tagger = Msg("Problem while loading Stanford POS Tagger\n{}")
-        encoding = Msg("Invalid file encoding. Please save the file as UTF-8 and try again.")
-        error_reading_file = Msg("Error reading file: {}")
+        stopwords_encoding = Msg("Invalid stopwords file encoding. Please save the file as UTF-8 and try again.")
+        lexicon_encoding = Msg("Invalid lexicon file encoding. Please save the file as UTF-8 and try again.")
+        error_reading_stopwords = Msg("Error reading file: {}")
+        error_reading_lexicon = Msg("Error reading file: {}")
 
     class Warning(OWWidget.Warning):
         no_token_left = Msg('No tokens on output! Please, change configuration.')

--- a/orangecontrib/text/widgets/utils/widgets.py
+++ b/orangecontrib/text/widgets/utils/widgets.py
@@ -351,11 +351,7 @@ class FileWidget(QWidget):
                 self.recent_files.remove(file)
 
     def open_file(self, path):
-        try:
-            self.on_open.emit(path if path != self.empty_file_label else '')
-        except (OSError, IOError):
-            self.loading_error_signal.emit('Could not open "{}".'
-                                           .format(path))
+        self.on_open.emit(path if path != self.empty_file_label else '')
 
     def get_selected_filename(self):
         if self.recent_files:


### PR DESCRIPTION
##### Issue
PreprocessText has issue reading stopwords files with incorrectly-detected encodings, such as [stopwords-sl2.txt](https://github.com/biolab/orange3-text/files/1511028/stopwords-sl2.txt).

##### Description of changes
Try UTF-8, system encoding, and detected encoding in succession. If all fails, warn politely.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
