### PR TITLE
Limit Orange version to lowest that orange3-text supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
         - &master
           python: '3.6'
           env: ORANGE="master"
+        - &orange3-21-0
+          python: '3.7'
+          env: ORANGE="3.21.0"
 
 env:
     global:

--- a/orangecontrib/text/widgets/owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/owsentimentanalysis.py
@@ -3,11 +3,10 @@ from AnyQt.QtWidgets import QApplication, QGridLayout, QLabel
 
 from Orange.widgets import gui, settings
 from Orange.widgets.utils.signals import Input, Output
-from Orange.widgets.widget import OWWidget
+from Orange.widgets.widget import OWWidget, Msg
 from orangecontrib.text import Corpus
 from orangecontrib.text.sentiment import VaderSentiment, LiuHuSentiment, \
     MultiSentiment, SentimentDictionaries
-from orangewidget.widget import Msg
 
 
 class OWSentimentAnalysis(OWWidget):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ docutils<0.16  # denpendency for botocore
 python-dateutil<2.8.1  # denpendency for botocore
 gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git
-Orange3>=3.4.3
+Orange3 >=3.21.0
 tweepy
 typing ; python_version < '3.5'
 beautifulsoup4


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Orange3-text do not work at versions <3.21.0.
##### Description of changes
Define minimal orange3 version to 3.21

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
