### PR TITLE
Remove deprecated parser

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,6 @@
 
 import sys
 import os
-from recommonmark.parser import CommonMarkParser
 
 # If extensions (or scripting to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -36,13 +35,12 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'sphinx.ext.intersphinx'
+    'sphinx.ext.intersphinx',
+    'recommonmark'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
-
-source_parsers = {'.md': CommonMarkParser}
 
 # The suffix of source filenames.
 source_suffix = ['.md', '.rst']


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Documentation was not properly built with the CommonMarkParser being deprecated.

##### Description of changes
Use recommonmark parser.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
