### PR TITLE
[ENH] Word Cloud: Show bag of words weights when bag of words features available

### DIFF
--- a/doc/widgets/wordcloud.md
+++ b/doc/widgets/wordcloud.md
@@ -11,9 +11,10 @@ Generates a word cloud from corpus.
 **Outputs**
 
 - Corpus: Documents that match the selection.
-- Word: Selected word that can be used as query in [Concordance](concordance.md).
+- Selected Word: Selected word that can be used as query in [Concordance](concordance.md).
+- Word Counts: Words and their weights.
 
-**Word Cloud** displays tokens in the corpus, their size denoting the frequency of the word in corpus. Words are listed by their frequency (weight) in the widget. The widget outputs documents, containing selected tokens from the word cloud.
+**Word Cloud** displays tokens in the corpus, their size denoting the frequency of the word in corpus or an average bag of words count, when bag of words features are at the input of the widget. Words are listed by their frequency (weight) in the widget. The widget outputs documents, containing selected tokens from the word cloud.
 
 ![](images/Word-Cloud-stamped.png)
 

--- a/orangecontrib/text/widgets/tests/test_owworldcloud.py
+++ b/orangecontrib/text/widgets/tests/test_owworldcloud.py
@@ -1,6 +1,9 @@
 import unittest
+import numpy as np
 
 from Orange.widgets.tests.base import WidgetTest
+from scipy.sparse import csr_matrix
+
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.widgets.owwordcloud import OWWordCloud
 
@@ -28,6 +31,72 @@ class TestWorldCloudWidget(WidgetTest):
         self.assertTrue(self.widget.documents_info_str == "9 documents with 42 words")
         self.send_signal(self.widget.Inputs.corpus, self.corpus[:0])
         self.assertTrue(self.widget.documents_info_str == "(no documents on input)")
+
+    def test_bow_features(self):
+        """
+        When bag of words features are at the input word cloud must be made
+        based on BOW weights.
+        """
+        data = self.corpus[:3]
+        data.extend_attributes(
+            csr_matrix([[3, 2, 0], [0, 3, 6], [0, 1, 0]]),
+            ["Word1", "Word2", "Word3"])
+        for v in data.domain.attributes:
+            v.attributes["bow-feature"] = True
+
+        self.send_signal(self.widget.Inputs.corpus, data)
+        self.assertDictEqual(
+            self.widget.corpus_counter, {"Word1": 1, "Word2": 2, "Word3": 2})
+        output = self.get_output(self.widget.Outputs.word_counts)
+        np.testing.assert_array_equal([2, 2, 1], output.X.flatten())
+        np.testing.assert_array_equal(
+            ["Word2", "Word3", "Word1"], output.metas.flatten())
+        self.assertListEqual(
+            [(2.0, 'Word2'), (2.0, 'Word3'), (1.0, 'Word1')],
+            self.widget.tablemodel[:])
+
+        # try with one word not bow-feature
+        data = self.corpus[:3]
+        data.extend_attributes(
+            csr_matrix([[3, 2, 0], [0, 3, 6], [0, 1, 0]]),
+            ["Word1", "Word2", "Word3"])
+        for v in data.domain.attributes[:2]:
+            v.attributes["bow-feature"] = True
+
+        self.send_signal(self.widget.Inputs.corpus, data)
+        self.assertDictEqual(
+            self.widget.corpus_counter, {"Word1": 1, "Word2": 2})
+        output = self.get_output(self.widget.Outputs.word_counts)
+        np.testing.assert_array_equal([2, 1], output.X.flatten())
+        np.testing.assert_array_equal(
+            ["Word2", "Word1"], output.metas.flatten())
+        self.assertListEqual(
+            [(2.0, 'Word2'), (1.0, 'Word1')],
+            self.widget.tablemodel[:])
+
+    def test_bow_info(self):
+        """
+        Widget shows info when bow-features used. This test tests this info.
+        """
+        data = self.corpus[:3]
+
+        # no data no info
+        self.assertFalse(self.widget.Info.bow_weights.is_shown())
+        self.send_signal(self.widget.Inputs.corpus, data)
+        self.assertFalse(self.widget.Info.bow_weights.is_shown())
+        self.send_signal(self.widget.Inputs.corpus, None)
+        self.assertFalse(self.widget.Info.bow_weights.is_shown())
+
+        # send bow data
+        data.extend_attributes(
+            csr_matrix([[3, 2, 0], [0, 3, 6], [0, 1, 0]]),
+            ["Word1", "Word2", "Word3"])
+        for v in data.domain.attributes:
+            v.attributes["bow-feature"] = True
+        self.send_signal(self.widget.Inputs.corpus, data)
+        self.assertTrue(self.widget.Info.bow_weights.is_shown())
+        self.send_signal(self.widget.Inputs.corpus, None)
+        self.assertFalse(self.widget.Info.bow_weights.is_shown())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Bag-of-words weights should be shown in the Word Cloud widget. When TF-IDF is used bag-of-words weights should better highlight the importance of the word. It was also discussed at the last meeting.

##### Description of changes
With this PR bag-of-words, weights are used in the Word Cloud widget when available.

##### Includes
- [X] Code changes
- [x] Tests
- [x] Documentation
