### PR TITLE
Limit NLTK version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scipy
-nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
+nltk>=3.0.5,<3.5  # TODO: change when fixed: https://bitbucket.org/mrabarnett/mrab-regex/issues/369/please-provide-macos-wheels-on-pypi
 scikit-learn
 numpy
 docutils<0.16  # denpendency for botocore


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/4730

##### Description of changes
NLTK 3.5 has regex as a dependency that does not provide macOS wheels. :( Until wheels are available we need to limit the version.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
