### PR TITLE
Corpus: add range indexing

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -513,8 +513,8 @@ class Corpus(Table):
                     new._tokens = np.array([orig._tokens[key]])
                     new.pos_tags = None if orig.pos_tags is None else np.array(
                         [orig.pos_tags[key]])
-                elif isinstance(key, list) or isinstance(key, np.ndarray) or isinstance(key,
-                                                                                        slice):
+                elif isinstance(key, list) or isinstance(key, np.ndarray) \
+                        or isinstance(key, slice) or isinstance(key, range):
                     new._tokens = orig._tokens[key]
                     new.pos_tags = None if orig.pos_tags is None else orig.pos_tags[key]
                 elif key is Ellipsis:

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -304,6 +304,12 @@ class CorpusTests(unittest.TestCase):
         sel = c[...]
         self.assertEqual(sel, c)
 
+        sel = c[range(0, 5)]
+        self.assertEqual(len(sel), 5)
+        self.assertEqual(len(sel._tokens), 5)
+        np.testing.assert_equal(sel._tokens, c._tokens[0:5])
+        self.assertEqual(sel._dictionary, c._dictionary)
+
     def test_set_text_features(self):
         c = Corpus.from_file('friends-transcripts')[:100]
         c2 = c.copy()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Corpus fails when indexing with range, which is not uncommon in Orange.

##### Description of changes
Support range as an indexing option.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
