### PR TITLE
Corpus: Fix titles property

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -265,7 +265,7 @@ class Corpus(Table):
     def titles(self):
         """ Returns a list of titles. """
         assert self._titles is not None
-        return self._titles.tolist()
+        return self._titles
 
     def documents_from_features(self, feats):
         """

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -3,6 +3,7 @@ import unittest
 from distutils.version import LooseVersion
 
 import numpy as np
+from numpy.testing import assert_array_equal
 from scipy.sparse import csr_matrix, issparse
 
 import Orange
@@ -432,13 +433,13 @@ class CorpusTests(unittest.TestCase):
         corpus = Corpus.from_numpy(
             domain, X=np.empty((2, 0)), metas=np.array(metas)
         )
-        self.assertListEqual(["Document 1", "Document 2"], corpus.titles)
+        assert_array_equal(["Document 1", "Document 2"], corpus.titles)
 
         domain["title"].attributes["title"] = True
         corpus = Corpus.from_numpy(
             domain, X=np.empty((2, 0)), metas=np.array(metas)
         )
-        self.assertListEqual(["title1", "title2"], corpus.titles)
+        assert_array_equal(["title1", "title2"], corpus.titles)
 
     def test_titles_from_rows(self):
         domain = Domain([],
@@ -449,7 +450,7 @@ class CorpusTests(unittest.TestCase):
             domain, X=np.empty((3, 0)), metas=np.array(metas)
         )
         corpus = Corpus.from_table_rows(corpus, [0, 2])
-        self.assertListEqual(["Document 1", "Document 3"], corpus.titles)
+        assert_array_equal(["Document 1", "Document 3"], corpus.titles)
 
     def test_titles_from_list(self):
         domain = Domain(
@@ -457,12 +458,12 @@ class CorpusTests(unittest.TestCase):
         )
         corpus = Corpus.from_list(
             domain, [["title1", "a"], ["title2", "b"]])
-        self.assertListEqual(["Document 1", "Document 2"], corpus.titles)
+        assert_array_equal(["Document 1", "Document 2"], corpus.titles)
 
         domain["title"].attributes["title"] = True
         corpus = Corpus.from_list(
             domain, [["title1", "a"], ["title2", "b"]])
-        self.assertListEqual(["title1", "title2"], corpus.titles)
+        assert_array_equal(["title1", "title2"], corpus.titles)
 
 
 if __name__ == "__main__":

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -192,7 +192,7 @@ class OWCorpusViewer(OWWidget):
                                                       self.corpus_docs)):
             if is_match(content):
                 item = QStandardItem()
-                item.setData(title, Qt.DisplayRole)
+                item.setData(str(title), Qt.DisplayRole)
                 item.setData(doc, Qt.UserRole)
                 self.doc_list_model.appendRow(item)
                 self.output_mask.append(i)


### PR DESCRIPTION
##### Issue
Currently, every time the `titles` property is accessed, the `tolist` method is called on numpy array. This operation can be relatively slow for large corpora (0.7s for friends-transcripts) and can slow down widgets that access the property many times (with this PR, the Concordance widget is approximately 500 times faster on several examples I tested it on so this partially fixes #522).


##### Description of changes
Numpy array `_titles` is converted to list only once  (inside `_set_unique_titles`) instead of every time the property is accessed.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
