### PR TITLE
Document Embedding: do not lock controls, always commit on new data

### DIFF
--- a/orangecontrib/text/widgets/owdocumentembedding.py
+++ b/orangecontrib/text/widgets/owdocumentembedding.py
@@ -20,7 +20,6 @@ def run_pretrained_embedder(corpus: Corpus,
                             language: str,
                             aggregator: str,
                             state: TaskState) -> Corpus:
-
     """Runs DocumentEmbedder.
 
     Parameters
@@ -170,7 +169,7 @@ class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
             return
 
         self.corpus = data
-        self.commit()
+        self.unconditional_commit()
 
     def _option_changed(self):
         self.commit()
@@ -180,7 +179,7 @@ class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
             self.clear_outputs()
             return
 
-        self._set_fields(False)
+        self.cancel_button.setDisabled(False)
 
         self.start(run_pretrained_embedder,
                    self.corpus,
@@ -190,7 +189,7 @@ class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
         self.Error.clear()
 
     def on_done(self, result: Any) -> None:
-        self._set_fields(True)
+        self.cancel_button.setDisabled(True)
         self._send_output_signals(result)
 
     def on_partial_result(self, result: Any):
@@ -198,7 +197,7 @@ class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
         self.Error.no_connection()
 
     def on_exception(self, ex: Exception):
-        self._set_fields(False)
+        self.cancel_button.setDisabled(True)
         if isinstance(ex, EmbeddingConnectionError):
             self.Error.no_connection()
         else:
@@ -207,14 +206,8 @@ class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
         self.clear_outputs()
 
     def cancel(self):
-        self._set_fields(True)
+        self.cancel_button.setDisabled(True)
         super().cancel()
-
-    def _set_fields(self, active):
-        self.auto_commit_widget.setDisabled(not active)
-        self.cancel_button.setDisabled(active)
-        self.language_cb.setDisabled(not active)
-        self.aggregator_cb.setDisabled(not active)
 
     def _send_output_signals(self, result):
         self.Outputs.new_corpus.send(result)

--- a/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
+++ b/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest.mock import Mock, patch
 
 from Orange.widgets.tests.base import WidgetTest
@@ -88,3 +89,25 @@ class TestOWDocumentEmbedding(WidgetTest):
         self.wait_until_finished()
         self.assertIsNone(self.get_output(self.widget.Outputs.new_corpus))
         self.assertTrue(self.widget.Error.unexpected_error.is_shown())
+
+    @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [1.3, 1]}'))
+    def test_rerun_on_new_data(self):
+        """ Check if embedding is automatically re-run on new data """
+        self.widget._auto_apply = False
+        self.assertIsNone(self.get_output(self.widget.Outputs.new_corpus))
+
+        self.send_signal(self.widget.Inputs.corpus, self.corpus[:3])
+        self.wait_until_finished()
+        self.assertEqual(
+            3, len(self.get_output(self.widget.Outputs.new_corpus))
+        )
+
+        self.send_signal(self.widget.Inputs.corpus, self.corpus[:1])
+        self.wait_until_finished()
+        self.assertEqual(
+            1, len(self.get_output(self.widget.Outputs.new_corpus))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
- Widget is locking controls while embedding. It is not required since we can easily cancel embedding when control is changed.
- The widget does not embed on new data when auto-apply is off - it is different than in other widgets (e.g. distances)

##### Description of changes
- Widget changed to not lock controls anymore
- Widget changed to always commit on new data

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
