### PR TITLE
Improve report functionality

### DIFF
--- a/orangecontrib/text/preprocess/preprocess.py
+++ b/orangecontrib/text/preprocess/preprocess.py
@@ -132,13 +132,17 @@ class Preprocessor:
 
     def report(self):
         return (
-            ('Transformers', ', '.join(str(tr) for tr in self.transformers)),
-            ('Tokenizer', str(self.tokenizer)),
-            ('Normalizer', str(self.normalizer)),
-            ('Filters', ', '.join(str(f) for f in self.filters)),
-            ('Ngrams range', str(self.ngrams_range)),
-            ('Frequency filter', str(self.freq_filter)),
-            ('Pos tagger', str(self.pos_tagger)),
+            ('Transformers', ', '.join(str(tr) for tr in self.transformers)
+            if self.transformers else None),
+            ('Tokenizer', str(self.tokenizer) if self.tokenizer else None),
+            ('Normalizer', str(self.normalizer) if self.normalizer else None),
+            ('Filters', ', '.join(str(f) for f in self.filters) if
+            self.filters else None),
+            ('Ngrams range', str(self.ngrams_range) if self.ngrams_range else
+            None),
+            ('Frequency filter', str(self.freq_filter) if self.freq_filter
+            else None),
+            ('Pos tagger', str(self.pos_tagger) if self.pos_tagger else None),
         )
 
 

--- a/orangecontrib/text/widgets/owcorpus.py
+++ b/orangecontrib/text/widgets/owcorpus.py
@@ -8,7 +8,7 @@ from Orange.widgets.data.owselectcolumns import VariablesListItemView
 from Orange.widgets.settings import Setting, ContextSetting, PerfectDomainContextHandler
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from orangecontrib.text.corpus import Corpus, get_sample_corpora_dir
-from orangecontrib.text.widgets.utils import widgets
+from orangecontrib.text.widgets.utils import widgets, QSize
 
 
 class OWCorpus(OWWidget):
@@ -101,10 +101,12 @@ class OWCorpus(OWWidget):
                 get_sample_corpora_dir()),
             autoDefault=False,
         )
-        box.layout().addWidget(self.report_button)
 
         # load first file
         self.file_widget.select(0)
+
+    def sizeHint(self):
+        return QSize(400, 300)
 
     @Inputs.data
     def set_data(self, data):

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -406,15 +406,22 @@ class OWCorpusViewer(OWWidget):
             self.Outputs.matching_docs.send(None)
             self.Outputs.other_docs.send(None)
 
+    def send_report(self):
+        self.report_items((
+            ("Query", self.regexp_filter),
+            ("Matching documents", self.n_matching),
+        ))
+
 
 if __name__ == '__main__':
-    from orangecontrib.text.tag import pos_tagger
+    from orangecontrib.text.tag.pos import AveragedPerceptronTagger
     app = QApplication([])
     widget = OWCorpusViewer()
     widget.show()
     corpus = Corpus.from_file('book-excerpts')
     corpus = corpus[:3]
-    corpus = pos_tagger.tag_corpus(corpus)
-    corpus.ngram_range = (1, 2)
-    widget.set_data(corpus)
+    tagger = AveragedPerceptronTagger()
+    tagged_corpus = tagger.tag_corpus(corpus)
+    tagged_corpus.ngram_range = (1, 2)
+    widget.set_data(tagged_corpus)
     app.exec()

--- a/orangecontrib/text/widgets/owguardian.py
+++ b/orangecontrib/text/widgets/owguardian.py
@@ -125,7 +125,6 @@ class OWGuardian(OWWidget):
 
         # Buttons
         self.button_box = gui.hBox(self.controlArea)
