### PR TITLE
Fix docutils issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 scipy
-nltk>=3.0.5     # TweetTokenizer introduces in 3.0.5
+nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
 scikit-learn
 numpy
-# fixing boto issue in gensim; TODO: remove after while and check if tests passes
+# gensim needs smart-open that needs boto3 that needs botocore that needs docutils < 0.15
+docutils==0.14.*
 gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git
 Orange3>=3.4.3


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`gensim` needs `smart-open` that needs `boto3` that needs `botocore` that needs `docutils < 0.15`

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
