### PR TITLE
Remove typing as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ gensim>=0.12.3  # LDA's show topics unified in 0.12.3
 setuptools-git
 Orange3 >=3.21.0
 tweepy
-typing ; python_version < '3.5'
 beautifulsoup4
 simhash
 wikipedia


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Since we do not support python <3.6 anymore typing dependecy can be removed.

##### Description of changes
Removing typing dependency which comes with python in python >=3.5

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
