### PR TITLE
[FIX] Corpus: X and Y arrays must always be float!

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -371,9 +371,9 @@ class Corpus(Table):
 
         if documents:
             X = np.array([[to_val(attr, func(doc)) for attr, func in attributes]
-                          for doc in documents])
+                          for doc in documents], dtype=np.float64)
             Y = np.array([[to_val(attr, func(doc)) for attr, func in class_vars]
-                          for doc in documents])
+                          for doc in documents], dtype=np.float64)
             metas = np.array([[to_val(attr, func(doc)) for attr, func in metas]
                               for doc in documents], dtype=object)
         else:   # assure shapes match the number of columns


### PR DESCRIPTION
##### Issue
Sometimes a `corpus` is created which has integer types numpy arrays.

See here:

##### Description of changes
Make sure that a new created array is type `float64`.
![screenshot_20171213_121642](https://user-images.githubusercontent.com/22157215/33936336-8177dc70-dfff-11e7-9881-a579c5715e51.png)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
