### PR TITLE
Include widgets in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 source = orangecontrib
 omit =
-    orangecontrib/text/widgets/*
+    orangecontrib/text/widgets/tests/*
     orangecontrib/text/tests/*
 
 [report]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When I write a test for a widget I cannot access the coverage. I understand that the coverage for widgets was omitted since they are not well covered, but anyway it helps if one can access the coverage for widgets too.

##### Description of changes
With this PR I suggest including widgets in coverage. What do you think @ajdapretnar?

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
