### PR TITLE
Corpus: fix - from_list and from_table_rows do not define titles

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -446,6 +446,20 @@ class Corpus(Table):
         return c
 
     @classmethod
+    def from_list(cls, domain, rows, weights=None):
+        c = super().from_list(domain, rows, weights)
+        c._set_unique_titles()
+        return c
+
+    @classmethod
+    def from_table_rows(cls, source, row_indices):
+        c = super().from_table_rows(source, row_indices)
+        if hasattr(source, "_titles"):
+            # covering case when from_table_rows called by from_table
+            c._titles = source._titles[row_indices]
+        return c
+
+    @classmethod
     def from_file(cls, filename):
         if not os.path.exists(filename):  # check the default location
             abs_path = os.path.join(get_sample_corpora_dir(), filename)

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -235,8 +235,6 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(types), 1)
         self.assertIn(str, types)
 
-    @unittest.skipIf(LooseVersion(Orange.__version__) < LooseVersion('3.3.6'),
-                     'Not supported in versions of Orange below 3.3.6')
     def test_documents_from_sparse_features(self):
         t = Table.from_file('brown-selected')
         c = Corpus.from_table(t.domain, t)
@@ -440,6 +438,30 @@ class CorpusTests(unittest.TestCase):
         corpus = Corpus.from_numpy(
             domain, X=np.empty((2, 0)), metas=np.array(metas)
         )
+        self.assertListEqual(["title1", "title2"], corpus.titles)
+
+    def test_titles_from_rows(self):
+        domain = Domain([],
+                        metas=[StringVariable("title"), StringVariable("a")])
+        metas = [["title1", "a"], ["title2", "b"], ["titles3", "c"]]
+
+        corpus = Corpus.from_numpy(
+            domain, X=np.empty((3, 0)), metas=np.array(metas)
+        )
+        corpus = Corpus.from_table_rows(corpus, [0, 2])
+        self.assertListEqual(["Document 1", "Document 3"], corpus.titles)
+
+    def test_titles_from_list(self):
+        domain = Domain(
+            [], metas=[StringVariable("title"), StringVariable("a")]
+        )
+        corpus = Corpus.from_list(
+            domain, [["title1", "a"], ["title2", "b"]])
+        self.assertListEqual(["Document 1", "Document 2"], corpus.titles)
+
+        domain["title"].attributes["title"] = True
+        corpus = Corpus.from_list(
+            domain, [["title1", "a"], ["title2", "b"]])
         self.assertListEqual(["title1", "title2"], corpus.titles)
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`from_list` and `from_table_rows` do not define titles, this lead to error when preprocessing is used.

##### Description of changes
Reimplemented `from_list` and `from_table_rows` such that they define titles. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
