### PR TITLE
[FIX] Update ulr to use https for udpipe models

### DIFF
--- a/orangecontrib/text/preprocess/normalize.py
+++ b/orangecontrib/text/preprocess/normalize.py
@@ -103,7 +103,7 @@ def file_to_language(file):
 
 
 class UDPipeModels:
-    server_url = "http://file.biolab.si/files/udpipe/"
+    server_url = "https://file.biolab.si/files/udpipe/"
 
     def __init__(self):
         self.local_data = os.path.join(data_dir(versioned=False), 'udpipe/')


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #519 

##### Description of changes
The issue was that we were using HTTP and when 404 happened the internet provider can replace 404 responses with something else. It can be avoided with https

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
