### PR TITLE
Remove google compute engine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ nltk>=3.0.5     # TweetTokenizer introduces in 3.0.5
 scikit-learn
 numpy
 validate_email
-google-compute-engine  # fixing boto issue in gensim; TODO: remove after while and check if tests passes
+# fixing boto issue in gensim; TODO: remove after while and check if tests passes
+google-compute-engine ; platform_system!="Windows"
 gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git
 Orange3>=3.4.3


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Google compute engine was added as a requirement because Travis test was failing because of issues with boto. The issue is still present but since google-compute-engine is not available on Windows it must be installed only on Linux and Mac OS.

##### Description of changes
Google compute engine is limited to Linux and Mac OS.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
