### PR TITLE
Bag of Words: add option to show bow features

### DIFF
--- a/orangecontrib/text/widgets/utils/owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/owbasevectorizer.py
@@ -1,4 +1,5 @@
-from AnyQt.QtWidgets import QGroupBox, QHBoxLayout, QVBoxLayout
+
+from AnyQt.QtWidgets import QGroupBox, QVBoxLayout
 
 from Orange.widgets import gui
 from Orange.widgets import settings
@@ -24,6 +25,7 @@ class OWBaseVectorizer(OWWidget):
 
     # Settings
     autocommit = settings.Setting(True)
+    hidden_cb = settings.Setting(True)
 
     Method = NotImplemented
 
@@ -31,38 +33,55 @@ class OWBaseVectorizer(OWWidget):
         super().__init__()
         self.corpus = None
         self.method = None
+        self.new_corpus = None
+        self.new_attrs = None
 
         box = QGroupBox(title='Options')
         box.setLayout(self.create_configuration_layout())
         self.controlArea.layout().addWidget(box)
 
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addSpacing(15)
-        buttons_layout.addWidget(
-            gui.auto_commit(None, self, 'autocommit', 'Commit', box=False)
-        )
-        self.controlArea.layout().addLayout(buttons_layout)
+        output_layout = gui.hBox(self.controlArea)
+        gui.checkBox(output_layout, self, "hidden_cb", "Hide bow attributes",
+                     callback=self.hide_attrs)
+
+        buttons_layout = gui.hBox(self.controlArea)
+        gui.auto_commit(buttons_layout, self, 'autocommit', 'Commit', box=False)
         self.update_method()
 
     @Inputs.corpus
     def set_data(self, data):
         self.corpus = data
-        self.commit()
+        self.invalidate()
+
+    def hide_attrs(self):
+        if self.new_corpus:
+            new_domain = self.new_corpus.domain
+            for f in new_domain.attributes:
+                if f.name in self.new_attrs:
+                    f.attributes['hidden'] = self.hidden_cb
+            self.new_corpus = self.new_corpus.transform(new_domain)
+            self.commit()
 
     def commit(self):
-        self.apply()
+        self.Outputs.corpus.send(self.new_corpus)
 
     def apply(self):
         if self.corpus is not None:
-            new_corpus = self.method.transform(self.corpus)
-            self.Outputs.corpus.send(new_corpus)
+            self.new_corpus = self.method.transform(self.corpus)
+            self.new_attrs = {f.name for f in self.new_corpus.domain.attributes} \
+                - {f.name for f in self.corpus.domain.attributes}
+
+    def invalidate(self):
+        self.apply()
+        self.hide_attrs()
+        self.commit()
 
     def update_method(self):
         self.method = self.Method()
 
     def on_change(self):
         self.update_method()
-        self.commit()
+        self.invalidate()
 
     def send_report(self):
         self.report_items(self.method.report())

--- a/orangecontrib/text/widgets/utils/tests/test_owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/tests/test_owbasevectorizer.py
@@ -1,0 +1,27 @@
+from orangecontrib.text import Corpus
+from orangecontrib.text.vectorization import BowVectorizer
+from orangecontrib.text.widgets.utils.owbasevectorizer import OWBaseVectorizer
+from orangewidget.tests.base import WidgetTest
+
+
+class TestableBaseVectWidget(OWBaseVectorizer):
+    name = "TBV"
+    Method = BowVectorizer
+
+
+class TestOWBaseVectorizer(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(TestableBaseVectWidget)
+        self.corpus = Corpus.from_file('deerwester')
+
+    def test_hide_attributes(self):
+        self.send_signal("Corpus", self.corpus)
+        self.assertTrue(all(f.attributes['hidden'] for f in
+                            self.get_output("Corpus").domain.attributes))
+        self.widget.controls.hidden_cb.setChecked(False)
+        self.assertFalse(any(f.attributes['hidden'] for f in
+                            self.get_output("Corpus").domain.attributes))
+        new_corpus = Corpus.from_file('book-excerpts')[:10]
+        self.send_signal("Corpus", new_corpus)
+        self.assertFalse(any(f.attributes['hidden'] for f in
+                            self.get_output("Corpus").domain.attributes))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #498.

##### Description of changes
Add a checkbox to set 'hidden' attribute of attributes to True. Added to the base widget, so now both Bag of Words and SimHash use this option.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
