### PR TITLE
Documentation can appear in canvas

### DIFF
--- a/orangecontrib/text/widgets/__init__.py
+++ b/orangecontrib/text/widgets/__init__.py
@@ -21,5 +21,5 @@ WIDGET_HELP_PATH = (
     # Url should point to a page with a section Widgets. This section should
     # includes links to documentation pages of each widget. Matching is
     # performed by comparing link caption to widget name.
-    ("http://orange3-text.readthedocs.io/en/latest/", "")
+    ("https://orange3-text.readthedocs.io/en/latest/", "")
 )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Directs docs to https so that they always appear in canvas.

##### Description of changes
See https://github.com/biolab/orange3/issues/3247 and https://github.com/Quasars/orange-spectroscopy/pull/216.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
