### PR TITLE
owpreprocess: Add choice in FilteringModule for All Files (*)

### DIFF
--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -312,7 +312,7 @@ class FilteringModule(MultipleMethodModule):
     REGEXP = 2
     FREQUENCY = 3
     KEEP_N = 4
-    dlgFormats = 'Only text files (*.txt)'
+    dlgFormats = 'Only text files (*.txt);;All files (*)'
 
     stopwords_language = settings.Setting('English')
 


### PR DESCRIPTION
##### Issue
The FileWidget used in the FilteringModule class of owpreprocess allows opening files with a .txt extension only. The stopwords files included with the nltk_data do not have this extension. So these files nor any other files lacking a .txt extension can be selected as files for Stopwords or Lexicons.

Fixes https://github.com/biolab/orange3-text/issues/333.

##### Description of changes
This change adds a selector for "All files" in addition to "Only text files" in the FileWidget creation for the FilteringModule class. 

![all_files_choice](https://user-images.githubusercontent.com/7545948/35477083-f41c9d26-0389-11e8-9faa-df80bef83bb6.jpg)


The documentation describes creating files from scratch with a .txt extension, which is still appropriate, so no documentation changes are needed. No tests cover the FileWidget dialogs used by the FilteringModule. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
