### PR TITLE
Remove uses of deprecated 'processEvents' argument

### DIFF
--- a/orangecontrib/text/widgets/owguardian.py
+++ b/orangecontrib/text/widgets/owguardian.py
@@ -163,20 +163,20 @@ class OWGuardian(OWWidget):
 
     @search.callback(should_raise=False)
     def progress_with_info(self, n_retrieved, n_all):
-        self.progressBarSet(100 * (n_retrieved / n_all if n_all else 1), None)  # prevent division by 0
+        self.progressBarSet(100 * (n_retrieved / n_all if n_all else 1))  # prevent division by 0
         self.output_info = '{}/{}'.format(n_retrieved, n_all)
 
     @search.on_start
     def on_start(self):
         self.Error.no_query.clear()
-        self.progressBarInit(None)
+        self.progressBarInit()
         self.search_button.setText('Stop')
         self.Outputs.corpus.send(None)
 
     @search.on_result
     def on_result(self, result):
         self.search_button.setText('Search')
-        self.progressBarFinished(None)
+        self.progressBarFinished()
         self.corpus = result
         self.set_text_features()
 

--- a/orangecontrib/text/widgets/ownyt.py
+++ b/orangecontrib/text/widgets/ownyt.py
@@ -159,7 +159,7 @@ class OWNYT(OWWidget):
 
     @search.callback(should_raise=False)
     def progress_with_info(self, n_retrieved, n_all):
-        self.progressBarSet(100 * (n_retrieved / n_all if n_all else 1), None)  # prevent division by 0
+        self.progressBarSet(100 * (n_retrieved / n_all if n_all else 1))  # prevent division by 0
         self.num_all = n_all
         self.num_retrieved = n_retrieved
         self.update_info_label()
@@ -171,7 +171,7 @@ class OWNYT(OWWidget):
         self.Error.offline.clear()
         self.num_all, self.num_retrieved = 0, 0
         self.update_info_label()
-        self.progressBarInit(None)
+        self.progressBarInit()
         self.search_button.setText('Stop')
         self.Outputs.corpus.send(None)
 
@@ -180,7 +180,7 @@ class OWNYT(OWWidget):
         self.search_button.setText('Search')
         self.corpus = result
         self.set_text_features()
-        self.progressBarFinished(None)
+        self.progressBarFinished()
 
     def update_info_label(self):
         self.output_info = '{}/{}'.format(self.num_retrieved, self.num_all)

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -730,11 +730,11 @@ class OWPreprocess(OWWidget):
 
     @preprocess.on_start
     def on_start(self):
-        self.progressBarInit(None)
+        self.progressBarInit()
 
     @preprocess.callback
     def on_progress(self, i):
-        self.progressBarSet(i, None)
+        self.progressBarSet(i)
 
     @preprocess.on_result
     def on_result(self, result):
@@ -743,7 +743,7 @@ class OWPreprocess(OWWidget):
             self.Warning.no_token_left()
             result = None
         self.Outputs.corpus.send(result)
-        self.progressBarFinished(None)
+        self.progressBarFinished()
 
     def set_minimal_width(self):
         max_width = 250

--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -203,12 +203,12 @@ class OWTopicModeling(OWWidget):
 
     @learning_task.on_start
     def on_start(self):
-        self.progressBarInit(None)
+        self.progressBarInit()
         self.topic_desc.clear()
 
     @learning_task.on_result
     def on_result(self, corpus):
-        self.progressBarFinished(None)
+        self.progressBarFinished()
         self.Outputs.corpus.send(corpus)
         if corpus is None:
             self.topic_desc.clear()
@@ -220,7 +220,7 @@ class OWTopicModeling(OWWidget):
 
     @learning_task.callback
     def on_progress(self, p):
-        self.progressBarSet(100 * p, processEvents=None)
+        self.progressBarSet(100 * p)
 
     def send_report(self):
         self.report_items(*self.widgets[self.method_index].report_model())

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -241,11 +241,11 @@ class OWTwitter(OWWidget):
     @search.on_start
     def on_start(self):
         self.Error.clear()
-        self.progressBarInit(None)
+        self.progressBarInit()
         self.search_button.setText('Stop')
         self.Outputs.corpus.send(None)
         if self.mode == self.CONTENT and not self.limited_search:
-            self.progressBarFinished(None)
+            self.progressBarFinished()
 
     @search.on_result
     def on_result(self, result):
@@ -253,13 +253,13 @@ class OWTwitter(OWWidget):
         self.tweets_info_label.setText(self.tweets_info.format(len(result) if result else 0))
         self.corpus = result
         self.set_text_features()
-        self.progressBarFinished(None)
+        self.progressBarFinished()
 
     @search.callback(should_raise=False)
     def update_tweets_num(self, num=0, progress=None):
         if self.limited_search or self.mode == self.AUTHOR:
             if progress is not None:
-                self.progressBarSet(100 * progress, None)
+                self.progressBarSet(100 * progress)
         self.tweets_info_label.setText(self.tweets_info.format(num))
 
     def set_text_features(self):

--- a/orangecontrib/text/widgets/owwikipedia.py
+++ b/orangecontrib/text/widgets/owwikipedia.py
@@ -103,13 +103,13 @@ class OWWikipedia(OWWidget):
 
     @search.callback(should_raise=False)
     def progress_with_info(self, progress, n_retrieved):
-        self.progressBarSet(100 * progress, None)
+        self.progressBarSet(100 * progress)
         self.result_label.setText(self.info_label.format(n_retrieved))
 
     @search.on_start
     def on_start(self):
         self.Error.api_error.clear()
-        self.progressBarInit(None)
+        self.progressBarInit()
         self.search_button.setText('Stop')
         self.result_label.setText(self.info_label.format(0))
         self.Outputs.corpus.send(None)
@@ -120,7 +120,7 @@ class OWWikipedia(OWWidget):
         self.result_label.setText(self.info_label.format(len(result) if result else 0))
         self.search_button.setText('Search')
         self.set_text_features()
-        self.progressBarFinished(None)
+        self.progressBarFinished()
 
     def set_text_features(self):
         self.Warning.no_text_fields.clear()


### PR DESCRIPTION
##### Issue
`processEvents` was deprecated and is already removed in orange-widget-base (https://github.com/biolab/orange-widget-base/commit/513a926901e226b6e9525a72f52a0ae0e23e8fd7), which will cause crashes once the versions are bumped.

##### Description of changes
Remove the setting of argument. All of them were set to `None` currently anyway.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
