### PR TITLE
OWWordCloud: Add the word cloud image to the report.

### DIFF
--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -297,6 +297,16 @@ span.selected {color:red !important}
         self.Outputs.selected_words.send(topic)
 
     def send_report(self):
+        html = self.webview.html()
+        start = html.index('>', html.index('<body')) + 1
+        end = html.index('</body>')
+        body = html[start:end]
+        # create an empty div of appropriate height to compensate for
+        # absolute positioning of words in the html
+        height = self.webview._evalJS("document.getElementById('canvas').clientHeight")
+        self.report_html += '<div style="position: relative; height: {}px;">{}</div>'.format(
+            height, body)
+
         self.report_table(self.tableview)
 
 


### PR DESCRIPTION
##### Issue
WordCloud's report contains only the frequency list of words and not the nice word cloud picture.

Adding the picture with `report_plot(self.webview)` results in an image at the top of the report that overlaps other content.

##### Description of changes
Augment the html with a div of appropriate height to compensate for the absolute positioning of span objects of individual words in the webview's html.

Depends on https://github.com/biolab/orange3/pull/3148.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
