### PR TITLE
Test remove google-compute-engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
           python: '3.6'
           env: ORANGE="master"
 
+env:
+    global:
+        - BOTO_CONFIG=/dev/null  # it solves boto travis issue https://github.com/boto/boto/issues/3717
+
 cache:
     apt: true   # does not work for public repos
     directories:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,6 @@ nltk>=3.0.5     # TweetTokenizer introduces in 3.0.5
 scikit-learn
 numpy
 validate_email
-# fixing boto issue in gensim; TODO: remove after while and check if tests passes
-google-compute-engine ; platform_system!="Windows"
 gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git
 Orange3>=3.4.3


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`google-compute-engine` was added to the package to solve travis issues with `boto` library. 

##### Description of changes

With this PR I am trying to remove google-compute-engine since it is preventing us to make conda-forege package OS independent. https://github.com/conda-forge/orange3-text-feedstock/pull/26

##### Includes
- [ ] Code changes
- [x] Tests
- [ ] Documentation
