### PR TITLE
[Fix] topics: HdpModel showing no topics

### DIFF
--- a/orangecontrib/text/tests/test_topic_modeling.py
+++ b/orangecontrib/text/tests/test_topic_modeling.py
@@ -23,6 +23,11 @@ class BaseTests:
         # self.assertAlmostEqual(topic1.W.sum(), 1.)
         self.assertFalse(any(topic1.W == np.nan))
 
+    def test_get_all_topics(self):
+        self.model.fit(self.corpus)
+        topics = self.model.get_all_topics_table()
+        self.assertEqual(len(topics.domain), self.model.num_topics)
+
     def test_top_words_by_topic(self):
         self.model.fit(self.corpus)
         words, _ = self.model.get_top_words_by_id(1, num_of_words=10)

--- a/orangecontrib/text/topics/topics.py
+++ b/orangecontrib/text/topics/topics.py
@@ -139,14 +139,15 @@ class GensimWrapper:
 
     def _topics_words(self, num_of_words):
         """ Returns list of list of topic words. """
-        x = self.model.show_topics(-1, num_of_words, formatted=False)
+        x = self.model.show_topics(self.num_topics, num_of_words, formatted=False)
         # `show_topics` method return a list of `(topic_number, topic)` tuples,
         # where `topic` is a list of `(word, probability)` tuples.
         return [[i[0] for i in topic[1]] for topic in x]
 
     def _topics_weights(self, num_of_words):
         """ Returns list of list of topic weights. """
-        topics = self.model.show_topics(-1, num_of_words, formatted=False)
+        topics = self.model.show_topics(self.num_topics, num_of_words,
+                                        formatted=False)
         # `show_topics` method return a list of `(topic_number, topic)` tuples,
         # where `topic` is a list of `(word, probability)` tuples.
         return [[i[1] for i in t[1]] for t in topics]


### PR DESCRIPTION
##### Issue
Fixes #411
gensim>=3.7.0 changed HdpModel.show_topics() behavior when using num_topics=-1 ([issue](https://github.com/RaRe-Technologies/gensim/issues/2389))
##### Description of changes
Replace -1 with number of topics.
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