-        self.button_box.layout().addWidget(self.report_button)
 
         self.search_button = gui.button(self.button_box, self, 'Search',
                                         self.start_stop,

--- a/orangecontrib/text/widgets/owimportdocuments.py
+++ b/orangecontrib/text/widgets/owimportdocuments.py
@@ -604,6 +604,17 @@ class OWImportDocuments(widget.OWWidget):
 
         return super().eventFilter(receiver, event)
 
+    def send_report(self):
+        if not self.currentPath:
+            return
+        items = [('Path', self.currentPath),
+                 ('Number of documents', self.n_text_data)]
+        if self.n_text_categories:
+            items += [('Categories', self.n_text_categories)]
+        if self.n_skipped:
+            items += [('Number of skipped', self.n_skipped)]
+        self.report_items(items, )
+
 
 class UserInterruptError(BaseException):
     """

--- a/orangecontrib/text/widgets/ownyt.py
+++ b/orangecontrib/text/widgets/ownyt.py
@@ -126,7 +126,6 @@ class OWNYT(OWWidget):
 
         # Buttons
         self.button_box = gui.hBox(self.controlArea)
-        self.button_box.layout().addWidget(self.report_button)
 
         self.search_button = gui.button(self.button_box, self, 'Search', self.start_stop,
                                         focusPolicy=Qt.NoFocus)

--- a/orangecontrib/text/widgets/owpubmed.py
+++ b/orangecontrib/text/widgets/owpubmed.py
@@ -440,6 +440,34 @@ class OWPubmed(OWWidget):
         if cal_dlg.exec_():
             widget.setText(cal_dlg.picked_date)
 
+    def send_report(self):
+        if not self.pubmed_api:
+            return
+        max_records_count = min(
+            self.pubmed_api.MAX_RECORDS,
+            self.pubmed_api.search_record_count
+        )
+        if self.search_tabs.currentIndex() == 0:
+            terms = self.keyword_combo.currentText()
+            authors = self.author_input.text()
+            self.report_items((
+                ('Query', terms if terms else None),
+                ('Authors', authors if authors else None),
+                ('Date', 'from {} to {}'.format(self.pub_date_from,
+                                          self.pub_date_to)),
+                ('Number of records retrieved', '{}/{}'.format(len(
+                    self.output_corpus) if self.output_corpus else 0,
+                                                               max_records_count))
+            ))
+        else:
+            query = self.advanced_query_input.toPlainText()
+            self.report_items((
+                ('Query', query if query else None),
+                ('Number of records retrieved', '{}/{}'.format(len(
+                    self.output_corpus) if self.output_corpus else 0,
+                                                               max_records_count))
+            ))
+
 
 class CalendarDialog(QDialog):
 

--- a/orangecontrib/text/widgets/owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/owsentimentanalysis.py
@@ -38,7 +38,6 @@ class OWSentimentAnalysis(OWWidget):
 
         ac = gui.auto_commit(self.controlArea, self, 'autocommit', 'Commit',
                              'Autocommit is on')
-        ac.layout().insertWidget(0, self.report_button)
         ac.layout().insertSpacing(1, 8)
 
     @Inputs.corpus
@@ -66,7 +65,7 @@ class OWSentimentAnalysis(OWWidget):
 def main():
     app = QApplication([])
     widget = OWSentimentAnalysis()
-    corpus = Corpus.from_file('bookexcerpts')
+    corpus = Corpus.from_file('book-excerpts')
     corpus = corpus[:3]
     widget.set_corpus(corpus)
     widget.show()

--- a/orangecontrib/text/widgets/owtweetprofiler.py
+++ b/orangecontrib/text/widgets/owtweetprofiler.py
@@ -46,7 +46,6 @@ class OWTweetProfiler(OWWidget):
 
         # Auto commit
         buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(self.report_button)
         buttons_layout.addSpacing(15)
         buttons_layout.addWidget(
             gui.auto_commit(None, self, 'auto_commit', 'Commit', box=False)

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -181,7 +181,6 @@ class OWTwitter(OWWidget):
 
         # Buttons
         self.button_box = gui.hBox(self.controlArea)
-        self.button_box.layout().addWidget(self.report_button)
 
         self.search_button = gui.button(self.button_box, self, 'Search',
                                         self.start_stop,

--- a/orangecontrib/text/widgets/owwikipedia.py
+++ b/orangecontrib/text/widgets/owwikipedia.py
@@ -6,7 +6,8 @@ from Orange.widgets import settings
 from Orange.widgets.widget import OWWidget, Msg, Output
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.language_codes import lang2code, code2lang
-from orangecontrib.text.widgets.utils import ComboBox, ListEdit, CheckListLayout, asynchronous
+from orangecontrib.text.widgets.utils import ComboBox, ListEdit, CheckListLayout, asynchronous, \
+    QSize
 from orangecontrib.text.wikipedia import WikipediaAPI
 
 
@@ -53,7 +54,8 @@ class OWWikipedia(OWWidget):
         layout.setSpacing(7)
 
         row = 0
-        query_edit = ListEdit(self, 'query_list', "Each line represents a separate query.", None, self)
+        query_edit = ListEdit(self, 'query_list', "Each line represents a "
+                                                  "separate query.", 100, self)
         layout.addWidget(QLabel('Query word list:'), row, 0, 1, self.label_width)
         layout.addWidget(query_edit, row, self.label_width, 1, self.widgets_width)
 
@@ -81,7 +83,6 @@ class OWWikipedia(OWWidget):
         self.result_label = gui.label(self.info_box, self, self.info_label.format(0))
 
         self.button_box = gui.hBox(self.controlArea)
-        self.button_box.layout().addWidget(self.report_button)
 
         self.search_button = gui.button(self.button_box, self, 'Search', self.start_stop)
         self.search_button.setFocusPolicy(Qt.NoFocus)

--- a/orangecontrib/text/widgets/owwikipedia.py
+++ b/orangecontrib/text/widgets/owwikipedia.py
@@ -6,8 +6,8 @@ from Orange.widgets import settings
 from Orange.widgets.widget import OWWidget, Msg, Output
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.language_codes import lang2code, code2lang
-from orangecontrib.text.widgets.utils import ComboBox, ListEdit, CheckListLayout, asynchronous, \
-    QSize
+from orangecontrib.text.widgets.utils import ComboBox, ListEdit, CheckListLayout, asynchronous
+
 from orangecontrib.text.wikipedia import WikipediaAPI
 
 
@@ -54,10 +54,11 @@ class OWWikipedia(OWWidget):
         layout.setSpacing(7)
 
         row = 0
-        query_edit = ListEdit(self, 'query_list', "Each line represents a "
+        self.query_edit = ListEdit(self, 'query_list', "Each line represents a "
                                                   "separate query.", 100, self)
         layout.addWidget(QLabel('Query word list:'), row, 0, 1, self.label_width)
-        layout.addWidget(query_edit, row, self.label_width, 1, self.widgets_width)
+        layout.addWidget(self.query_edit, row, self.label_width, 1,
+                         self.widgets_width)
 
         # Language
         row += 1
@@ -134,7 +135,7 @@ class OWWikipedia(OWWidget):
     def send_report(self):
         if self.result:
             items = (('Language', code2lang[self.language]),
-                     ('Query', self.query_list),
+                     ('Query', self.query_edit.toPlainText()),
                      ('Articles count', len(self.result)))
             self.report_items('Query', items)
 

--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -296,6 +296,9 @@ span.selected {color:red !important}
             topic.name = 'Selected Words'
         self.Outputs.selected_words.send(topic)
 
+    def send_report(self):
+        self.report_table(self.tableview)
+
 
 def main():
     from Orange.data import Table, Domain, ContinuousVariable, StringVariable

--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -1,5 +1,6 @@
 import numpy as np
-from AnyQt.QtWidgets import QTreeWidget, QTreeView, QTreeWidgetItem
+from AnyQt.QtWidgets import QTreeWidget, QTreeView, QTreeWidgetItem, \
+    QApplication
 
 from Orange.data import Table, Domain
 from Orange.widgets import gui
@@ -199,6 +200,13 @@ class OWWordEnrichment(OWWidget):
         self.filter_enabled(True)
         self.progressBarFinished()
 
+    def send_report(self):
+        if self.words:
+            self.report_table(
+                "Enriched words".
+                    format(self.words,
+                           self.p_values),
+                self.tableview)
 
 fp = lambda score: "%0.5f" % score if score > 10e-3 else "%0.1e" % score
 fpt = lambda score: "%0.9f" % score if score > 10e-3 else "%0.5e" % score
@@ -217,3 +225,17 @@ class EATreeWidgetItem(QTreeWidgetItem):
     def __lt__(self, other):
         col = self.treeWidget().sortColumn()
         return self.data[col] < other.data[col]
+
+def main():
+    app = QApplication([])
+    widget = OWWordEnrichment()
+    corpus = Corpus.from_file('book-excerpts')
+    widget.set_data(corpus)
+    subset_corpus = corpus[:10]
+    #do bag of words
+    widget.set_data_selected(subset_corpus)
+    widget.show()
+    app.exec()
+
+if __name__ == '__main__':
+    main()

--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -6,9 +6,11 @@ from Orange.data import Table, Domain
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.widget import OWWidget, Msg, Input
+from PyQt5.QtCore import QSize
 from orangecontrib.text import Corpus
 from orangecontrib.text.util import np_sp_sum
 from orangecontrib.text.stats import false_discovery_rate, hypergeom_p_values
+from orangecontrib.text.vectorization import BowVectorizer
 
 
 class OWWordEnrichment(OWWidget):
@@ -92,6 +94,9 @@ class OWWordEnrichment(OWWidget):
         for i in range(len(self.cols)):
             self.sig_words.resizeColumnToContents(i)
         self.mainArea.layout().addWidget(self.sig_words)
+
+    def sizeHint(self):
+        return QSize(450, 240)
 
     @Inputs.data
     def set_data(self, data=None):
@@ -200,13 +205,19 @@ class OWWordEnrichment(OWWidget):
         self.filter_enabled(True)
         self.progressBarFinished()
 
+    def tree_to_table(self):
+        view = [self.cols]
+        items = self.sig_words.topLevelItemCount()
+        for i in range(items):
+            line = []
+            for j in range(3):
+                line.append(self.sig_words.topLevelItem(i).text(j))
+            view.append(line)
+        return(view)
+
     def send_report(self):
         if self.words:
-            self.report_table(
-                "Enriched words".
-                    format(self.words,
-                           self.p_values),
-                self.tableview)
+            self.report_table("Enriched words", self.tree_to_table())
 
 fp = lambda score: "%0.5f" % score if score > 10e-3 else "%0.1e" % score
 fpt = lambda score: "%0.9f" % score if score > 10e-3 else "%0.5e" % score
@@ -227,13 +238,16 @@ class EATreeWidgetItem(QTreeWidgetItem):
         return self.data[col] < other.data[col]
 
 def main():
+
+    corpus = Corpus.from_file('book-excerpts')
+    vect = BowVectorizer()
+    corpus_vect = vect.transform(corpus)
     app = QApplication([])
     widget = OWWordEnrichment()
-    corpus = Corpus.from_file('book-excerpts')
-    widget.set_data(corpus)
-    subset_corpus = corpus[:10]
-    #do bag of words
+    widget.set_data(corpus_vect)
+    subset_corpus = corpus_vect[:10]
     widget.set_data_selected(subset_corpus)
+    widget.handleNewSignals()
     widget.show()
     app.exec()
 

--- a/orangecontrib/text/widgets/utils/owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/owbasevectorizer.py
@@ -37,7 +37,6 @@ class OWBaseVectorizer(OWWidget):
         self.controlArea.layout().addWidget(box)
 
         buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(self.report_button)
         buttons_layout.addSpacing(15)
         buttons_layout.addWidget(
             gui.auto_commit(None, self, 'autocommit', 'Commit', box=False)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #350.

##### Description of changes
Remove redundant report buttons as we now have footer report.
Add report functions where they don't yet exist.
Add __main__ calls for testing widgets.

##### Remaining problems
Don't know how to add word cloud to report. report_plot doesn't work as there is no <svg> tag in the constructed html. report_raw works, but places the word cloud over existing text and remains selectable.
Don't know how to make the header of Word Enrichment bold. 🤦‍♂️ 
Don't know how to shorten QTableView in Concordance to show only, say, top 50 results. I read about QSortFilterProxyModel, but I don't know how to set the number of rows.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
