### PR TITLE
[FIX] Fix failing tests

### DIFF
--- a/orangecontrib/text/tests/test_wikipedia.py
+++ b/orangecontrib/text/tests/test_wikipedia.py
@@ -29,11 +29,11 @@ class WikipediaTests(unittest.TestCase):
 
         result = api.search('en', ['Clinton'], articles_per_query=2, on_progress=on_progress)
         self.assertIsInstance(result, Corpus)
-        self.assertEquals(len(result.domain.attributes), 0)
-        self.assertEquals(len(result.domain.metas), 7)
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result.domain.attributes), 0)
+        self.assertEqual(len(result.domain.metas), 7)
+        self.assertEqual(len(result), 2)
 
-        self.assertEquals(on_progress.call_count, 2)
+        self.assertEqual(on_progress.call_count, 2)
         progress = 0
         for arg in on_progress.call_args_list:
             self.assertGreater(arg[0][0], progress)

--- a/orangecontrib/text/widgets/owduplicates.py
+++ b/orangecontrib/text/widgets/owduplicates.py
@@ -73,7 +73,7 @@ class OWDuplicates(widget.OWWidget):
         # Add to main area
         height = 300
         main_area = gui.hBox(self.mainArea)
-        self.histogram.setMinimumWidth(500)
+        self.histogram.setMinimumWidth(300)
         self.histogram.setMinimumHeight(height)
         self.table_view.setFixedWidth(140)
         main_area.layout().addWidget(self.histogram)

--- a/orangecontrib/text/widgets/tests/test_owduplicates.py
+++ b/orangecontrib/text/widgets/tests/test_owduplicates.py
@@ -7,7 +7,7 @@ from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.text.widgets.owduplicates import OWDuplicates
 
 
-class TestCorpusViewerWidget(WidgetTest):
+class TestDuplicatesWidget(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWDuplicates)
         self.data = Table.from_file('iris')
@@ -33,4 +33,3 @@ class TestCorpusViewerWidget(WidgetTest):
 
 if __name__ == "__main__":
     unittest.main()
-    


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests fail.

##### Description of changes
Two small fixes that make the test pass.
1. Replace assertEquals with assertEqual. This did not break the tests, but it did issue a warning.
2. Set smaller minimum width in Duplicates. Tests failed before because of the new version of Orange which enforced minimum widget width.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
