### PR TITLE
[FIX] Corpus: remove unnecessary empty values - it is not allowed anymore

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -401,10 +401,6 @@ class Corpus(Table):
         for ind in title_indices:
             domain[ind].attributes['title'] = True
 
-        for attr in domain.attributes:
-            if isinstance(attr, DiscreteVariable):
-                attr.values = []
-
         def to_val(attr, val):
             if isinstance(attr, DiscreteVariable):
                 attr.val_from_str_add(val)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
from_documents fail since it makes unallowed operation whichis prhibited with current changes in variable constructor.

##### Description of changes
Removed part of code that does not make harm. It is a temporary fix. We still need to simplify a corpus.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
