### PR TITLE
[ENH] Corpus: add title attribute selection dropdown

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -197,15 +197,7 @@ class Corpus(Table):
         """ Returns a list of titles. """
         attrs = [attr for attr in chain(self.domain.variables, self.domain.metas)
                  if attr.attributes.get('title', False)]
-        # Alternatively, use heuristics
-        if not attrs:
-            for var in sorted(chain(self.domain.metas, self.domain.variables),
-                              key=lambda var: var.name,
-                              reverse=True):  # reverse so that title < heading < filename
-                if var.name.lower() in ('title', 'heading', 'h1', 'filename') \
-                        and not var.attributes.get('hidden', False):    # skip BoW features
-                    attrs = [var]
-                    break
+
         if attrs:
             return self.documents_from_features(attrs)
         else:

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -163,13 +163,6 @@ class CorpusTests(unittest.TestCase):
         for title in titles:
             self.assertIn('Document ', title)
 
-        # inferred title from heuristics
-        expected = list(map(str, range(len(c))))
-        c2 = Corpus(Domain([], [], (StringVariable('heading'),)),
-                    None, None, np.c_[expected])
-        titles = c2.titles
-        self.assertEqual(titles, expected)
-
         # title feature set
         c.domain[0].attributes['title'] = True
         titles = c.titles

--- a/orangecontrib/text/widgets/tests/test_owcorpus.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpus.py
@@ -1,0 +1,165 @@
+import numpy as np
+from Orange.data import Table, Domain, StringVariable
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.text import Corpus
+from orangecontrib.text.widgets.owcorpus import OWCorpus
+
+
+class TestOWCorpus(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWCorpus)
+
+    def check_output(self, sel_title):
+        """
+        This function check whether the `sel_title` variable has a title true
+        in the output
+        """
+        output = self.get_output(self.widget.Outputs.corpus)
+        for attr in output.domain.variables + output.domain.metas:
+            if str(attr) == sel_title:
+                # sel_title attribute must be marked as a title
+                self.assertTrue(attr.attributes.get("title", False))
+            else:
+                # others must not be marked as a title
+                self.assertFalse(attr.attributes.get("title", False))
+
+    def test_title_combo(self):
+        # default corpus dataset
+        self.assertEqual(self.widget.corpus.name, "book-excerpts")
+
+        options = self.widget.title_model[:]
+        self.assertIn(self.widget.corpus.domain["Text"], options)
+        # for this dataset no title variable is selected
+        self.assertEqual(None, self.widget.title_variable)
+        self.check_output(None)
+
+    def test_title_already_in_dataset(self):
+        """
+        This dataset already have the title attribute so the title option
+        is set to this attribute by default
+        """
+        # default corpus dataset
+        data = Corpus.from_file("election-tweets-2016")
+        self.send_signal(self.widget.Inputs.data, data)
+
+        self.assertEqual(data.domain["Content"], self.widget.title_variable)
+        self.check_output("Content")
+
+    def test_title_selection_strategy_title_heading(self):
+        """
+        When a there is a title, heading, filename attribute, select this one
+        as a default title.
+        """
+        data = Table(
+            Domain([], metas=[StringVariable("title"), StringVariable("b"),
+                              StringVariable("c")]),
+            np.empty((3, 0)),
+            metas=[["a" * 100, "a" * 40, "a" * 40],
+                   ["b" * 100, "a" * 40, "b" * 30],
+                   ["c" * 100, "a" * 40, "b" * 40]]
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertEqual(data.domain["title"], self.widget.title_variable)
+        self.check_output("title")
+
+        data = Table(
+            Domain([], metas=[StringVariable("Title"), StringVariable("b"),
+                              StringVariable("c")]),
+            np.empty((3, 0)),
+            metas=[["a" * 100, "a" * 40, "a" * 40],
+                   ["b" * 100, "a" * 40, "b" * 30],
+                   ["c" * 100, "a" * 40, "b" * 40]]
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertEqual(data.domain["Title"], self.widget.title_variable)
+        self.check_output("Title")
+
+        # when title and heading present first select title
+        data = Table(
+            Domain([], metas=[
+                StringVariable("Title"),
+                StringVariable("Heading"),
+                StringVariable("c")]),
+            np.empty((3, 0)),
+            metas=[["a" * 100, "a" * 40, "a" * 40],
+                   ["b" * 100, "a" * 40, "b" * 30],
+                   ["c" * 100, "a" * 40, "b" * 40]]
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertEqual(data.domain["Title"], self.widget.title_variable)
+        self.check_output("Title")
+
+        data = Table(
+            Domain([], metas=[
+                StringVariable("Heading"),
+                StringVariable("Title"),
+                StringVariable("c")]),
+            np.empty((3, 0)),
+            metas=[["a" * 100, "a" * 40, "a" * 40],
+                   ["b" * 100, "a" * 40, "b" * 30],
+                   ["c" * 100, "a" * 40, "b" * 40]]
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertEqual(data.domain["Title"], self.widget.title_variable)
+        self.check_output("Title")
+
+        data = Table(
+            Domain([], metas=[
+                StringVariable("Heading"),
+                StringVariable("Filename"),
+                StringVariable("c")]),
+            np.empty((3, 0)),
+            metas=[["a" * 100, "a" * 40, "a" * 40],
+                   ["b" * 100, "a" * 40, "b" * 30],
+                   ["c" * 100, "a" * 40, "b" * 40]]
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertEqual(data.domain["Heading"], self.widget.title_variable)
+        self.check_output("Heading")
+
+    def test_title_selection_strategy(self):
+        """
+        With this test we test whether the selection strategy for a title
+        attribute works correctly
+        """
+        # select the most unique
+        data = Table(
+            Domain([], metas=[StringVariable("a"), StringVariable("b")]),
+            np.empty((3, 0)),
+            metas=[["a" * 10, "a" * 10],
+                   ["a" * 10, "b" * 10],
+                   ["a" * 10, "c" * 10]]
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertEqual(data.domain["b"], self.widget.title_variable)
+        self.check_output("b")
+
+        # select the uniquest and also short enough, here attribute a is not
+        # suitable since it has too long title, and c is more unique than b
+        data = Table(
+            Domain([], metas=[StringVariable("a"), StringVariable("b"),
+                              StringVariable("c")]),
+            np.empty((3, 0)),
+            metas=[["a" * 100, "a" * 10, "a" * 10],
+                   ["b" * 100, "a" * 10, "b" * 10],
+                   ["c" * 100, "a" * 10, "b" * 10]]
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertEqual(data.domain["c"], self.widget.title_variable)
+        self.check_output("c")
+
+        # when no variable is short enough we just select the shortest
+        # attribute
+        data = Table(
+            Domain([], metas=[StringVariable("a"), StringVariable("b"),
+                              StringVariable("c")]),
+            np.empty((3, 0)),
+            metas=[["a" * 100, "a" * 40, "a" * 40],
+                   ["b" * 100, "a" * 40, "b" * 30],
+                   ["c" * 100, "a" * 40, "b" * 40]]
+        )
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertEqual(data.domain["c"], self.widget.title_variable)
+        self.check_output("c")
+


### PR DESCRIPTION
##### Issue
When the corpus is loaded from a file or made out of the data table, the title attribute is not set if it does not exist in data already.

##### Description of changes
With this PR we:
- implement the dropdown to select the title attribute
- implement the strategy to select the most suitable title attribute by default
- add unit-tests

When this PR is checked I will update the documentation since new images must be made.
This PR also does not address the numbering of documents in a Corpus Viewer it will be solved in a separate pull request https://github.com/biolab/orange3-text/issues/482.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
