### PR TITLE
[ENH] nltk: disable download prints

### DIFF
--- a/orangecontrib/text/misc/nltk_data_download.py
+++ b/orangecontrib/text/misc/nltk_data_download.py
@@ -33,7 +33,7 @@ is_done_loading = False
 
 def _download_nltk_data():
     global is_done_loading
-    nltk.download(NLTK_DATA, download_dir=nltk_data_dir())
+    nltk.download(NLTK_DATA, download_dir=nltk_data_dir(), quiet=True)
     is_done_loading = True
     sys.stdout.flush()
 


### PR DESCRIPTION
##### Issue
The nltk package prints download status which can be annoying. 
##### Description of changes
Silence the prints. 
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
