### PR TITLE
Pickling UDPipe #387

### DIFF
--- a/orangecontrib/text/preprocess/normalize.py
+++ b/orangecontrib/text/preprocess/normalize.py
@@ -188,3 +188,10 @@ class UDPipeLemmatizer(BaseNormalizer):
     def language(self, value):
         self._language = value
         self.model = None
+
+    def __getstate__(self):
+        return {'language': self.language}
+
+    def __setstate__(self, state):
+        self.__init__(state['language'])
+

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -1,3 +1,4 @@
+import pickle
 import tempfile
 import unittest
 import os.path
@@ -186,6 +187,15 @@ class TokenNormalizerTests(unittest.TestCase):
         normalizer.use_tokenizer = True
         self.assertListEqual(normalizer.normalize_doc('Gori na gori hiša gori'),
                              ['gora', 'na', 'gora', 'hiša', 'goreti'])
+
+    def test_udpipe_pickle(self):
+        normalizer = preprocess.UDPipeLemmatizer()
+        normalizer.language = 'English'
+
+        loaded = pickle.loads(pickle.dumps(normalizer))
+        self.assertEqual(normalizer.language, loaded.language)
+        self.assertEqual(loaded.normalize_doc('peter piper pickled'),
+                         ['peter', 'piper', 'pickle'])
 
     def test_porter_with_bad_input(self):
         stemmer = preprocess.PorterStemmer()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Even though this will fix the issue with pickling `UDPipeLemmatizer` the fact that `Corpus.used_preprocessor` is traveling around up to `Network from Distances` is quite suspicious. 


##### Description of changes
`updipe.Model` is not compatible with pickle protocol thus should be manually loaded.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
