### PR TITLE
TweetProfiler: Run in separate thread

### DIFF
--- a/orangecontrib/text/tweet_profiler.py
+++ b/orangecontrib/text/tweet_profiler.py
@@ -37,7 +37,7 @@ class TweetProfiler:
             json = {'tweets': tweets[i: i+self.BATCH_SIZE],
                     'model_name': model_name,
                     'output_mode': output_mode,
-            }
+                    }
 
             json = self.server_call('tweet_profiler', json=json)
 
@@ -50,7 +50,7 @@ class TweetProfiler:
             results.append(profile)
 
             if callable(on_advance):
-                on_advance(self.BATCH_SIZE)
+                on_advance()
 
         if results:
             results = np.vstack(results)

--- a/orangecontrib/text/widgets/owtweetprofiler.py
+++ b/orangecontrib/text/widgets/owtweetprofiler.py
@@ -1,15 +1,34 @@
-from AnyQt.QtWidgets import QApplication, QGridLayout, QLabel, QGroupBox, QHBoxLayout
+import numpy as np
+
+from AnyQt.QtWidgets import QApplication, QGridLayout, QLabel, QGroupBox, \
+    QHBoxLayout, QPushButton, QStyle
 
 from Orange.data import StringVariable
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.itemmodels import VariableListModel
+from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from orangecontrib.text.tweet_profiler import TweetProfiler
 from orangecontrib.text.corpus import Corpus
 
 
-class OWTweetProfiler(OWWidget):
+def run_profiler(profiler, corpus, meta_var, model_name, output_mode, state):
+
+    ticks = iter(np.linspace(0., 100.,
+                             int(np.ceil(len(corpus) / profiler.BATCH_SIZE) + 1)))
+
+    def advance():
+        if state.is_interruption_requested():
+            raise InterruptedError
+        state.set_progress_value(next(ticks))
+
+    out = profiler.transform(corpus, meta_var, model_name, output_mode,
+                             on_advance=advance)
+    return out
+
+
+class OWTweetProfiler(OWWidget, ConcurrentWidgetMixin):
     name = "Tweet Profiler"
     description = "Detect Ekman's, Plutchik's or Profile of Mood States's " \
                   "emotions in tweets."
@@ -34,9 +53,11 @@ class OWTweetProfiler(OWWidget):
     class Error(OWWidget.Error):
         server_down = Msg('Our servers are not responding. '
                           'Please try again later.')
+        unexpected_error = Msg('Unknown error: {}')
 
     def __init__(self):
-        super().__init__()
+        OWWidget.__init__(self)
+        ConcurrentWidgetMixin.__init__(self)
         self.corpus = None
         self.last_config = None     # to avoid reruns with the same params
         self.strings_attrs = []
@@ -52,6 +73,17 @@ class OWTweetProfiler(OWWidget):
             gui.auto_commit(None, self, 'auto_commit', 'Commit', box=False)
         )
         self.controlArea.layout().addLayout(buttons_layout)
+
+        self.cancel_button = QPushButton(
+            'Cancel',
+            icon=self.style()
+            .standardIcon(QStyle.SP_DialogCancelButton))
+
+        self.cancel_button.clicked.connect(self.cancel)
+
+        hbox = gui.hBox(self.controlArea)
+        hbox.layout().addWidget(self.cancel_button)
+        self.cancel_button.setDisabled(True)
 
     def generate_grid_layout(self):
         box = QGroupBox(title='Options')
@@ -90,7 +122,9 @@ class OWTweetProfiler(OWWidget):
 
     @Inputs.corpus
     def set_corpus(self, corpus):
+        self.cancel()
         self.corpus = corpus
+        self.last_config = None
 
         if corpus is not None:
             self.strings_attrs = [a for a in self.corpus.domain.metas
@@ -108,8 +142,7 @@ class OWTweetProfiler(OWWidget):
         self.commit()
 
     def apply(self):
-        if self.last_config != self._get_config():
-            self.commit()
+        self.commit()
 
     def _get_config(self):
         return self.tweet_attr, self.model_name, self.output_mode
@@ -117,21 +150,37 @@ class OWTweetProfiler(OWWidget):
     def commit(self):
         self.Error.clear()
 
+        if self.last_config == self._get_config():
+            return
+
         if self.corpus is not None:
-            self.last_config = self._get_config()
-            with self.progressBar(iterations=len(self.corpus)) as pb:
-                out = self.profiler.transform(
-                    self.corpus, self.strings_attrs[self.tweet_attr],
-                    self.model_name, self.output_mode,
-                    on_advance=pb.advance)
-            self.Outputs.corpus.send(out)
+            self.cancel_button.setDisabled(False)
+            self.start(run_profiler, self.profiler, self.corpus,
+                       self.strings_attrs[self.tweet_attr],
+                       self.model_name, self.output_mode)
         else:
             self.Outputs.corpus.send(None)
+
+    def on_done(self, result):
+        self.cancel_button.setDisabled(True)
+        self.last_config = self._get_config()
+        self.Outputs.corpus.send(result)
+
+    def on_partial_result(self, result):
+        self.cancel()
+
+    def on_exception(self, ex):
+        self.Error.unexpected_error(type(ex).__name__)
+        self.cancel()
+
+    def cancel(self):
+        self.cancel_button.setDisabled(True)
+        super().cancel()
 
     def send_report(self):
         self.report_items([
             ('Attribute', self.strings_attrs[self.tweet_attr]
-                if len(self.strings_attrs) > self.tweet_attr else ''),
+             if len(self.strings_attrs) > self.tweet_attr else ''),
             ('Emotions', self.model_name),
             ('Output', self.output_mode),
         ])


### PR DESCRIPTION
##### Issue
Current implementation of Tweet Profiler runs in the main thread preventing user from working while the widget is running.


##### Description of changes
- Added concurrent mixin.
- Added cancel button.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
