### PR TITLE
Travis changed dist to Xenial (Ubuntu 16.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,9 @@ install:
     - pip install sip pyqt5==5.11.*
     - python setup.py develop   # assure version.py is present; required for imports
 
-before_script:  # required for widget tests
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
-    - sleep 3 # give xvfb some time to start
-
 script:
-    - coverage run setup.py test
+    - XVFBARGS="-screen 0 1280x1024x24"
+    - catchsegv xvfb-run -a -s "$XVFBARGS" coverage run setup.py test
 
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ matrix:
               - source $TRAVIS_BUILD_DIR/.travis/create_conda_env.sh
               - python setup.py develop
           script: source $TRAVIS_BUILD_DIR/.travis/build_doc.sh
-        - &pyqt5
+        - &python36
           python: '3.6'
-          env: PYQT5=true
+        - &python37
+          python: '3.7'
 
 cache:
     apt: true   # does not work for public repos

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-sudo: false   # use container-based infrastructure
+dist: xenial
 
 matrix:
     include:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Traivs test fails due to too many static dependencies

##### Description of changes

- Changed dist to Ubuntu Xenial (longer cache for dependencies).
- Added tests for Python 3.7.
- Removed PyQt5 from env since all builds use PyQt5.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
