### PR TITLE
Limit Pubmed to 10,000 entries

### DIFF
--- a/orangecontrib/text/widgets/owpubmed.py
+++ b/orangecontrib/text/widgets/owpubmed.py
@@ -206,7 +206,7 @@ class OWPubmed(OWWidget):
         label = gui.label(h_box, self, 'Retrieve')
         label.setMaximumSize(label.sizeHint())
         self.num_records_input = gui.spin(h_box, self, 'num_records',
-                                          minv=1, maxv=100000)
+                                          minv=1, maxv=10000)
         self.max_records_label = gui.label(h_box, self, 'records from /.')
         self.max_records_label.setMaximumSize(self.max_records_label
                                               .sizeHint())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #345. Shelve module triggered an error when saving large matrices.

##### Description of changes
Set the upper bound for PubMed text retrieval to 10,000. Orange would work terribly slow with 100,000 entries anyway.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
