### PR TITLE
Remove a redundant web view

### DIFF
--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -88,7 +88,6 @@ span.selected {color:red !important}
         self.mainArea.layout().addWidget(webview)
 
     def _create_layout(self):
-        self._new_webview()
         box = gui.widgetBox(self.controlArea, 'Info')
         self.topic_info = gui.label(box, self, '%(n_topic_words)d words in a topic')
         gui.label(box, self, '%(documents_info_str)s')


### PR DESCRIPTION
##### Issue
Partially fix #204 

##### Description of changes
I remove one `_new_webview()` out of `_create_layout()`.

From my understanding, `handleNewSignals()` calls either `_apply_topic()`, `_apply_corpus()`, or `clear()`. The latter directly calls `_new_webview()` while the first two call `_repopulate_wordcloud()` and then `on_cloud_pref_change()` which calls `_new_webview()` in the end. So, calling `_new_webview()` in `_create_layout()` is unnecessary and actually redundant.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
