### PR TITLE
Output corresponding duplicate cluster

### DIFF
--- a/orangecontrib/text/widgets/owduplicates.py
+++ b/orangecontrib/text/widgets/owduplicates.py
@@ -228,12 +228,15 @@ class OWDuplicates(widget.OWWidget):
             self.Outputs.corpus_without_duplicates.send(None)
 
     def send_duplicates(self):
-        index = self.table_view.selectionModel().currentIndex().row()
-        cluster = self.table_model[index][0]
-        mask = np.flatnonzero(self.clustering_mask == cluster.id)
-        c = self.corpus[mask]
-        c.name = '{} {}'.format(self.Outputs.duplicates.name, cluster)
+        c = None
+        indices = self.table_view.selectionModel().selectedIndexes()
+        if indices:
+            cluster = self.table_view.model().data(indices[0], Qt.EditRole)
+            mask = np.flatnonzero(self.clustering_mask == cluster.id)
+            c = self.corpus[mask]
+            c.name = '{} {}'.format(self.Outputs.duplicates.name, cluster)
         self.Outputs.duplicates.send(c)
+
 
     def send_report(self):
         self.report_items([

--- a/orangecontrib/text/widgets/tests/test_owduplicates.py
+++ b/orangecontrib/text/widgets/tests/test_owduplicates.py
@@ -22,6 +22,15 @@ class TestCorpusViewerWidget(WidgetTest):
         out_corpus = self.get_output(self.widget.Outputs.duplicates)
         self.assertEqual(len(out_corpus), 1)
 
+    def test_deselecting(self):
+        self.send_signal(self.widget.Inputs.distances, self.distances)
+        self.widget.table_view.selectRow(0)
+        out_corpus = self.get_output(self.widget.Outputs.duplicates)
+        self.assertTrue(out_corpus)
+        self.widget.table_view.clearSelection()
+        out_corpus = self.get_output(self.widget.Outputs.duplicates)
+        self.assertIsNone(out_corpus)
 
 if __name__ == "__main__":
     unittest.main()
+    

--- a/orangecontrib/text/widgets/tests/test_owduplicates.py
+++ b/orangecontrib/text/widgets/tests/test_owduplicates.py
@@ -1,0 +1,27 @@
+import unittest
+
+from Orange.data import Table
+from Orange.distance import Euclidean
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.text.widgets.owduplicates import OWDuplicates
+
+
+class TestCorpusViewerWidget(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWDuplicates)
+        self.data = Table.from_file('iris')
+        self.distances = Euclidean(self.data)
+
+    def test_duplicates(self):
+        self.send_signal(self.widget.Inputs.distances, self.distances)
+        self.widget.table_view.selectRow(0)
+        out_corpus = self.get_output(self.widget.Outputs.duplicates)
+        self.assertEqual(len(out_corpus), 2)
+        self.widget.table_view.selectRow(3)
+        out_corpus = self.get_output(self.widget.Outputs.duplicates)
+        self.assertEqual(len(out_corpus), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
Fixes #378. 

##### Description of changes
Detect Duplicates now outputs correct documents with Duplicate Cluster output.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
