### PR TITLE
Word Cloud: Remove words with zero weights from word cloud

### DIFF
--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -348,25 +348,13 @@ span.selected {color:red !important}
         This function extract words from bag of words features and assign them
         the frequency which is average bow count.
         """
-        bow_features = self._get_bow_variables()
-        if not bow_features:
-            return {}
-
         average_bows = {
-            f.name: self.corpus.get_column_view(f)[0].mean()
-            for f in bow_features
+            f.name: self.corpus.X[:, i].mean()
+            for i, f in enumerate(self.corpus.domain.attributes)
+            if f.attributes.get("bow-feature", False)
         }
-        return average_bows
-
-    def _get_bow_variables(self):
-        """
-        Extract bow variables from data
-        """
-        return [
-            var
-            for var in self.corpus.domain.variables
-            if var.attributes.get("bow-feature", False)
-        ]
+        # return only positive bow weights (those == 0 are non-existing words)
+        return {f: w for f, w in average_bows.items() if w > 0}
 
     def handleNewSignals(self):
         if self.topic is not None and len(self.topic):

--- a/orangecontrib/text/widgets/tests/test_owworldcloud.py
+++ b/orangecontrib/text/widgets/tests/test_owworldcloud.py
@@ -62,15 +62,20 @@ class TestWorldCloudWidget(WidgetTest):
             v.attributes["bow-feature"] = True
 
         self.send_signal(self.widget.Inputs.corpus, data)
-        self.assertDictEqual(
-            self.widget.corpus_counter, {"Word1": 1, "Word2": 2, "Word3": 2})
+        weights = list(zip(*sorted(self.widget.corpus_counter.items())))[1]
+        # due to computation error in computing mean use array_almost_equal
+        np.testing.assert_array_almost_equal(weights, [1, 2, 2])
+
         output = self.get_output(self.widget.Outputs.word_counts)
-        np.testing.assert_array_equal([2, 2, 1], output.X.flatten())
+        np.testing.assert_array_almost_equal([2, 2, 1], output.X.flatten())
         np.testing.assert_array_equal(
-            ["Word2", "Word3", "Word1"], output.metas.flatten())
-        self.assertListEqual(
-            [(2.0, 'Word2'), (2.0, 'Word3'), (1.0, 'Word1')],
-            self.widget.tablemodel[:])
+            ["Word3", "Word2", "Word1"], output.metas.flatten())
+        self.assertTupleEqual(
+            ("Word3", "Word2", "Word1"),
+            list(zip(*self.widget.tablemodel[:]))[1])
+        np.testing.assert_array_almost_equal(
+            [2, 2, 1],
+            list(zip(*self.widget.tablemodel[:]))[0])
 
         # try with one word not bow-feature
         data = self.corpus[:3]
@@ -81,15 +86,19 @@ class TestWorldCloudWidget(WidgetTest):
             v.attributes["bow-feature"] = True
 
         self.send_signal(self.widget.Inputs.corpus, data)
-        self.assertDictEqual(
-            self.widget.corpus_counter, {"Word1": 1, "Word2": 2})
+        weights = list(zip(*sorted(self.widget.corpus_counter.items())))[1]
+        np.testing.assert_array_almost_equal(weights, [1, 2])
+
         output = self.get_output(self.widget.Outputs.word_counts)
-        np.testing.assert_array_equal([2, 1], output.X.flatten())
+        np.testing.assert_array_almost_equal([2, 1], output.X.flatten())
         np.testing.assert_array_equal(
             ["Word2", "Word1"], output.metas.flatten())
-        self.assertListEqual(
-            [(2.0, 'Word2'), (1.0, 'Word1')],
-            self.widget.tablemodel[:])
+        self.assertTupleEqual(
+            ("Word2", "Word1"),
+            list(zip(*self.widget.tablemodel[:]))[1])
+        np.testing.assert_array_almost_equal(
+            [2, 1],
+            list(zip(*self.widget.tablemodel[:]))[0])
 
     def test_bow_info(self):
         """


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
https://github.com/biolab/orange3-text/issues/500

##### Description of changes
- Words with a bag of words below or equal zero are removed from the word cloud. Those are words that exist in the table but does not exist for the selected text.
- Small optimization of extracting bow features
- Test fix to be robust on computational error (instead of 2. number is 1.99999999999999999).
- Rounding numbers in the list on the same number of decimal spaces (0 when all whole numbers, 2 when float numbers).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
