### PR TITLE
[FIX] Fix stopwords filtering

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -78,7 +78,7 @@ class StopwordsFilter(BaseTokenFilter, WordListMixin):
         except LookupError:  # when no NLTK data is available
             pass
 
-        return [file.capitalize() for file in stopwords_listdir]
+        return sorted(file.capitalize() for file in stopwords_listdir)
 
     @wait_nltk_data
     def __init__(self, language='English', word_list=None):
@@ -96,7 +96,8 @@ class StopwordsFilter(BaseTokenFilter, WordListMixin):
         if not self._language:
             self.stopwords = []
         else:
-            self.stopwords = set(stopwords.words(self.language.lower()))
+            self.stopwords = set(
+                x.strip() for x in stopwords.words(self.language.lower()))
 
     def __str__(self):
         config = ''

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -276,10 +276,24 @@ class FilteringTests(unittest.TestCase):
         self.assertEqual(df([['a', '1']]), [['a']])
 
     def test_stopwords(self):
-        filter = preprocess.StopwordsFilter('english')
+        f = preprocess.StopwordsFilter('english')
 
-        self.assertFalse(filter.check('a'))
-        self.assertTrue(filter.check('filter'))
+        self.assertFalse(f.check('a'))
+        self.assertTrue(f.check('filter'))
+
+        self.assertListEqual(
+            ["snake", "house"],
+            f(["a", "snake", "is", "in", "a", "house"]))
+
+    def test_stopwords_slovene(self):
+        f = preprocess.StopwordsFilter('slovene')
+
+        self.assertFalse(f.check('in'))
+        self.assertTrue(f.check('abeceda'))
+
+        self.assertListEqual(
+            ["kača", "hiši"],
+            f(["kača", "je", "v", "hiši", "in"]))
 
     def test_lexicon(self):
         filter = preprocess.LexiconFilter(['filter'])


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #455 

##### Description of changes

- Stopwords are now correctly removed - I removed the whitespace on the end of each word in the dictionary
- Languages in stopwords dropdown are now sorted in alphabetical order

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
