### PR TITLE
OWCommonTerms: distance matrix based on common terms in docs

### DIFF
--- a/orangecontrib/text/common_terms.py
+++ b/orangecontrib/text/common_terms.py
@@ -1,0 +1,22 @@
+import numpy as np
+import scipy.sparse as sp
+
+from Orange.misc import DistMatrix
+
+
+def common_terms(data, rows=None, cols=None):
+    """Accepts np.array and returns a distance matrix where values are
+    counts of non-zero column values."""
+    matrix = np.zeros((data.shape[0], data.shape[0]))
+
+    for i in range(len(matrix) - 1):
+        for j in range(i+1,len(matrix)):
+            if sp.issparse(data):
+                w = len(set(data[i].indices).intersection(data[j].indices))
+            else:
+                w = sum((data[i] > 0) & (data[j] > 0))
+            matrix[i, j] = w
+            matrix[j, i] = w
+
+    return DistMatrix(matrix, row_items=rows, col_items=cols)
+

--- a/orangecontrib/text/widgets/owcommonterms.py
+++ b/orangecontrib/text/widgets/owcommonterms.py
@@ -1,0 +1,60 @@
+from Orange.misc import DistMatrix
+from Orange.widgets import gui
+from Orange.widgets.utils.signals import Input, Output
+from Orange.widgets.widget import OWWidget, Msg
+from PyQt5.QtWidgets import QApplication
+from orangecontrib.text import Corpus
+from orangecontrib.text.common_terms import common_terms
+
+
+class OWCommonTerms(OWWidget):
+    name = "Common Terms"
+    priority = 1000
+    icon = "icons/File.svg"
+
+    class Inputs:
+        data = Input("Corpus", Corpus)
+
+    class Outputs:
+        distances = Output("Distances", DistMatrix)
+
+    want_main_area = False
+
+    class Error(OWWidget.Error):
+        no_bow_features = Msg('No bag-of-words features!')
+
+    def __init__(self):
+        super().__init__()
+        self.corpus = None
+
+        info_box = gui.widgetBox(self.controlArea, 'Info')
+        gui.label(info_box, self, 'None')
+
+    @Inputs.data
+    def set_data(self, data):
+        self.Error.clear()
+        if len(data.domain.attributes) == 0:
+            self.Error.no_bow_features()
+            self.clear()
+            return
+        if data and not isinstance(data, Corpus):
+            data = Corpus.from_table(data.domain, data)
+        self.corpus = data
+        self.commit()
+
+    def commit(self):
+        output = common_terms(self.corpus.X, rows=self.corpus)
+        self.Outputs.distances.send(output)
+
+
+if __name__ == "__main__":
+    from orangecontrib.text.vectorization import BowVectorizer
+
+    app = QApplication([])
+    widget = OWCommonTerms()
+    widget.show()
+    corpus = Corpus.from_file('deerwester')
+    vect = BowVectorizer()
+    result = vect.transform(corpus)
+    widget.set_data(result)
+    app.exec()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
It was not possible to create a network based on common terms from documents.

##### Description of changes
OWCommonTerms creates a distance matrix where values are counts of common terms between docs.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
