### PR TITLE
[FIX] from_numpy must define titles

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -440,6 +440,12 @@ class Corpus(Table):
         return c
 
     @classmethod
+    def from_numpy(cls, *args, **kwargs):
+        c = super().from_numpy(*args, **kwargs)
+        c._set_unique_titles()
+        return c
+
+    @classmethod
     def from_file(cls, filename):
         if not os.path.exists(filename):  # check the default location
             abs_path = os.path.join(get_sample_corpora_dir(), filename)

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -423,6 +423,25 @@ class CorpusTests(unittest.TestCase):
         # Make sure that copying works.
         d.copy()
 
+    def test_set_title_from_domain(self):
+        """
+        When we setup domain from data (e.g. from_numpy) _title variable
+        must be set.
+        """
+        domain = Domain([], metas=[StringVariable("title"), StringVariable("a")])
+        metas = [["title1", "a"], ["title2", "b"]]
+
+        corpus = Corpus.from_numpy(
+            domain, X=np.empty((2, 0)), metas=np.array(metas)
+        )
+        self.assertListEqual(["Document 1", "Document 2"], corpus.titles)
+
+        domain["title"].attributes["title"] = True
+        corpus = Corpus.from_numpy(
+            domain, X=np.empty((2, 0)), metas=np.array(metas)
+        )
+        self.assertListEqual(["title1", "title2"], corpus.titles)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
from_numpy in Corpus does not define titles of the documents - functions that need acess to _titles attribute fails.

##### Description of changes
from_numpy in Corpus call function that defines titles.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
