### PR TITLE
Docutils version corrected to avoid conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
 scikit-learn
 numpy
 # gensim needs smart-open that needs boto3 that needs botocore that needs docutils < 0.15
-docutils==0.14.*
+docutils >=0.10
 gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git
 Orange3>=3.4.3


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Docutils version was fixed to 1.14.* to prevent conflicts with botocore. They anyway released this restriction recently so it can be released.

##### Description of changes
docutils limitation released.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
