### PR TITLE
[ENH] Corpus: Store titles in corpus to match between Corpus Viewer even when subsampled

### DIFF
--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -164,11 +164,64 @@ class CorpusTests(unittest.TestCase):
             self.assertIn('Document ', title)
 
         # title feature set
-        c.domain[0].attributes['title'] = True
+        c.set_title_variable(c.domain[0])
         titles = c.titles
         self.assertEqual(len(titles), len(c))
-        for title in titles:
-            self.assertIn(title, c.domain.class_var.values)
+
+        # first 50 are children
+        for title, c in zip(titles[:50], range(1, 51)):
+            self.assertEqual(f"children ({c})", title)
+
+        # others are adults
+        for title, a in zip(titles[50:100], range(1, 51)):
+            self.assertEqual(f"adult ({a})", title)
+
+        # first 50 are children
+        for title, c in zip(titles[100:120], range(51, 71)):
+            self.assertEqual(f"children ({c})", title)
+
+        # others are adults
+        for title, a in zip(titles[120:140], range(51, 71)):
+            self.assertEqual(f"adult ({a})", title)
+
+    def test_titles_no_numbers(self):
+        """
+        The case when no number is used since the title appears only once.
+        """
+        c = Corpus.from_file('andersen')
+        c.set_title_variable(c.domain.metas[0])
+
+        # title feature set
+        self.assertEqual("The Little Match-Seller", c.titles[0])
+
+    def test_titles_read_document(self):
+        """
+        When we read the document with a title marked it should have titles
+        set correctly.
+        """
+        c = Corpus.from_file('election-tweets-2016')
+
+        self.assertEqual(len(c), len(c.titles))
+
+    def test_titles_sample(self):
+        c = Corpus.from_file('book-excerpts')
+        c.set_title_variable(c.domain[0])
+
+        c_sample = c[10:20]
+        for title, i in zip(c_sample.titles, range(11, 21)):
+            self.assertEqual(f"children ({i})", title)
+
+        c_sample = c[60:70]
+        for title, i in zip(c_sample.titles, range(11, 21)):
+            self.assertEqual(f"adult ({i})", title)
+
+        c_sample = c[[10, 11, 12]]
+        for title, i in zip(c_sample.titles, range(11, 14)):
+            self.assertEqual(f"children ({i})", title)
+
+        c_sample = c[np.array([10, 11, 12])]
+        for title, i in zip(c_sample.titles, range(11, 14)):
+            self.assertEqual(f"children ({i})", title)
 
     def test_documents_from_features(self):
         c = Corpus.from_file('book-excerpts')
@@ -369,3 +422,7 @@ class CorpusTests(unittest.TestCase):
         self.assertFalse(len(d.text_features))
         # Make sure that copying works.
         d.copy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/widgets/owcorpus.py
+++ b/orangecontrib/text/widgets/owcorpus.py
@@ -262,22 +262,13 @@ class OWCorpus(OWWidget):
             if len(self.unused_attrs_model) > 0 and not self.corpus.text_features:
                 self.Error.no_text_features_used()
 
-            self._set_title_attribute()
+            self.corpus.set_title_variable(self.title_variable)
             # prevent sending "empty" corpora
             dom = self.corpus.domain
             empty = not (dom.variables or dom.metas) \
                 or len(self.corpus) == 0 \
                 or not self.corpus.text_features
             self.Outputs.corpus.send(self.corpus if not empty else None)
-
-    def _set_title_attribute(self):
-        # remove all title attributes
-        for a in self.corpus.domain.variables + self.corpus.domain.metas:
-            a.attributes.pop("title", None)
-
-        if self.title_variable and self.title_variable in self.corpus.domain:
-            self.corpus.domain[
-                self.title_variable].attributes["title"] = True
 
     def send_report(self):
         def describe(features):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-text/issues/482

##### Description of changes
- Now titles are stored in the corpus and subsampled together with the corpus.
- Functionality to set tile is moved from widget to corpus. 


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
