### PR TITLE
[FIX] guardian: fix failing tests

### DIFF
--- a/orangecontrib/text/guardian.py
+++ b/orangecontrib/text/guardian.py
@@ -18,6 +18,7 @@ Then create :class:`TheGuardianAPI` object and use it for searching:
 import requests
 import math
 import json
+import os
 
 from Orange import data
 
@@ -155,7 +156,8 @@ class TheGuardianAPI:
 
 
 if __name__ == '__main__':
-    credentials = TheGuardianCredentials('')
+    key = os.getenv('THE_GUARDIAN_API_KEY', 'test')
+    credentials = TheGuardianCredentials(key)
     print(credentials.valid)
     api = TheGuardianAPI(credentials=credentials)
     c = api.search('refugees', max_documents=10)

--- a/orangecontrib/text/tests/test_guardian.py
+++ b/orangecontrib/text/tests/test_guardian.py
@@ -1,11 +1,12 @@
 import unittest
+import os
 
 from datetime import date, datetime
 
 from orangecontrib.text import guardian
 
 
-API_KEY = 'test'
+API_KEY = os.getenv('THE_GUARDIAN_API_KEY', 'test')
 
 
 class TestCredentials(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Fixes #354 
##### Description of changes
The `test` key has a limit we exceeded so the tests failed. This is resolved by requesting a developer  API key. Because it's a secret we add it to Travis as an environment variable (THE_GUARDIAN_API_KEY).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
