### PR TITLE
Suppress multithread communication errors 

### DIFF
--- a/orangecontrib/text/widgets/utils/concurrent.py
+++ b/orangecontrib/text/widgets/utils/concurrent.py
@@ -101,7 +101,11 @@ class CallbackFunction(QObject):
     @Slot(object)
     def call(self, scope):
         instance, args, kwargs = scope
-        self.func.__get__(instance, type(instance))(*args, **kwargs)
+        try:
+            self.func.__get__(instance, type(instance))(*args, **kwargs)
+        except RuntimeError:
+            # C++ object wrapped by `obj` may be already destroyed
+            raise
 
     def __get__(self, instance, owner):
         return CallbackMethod(self, instance)

--- a/orangecontrib/text/widgets/utils/concurrent.py
+++ b/orangecontrib/text/widgets/utils/concurrent.py
@@ -153,8 +153,7 @@ class BoundAsyncMethod(QObject):
             result = None
 
         if self.im_func.finish_callback and self.im_self:
-            QMetaObject.invokeMethod(self.im_self, self.im_func.finish_callback,
-                                     Qt.QueuedConnection, Q_ARG(object, result))
+            safe_invoke(self.im_self, self.im_func.finish_callback, Q_ARG(object, result))
         self.running = False
 
     def on_destroy(self):

--- a/orangecontrib/text/widgets/utils/concurrent.py
+++ b/orangecontrib/text/widgets/utils/concurrent.py
@@ -105,7 +105,7 @@ class CallbackFunction(QObject):
             self.func.__get__(instance, type(instance))(*args, **kwargs)
         except RuntimeError:
             # C++ object wrapped by `obj` may be already destroyed
-            raise
+            pass
 
     def __get__(self, instance, owner):
         return CallbackMethod(self, instance)


### PR DESCRIPTION
##### Issues

 #420 #421 

##### Description of changes
The problem occurs due to multithread communication using `QMetaObject.invokeMethod` with a destroyed object.  Wrapping up all invoke calls with try/except will suppress errors.

It seems like there is no _simple_ way to know that C++ `QObject` is about to be destroyed so I wasn't able to find other reliable solutions.



##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
