### PR TITLE
[FIX] Remove extend function from corpus

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -112,22 +112,6 @@ class Corpus(Table):
             include_feats.append(first)
         self.set_text_features(include_feats)
 
-    def extend(self, instances):
-        if self.domain != instances.domain:
-            raise NotImplementedError(
-                'Extending corpora with different domains is not supported.')
-        super().extend(instances)
-        if self._tokens is None or instances._tokens is None:
-            self._tokens = None
-        else:
-            self._tokens = np.append(self._tokens, instances._tokens)
-        self._dictionary = corpora.Dictionary(self._tokens)
-        if self.pos_tags is None or instances.pos_tags is None:
-            self.pos_tags = None
-        else:
-            self.pos_tags = np.append(self.pos_tags, instances.pos_tags)
-        self._ngrams_corpus = None  # Todo: extend instead of reset
-
     def extend_corpus(self, metadata, Y):
         """
         Append documents to corpus.

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -62,31 +62,6 @@ class CorpusTests(unittest.TestCase):
         c2 = Corpus(c.domain, c.X, c.Y, c.metas, c.text_features)
         self.assertEqual(c, c2)
 
-    @unittest.skipIf(LooseVersion(Orange.__version__) < LooseVersion('3.4.3'),
-                     'Not supported in versions of Orange below 3.4.3')
-    def test_extend(self):
-        c = Corpus.from_file('deerwester')
-        c2 = c[:5]
-        self.assertEqual(len(c2), 5)
-        n = len(c)
-        self.pos_tagger.tag_corpus(c)
-        self.assertIsNot(c._tokens, None)
-        self.assertIsNot(c.pos_tags, None)
-        self.assertIs(c2._tokens, None)
-        self.assertIs(c2.pos_tags, None)
-
-        c.extend(c2)
-        self.assertEqual(len(c), n + 5)
-        self.assertIs(c._tokens, None)
-        self.assertIs(c.pos_tags, None)
-
-        self.pos_tagger.tag_corpus(c)
-        self.pos_tagger.tag_corpus(c2)
-        c.extend(c2)
-        self.assertEqual(len(c), n + 10)
-        self.assertEqual(len(c._tokens), n + 10)
-        self.assertEqual(len(c.pos_tags), n + 10)
-
     def test_extend_corpus(self):
         c = Corpus.from_file('book-excerpts')
         n_classes = len(c.domain.class_var.values)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Extend function is no longer available in Orange - consequently it does not work in Text anymore. 

##### Description of changes

Since it is not available in Orange anymore I suggest removing it in Text too. I do not find any usage of this function within the add-on. The deprecation message was already appearing to users since Orange's extend was called.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
