### PR TITLE
[FIX] OWPreprocess: no stopword files on win

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -61,20 +61,24 @@ class WordListMixin:
         # No encoding worked, raise
         raise UnicodeError("Couldn't determine file encoding")
 
-# get NLTK list of stopwords
-stopwords_listdir = []
-try:
-    stopwords_listdir = [file for file in os.listdir(stopwords._get_root())
-                         if file.islower()]
-except LookupError:     # when no NLTK data is available
-    pass
-
 
 class StopwordsFilter(BaseTokenFilter, WordListMixin):
     """ Remove tokens present in NLTK's language specific lists or a file. """
     name = 'Stopwords'
 
-    supported_languages = [file.capitalize() for file in stopwords_listdir]
+    @staticmethod
+    @wait_nltk_data
+    def supported_languages():
+        # get NLTK list of stopwords
+        stopwords_listdir = []
+        try:
+            stopwords_listdir = [file for file in
+                                 os.listdir(stopwords._get_root())
+                                 if file.islower()]
+        except LookupError:  # when no NLTK data is available
+            pass
+
+        return [file.capitalize() for file in stopwords_listdir]
 
     @wait_nltk_data
     def __init__(self, language='English', word_list=None):

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -331,7 +331,7 @@ class FilteringModule(MultipleMethodModule):
         super().__init__(master)
 
         box = widgets.ComboBox(self, 'stopwords_language',
-                               items=[None] + preprocess.StopwordsFilter.supported_languages)
+                               items=[None] + preprocess.StopwordsFilter.supported_languages())
         box.currentIndexChanged.connect(self.stopwords_changed)
         self.stopwords_changed()
         self.method_layout.addWidget(box, self.STOPWORDS, 1)


### PR DESCRIPTION
##### Issue
Fixes #351 
##### Description of changes
Get existing stopword files when widget is loading and not before they are downloaded. 
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
