### PR TITLE
[FIX] bagofwords: Use vectorized 'BINARY' local weighting

### DIFF
--- a/orangecontrib/text/vectorization/bagofwords.py
+++ b/orangecontrib/text/vectorization/bagofwords.py
@@ -46,7 +46,7 @@ class BowVectorizer(BaseVectorizer):
 
     wlocals = OrderedDict((
         (COUNT, lambda tf: tf),
-        (BINARY, lambda tf: int(tf > 0)),
+        (BINARY, lambda tf: np.greater(tf, 0, dtype=np.int)),
         (SUBLINEAR, lambda tf: 1 + np.log(tf)),
     ))
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Using gensim==3.4.0
```
======================================================================
ERROR: test_binary (orangecontrib.text.tests.test_bowvectorizer.BowVectorizationTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/biolab/orange3-text/orangecontrib/text/tests/test_bowvectorizer.py", line 22, in test_binary
    result = vect.transform(corpus)
  File "/home/travis/build/biolab/orange3-text/orangecontrib/text/vectorization/base.py", line 17, in transform
    return self._transform(corpus, source_dict)
  File "/home/travis/build/biolab/orange3-text/orangecontrib/text/vectorization/bagofwords.py", line 78, in _transform
    X = matutils.corpus2csc(model[temp_corpus], dtype=np.float, num_terms=len(dic)).T
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/gensim/matutils.py", line 151, in corpus2csc
    for docno, doc in enumerate(corpus):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/gensim/interfaces.py", line 193, in __iter__
    yield self.obj[doc]
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/gensim/models/tfidfmodel.py", line 376, in __getitem__
    tf_array = self.wlocal(np.array(tf_array))
  File "/home/travis/build/biolab/orange3-text/orangecontrib/text/vectorization/bagofwords.py", line 49, in <lambda>
    (BINARY, lambda tf: int(tf > 0)),
TypeError: only size-1 arrays can be converted to Python scalars
----------------------------------------------------------------------
```

##### Description of changes

Use vectorized 'BINARY' local weighting

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
