### PR TITLE
Remove ufal.udpipe-temp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,4 @@ odfpy>=1.3.5
 docx2txt>=0.6
 lxml
 biopython # Enables Pubmed widget.
-ufal.udpipe ; platform_system!="Darwin"
-ufal.udpipe-temp; platform_system=="Darwin"
+ufal.udpipe >=1.2.0.2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
ufal.udpipe-temp is in requirements since it didn't compiled correctly at macos.

##### Description of changes
It seems it can be removed now since authors made a new release which adds missing compile requirements for macOS. I tested that on my macOS and it works correctly.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
