### PR TITLE
Corpus: make variables name unique when extending

### DIFF
--- a/orangecontrib/text/sentiment/__init__.py
+++ b/orangecontrib/text/sentiment/__init__.py
@@ -32,7 +32,7 @@ class LiuHuSentiment:
         self.positive = set(self.methods[self.language].positive())
         self.negative = set(self.methods[self.language].negative())
 
-    def transform(self, corpus, copy=True):
+    def transform(self, corpus):
         scores = []
         corpus = WordPunctTokenizer()(corpus)
 
@@ -47,9 +47,7 @@ class LiuHuSentiment:
         cv = [VectorizationComputeValue(shared_cv, col)
               for col in self.sentiments]
 
-        if copy:
-            corpus = corpus.copy()
-        corpus.extend_attributes(X, self.sentiments, compute_values=cv)
+        corpus = corpus.extend_attributes(X, self.sentiments, compute_values=cv)
         return corpus
 
 
@@ -61,7 +59,7 @@ class VaderSentiment:
     def __init__(self):
         self.vader = SentimentIntensityAnalyzer()
 
-    def transform(self, corpus, copy=True):
+    def transform(self, corpus):
         scores = []
         for text in corpus.documents:
             pol_sc = self.vader.polarity_scores(text)
@@ -73,9 +71,7 @@ class VaderSentiment:
         cv = [VectorizationComputeValue(shared_cv, col)
               for col in self.sentiments]
 
-        if copy:
-            corpus = corpus.copy()
-        corpus.extend_attributes(X, self.sentiments, compute_values=cv)
+        corpus = corpus.extend_attributes(X, self.sentiments, compute_values=cv)
         return corpus
 
 
@@ -110,7 +106,7 @@ class MultiSentiment:
             code = self.LANGS[self._language]
             self.positive, self.negative = self.dictionaries[code]
 
-    def transform(self, corpus, copy=True):
+    def transform(self, corpus):
         self.load_dict()
         scores = []
         corpus = WordPunctTokenizer()(corpus)
@@ -126,9 +122,7 @@ class MultiSentiment:
         cv = [VectorizationComputeValue(shared_cv, col)
               for col in self.sentiments]
 
-        if copy:
-            corpus = corpus.copy()
-        corpus.extend_attributes(X, self.sentiments, compute_values=cv)
+        corpus = corpus.extend_attributes(X, self.sentiments, compute_values=cv)
         return corpus
 
     @property

--- a/orangecontrib/text/tests/test_bowvectorizer.py
+++ b/orangecontrib/text/tests/test_bowvectorizer.py
@@ -117,6 +117,24 @@ class BowVectorizationTest(unittest.TestCase):
         out = vect.transform(corpus)
         self.assertEqual(out, corpus)
 
+    def tests_duplicated_names(self):
+        """
+        BOW adds words to the domain and if same attribute name already appear
+        in the domain it renames it and add number to the existing attribute
+        name
+        """
+        corpus = Corpus.from_file("deerwester")
+        corpus = corpus.extend_attributes(np.ones((len(corpus), 1)), ["human"])
+        corpus = corpus.extend_attributes(np.ones((len(corpus), 1)), ["testtest"])
+        vect = BowVectorizer()
+        out = vect.transform(corpus)
+        # first attribute is in the dataset before bow and should be renamed
+        self.assertEqual("human (1)", out.domain[0].name)
+        self.assertEqual("testtest", out.domain[1].name)
+        # all attributes from [1:] are are bow attributes and should include
+        # human
+        self.assertIn("human", [v.name for v in out.domain.attributes[1:]])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/text/tests/test_sentiment.py
+++ b/orangecontrib/text/tests/test_sentiment.py
@@ -47,6 +47,7 @@ class LiuHuTest(unittest.TestCase):
                          len(self.corpus.domain) + self.new_cols)
         self.assertEqual(len(sentiment), 0)
 
+
 class LiuHuSlovenian(unittest.TestCase):
     def setUp(self):
         self.corpus = Corpus.from_file('slo-opinion-corpus')

--- a/orangecontrib/text/tests/test_vectorization_base.py
+++ b/orangecontrib/text/tests/test_vectorization_base.py
@@ -21,9 +21,9 @@ class BaseVectorizationTest(unittest.TestCase):
             3: 'a',
         }
 
-        BaseVectorizer.add_features(c1, X, dictionary,
+        c1 = BaseVectorizer.add_features(c1, X, dictionary,
                                     compute_values=None, var_attrs=None)
-        BaseVectorizer.add_features(c2, X, dictionary,
+        c2 = BaseVectorizer.add_features(c2, X, dictionary,
                                     compute_values=None, var_attrs={'foo': 1})
 
         n_attrs_before = len(c1.domain.attributes[0].attributes)

--- a/orangecontrib/text/topics/topics.py
+++ b/orangecontrib/text/topics/topics.py
@@ -74,10 +74,13 @@ class GensimWrapper:
         """ Create a table with topics representation. """
         topics = self.model[corpus.ngrams_corpus]
         self.actual_topics = self.model.get_topics().shape[0]
-        matrix = matutils.corpus2dense(topics, num_docs=len(corpus),
-                                       num_terms=self.num_topics).T.astype(np.float64)
-        corpus.extend_attributes(matrix[:, :self.actual_topics],
-                                 self.topic_names[:self.actual_topics])
+        matrix = matutils.corpus2dense(
+            topics, num_docs=len(corpus), num_terms=self.num_topics
+        ).T.astype(np.float64)
+        corpus = corpus.extend_attributes(
+            matrix[:, :self.actual_topics],
+            self.topic_names[:self.actual_topics]
+        )
         self.doc_topic = matrix[:, :self.actual_topics]
         self.tokens = corpus.tokens
         corpus.store_tokens(self.tokens)

--- a/orangecontrib/text/tweet_profiler.py
+++ b/orangecontrib/text/tweet_profiler.py
@@ -26,7 +26,6 @@ class TweetProfiler:
         if not self.assure_server():
             return None
 
-        corpus = corpus.copy()
         metas_ind = corpus.domain.metas.index(meta_var)
         tweets = corpus.metas[:, metas_ind].tolist()
 
@@ -70,10 +69,12 @@ class TweetProfiler:
                 feature_names = class_vars
                 feature_values = tuple(['no', 'yes'] for _ in class_vars)
 
-            corpus.extend_attributes(results,
-                                     feature_names=feature_names,
-                                     feature_values=feature_values,
-                                     var_attrs=var_attrs)
+            corpus = corpus.extend_attributes(
+                results,
+                feature_names=feature_names,
+                feature_values=feature_values,
+                var_attrs=var_attrs
+            )
             return corpus
         else:
             return None

--- a/orangecontrib/text/vectorization/bagofwords.py
+++ b/orangecontrib/text/vectorization/bagofwords.py
@@ -87,7 +87,7 @@ class BowVectorizer(BaseVectorizer):
         cv = [VectorizationComputeValue(shared_cv, dic[i])
               for i in range(len(dic))]
 
-        self.add_features(corpus, X, dic, cv, var_attrs={'bow-feature': True})
+        corpus = self.add_features(corpus, X, dic, cv, var_attrs={'bow-feature': True})
         return corpus
 
     def report(self):

--- a/orangecontrib/text/vectorization/base.py
+++ b/orangecontrib/text/vectorization/base.py
@@ -1,7 +1,43 @@
+from itertools import chain
+
 import numpy as np
 from gensim import matutils
 
 from Orange.data.util import SharedComputeValue
+from Orange.data import Domain
+
+# uncomment when Orange3==3.27 is available
+# from Orange.data.util import get_unique_names
+
+
+# remove following section when orange3=3.27 is available
+import re
+
+RE_FIND_INDEX = r"(^{})( \((\d{{1,}})\))?$"
+
+
+def get_indices(names, name):
+    return [int(a.group(3) or 0) for x in filter(None, names)
+            for a in re.finditer(RE_FIND_INDEX.format(re.escape(name)), x)]
+
+
+def get_unique_names(names, proposed, equal_numbers=True):
+    # prevent cyclic import: pylint: disable=import-outside-toplevel
+    if isinstance(names, Domain):
+        names = [var.name for var in chain(names.variables, names.metas)]
+    if isinstance(proposed, str):
+        return get_unique_names(names, [proposed])[0]
+    indices = {name: get_indices(names, name) for name in proposed}
+    indices = {name: max(ind) + 1 for name, ind in indices.items() if ind}
+    if not (set(proposed) & set(names) or indices):
+        return proposed
+    if equal_numbers:
+        max_index = max(indices.values())
+        return [f"{name} ({max_index})" for name in proposed]
+    else:
+        return [f"{name} ({indices[name]})" if name in indices else name
+                for name in proposed]
+# ----
 
 
 class BaseVectorizer:
@@ -36,12 +72,17 @@ class BaseVectorizer:
         if isinstance(var_attrs, dict):
             variable_attrs.update(var_attrs)
 
-        corpus.extend_attributes(X[:, order],
-                                 feature_names=(dictionary[i] for i in order),
-                                 var_attrs=variable_attrs,
-                                 compute_values=compute_values,
-                                 sparse=True)
+        feature_names = [dictionary[i] for i in order]
+        corpus = corpus.extend_attributes(
+            X[:, order],
+            feature_names=feature_names,
+            var_attrs=variable_attrs,
+            compute_values=compute_values,
+            sparse=True,
+            rename_existing=True
+        )
         corpus.ngrams_corpus = matutils.Sparse2Corpus(X.T)
+        return corpus
 
 
 class SharedTransform:
@@ -55,9 +96,8 @@ class SharedTransform:
     def __call__(self, corpus):
         if callable(self.preprocessor):
             corpus = self.preprocessor(corpus)
-        corpus = self.vectorizer.transform(corpus,
-                                           copy=True,
-                                           **self.kwargs)
+        corpus = self.vectorizer.transform(corpus, **self.kwargs)
+
         # store name to indices mapping so SharedComputeValue can run faster
         corpus.feature_name_to_index = {
             attr.name: i

--- a/orangecontrib/text/vectorization/document_embedder.py
+++ b/orangecontrib/text/vectorization/document_embedder.py
@@ -59,16 +59,13 @@ class DocumentEmbedder:
                                          server_url='https://apiv2.garaza.io',
                                          embedder_type='text')
 
-    def __call__(self, corpus: Corpus, copy: bool = True,
-                 processed_callback=None) -> Corpus:
+    def __call__(self, corpus: Corpus, processed_callback=None) -> Corpus:
         """Adds matrix of document embeddings to a corpus.
 
         Parameters
         ----------
         corpus : Corpus
             Corpus on which transform is performed.
-        copy : bool
-            If set to True, a copy of corpus is made.
 
         Returns
         -------
@@ -85,7 +82,6 @@ class DocumentEmbedder:
         """
         if not isinstance(corpus, Corpus):
             raise ValueError("Input should be instance of Corpus.")
-        corpus = corpus.copy() if copy else corpus
         embs = self._embedder.embedd_data(
             list(corpus.ngrams),
             processed_callback=processed_callback)
@@ -117,10 +113,11 @@ class DocumentEmbedder:
         if len(inds) > 0:
             # if at least one embedding is not None,
             # extend attributes
-            new_corpus.extend_attributes(
+            new_corpus = new_corpus.extend_attributes(
                 np.array(embs[inds]),
                 ['Dim{}'.format(i + 1) for i in range(dim)],
-                var_attrs=variable_attrs)
+                var_attrs=variable_attrs
+            )
 
         if send_warning:
             warnings.warn(("Some documents were not embedded for " +

--- a/orangecontrib/text/vectorization/simhash.py
+++ b/orangecontrib/text/vectorization/simhash.py
@@ -44,11 +44,13 @@ class SimhashVectorizer(BaseVectorizer):
         """
 
         X = np.array([self.int2binarray(self.compute_hash(doc)) for doc in corpus.tokens], dtype=np.float)
-        corpus = corpus.copy()
-        corpus.extend_attributes(X,
-                                 feature_names=('simhash_{}'.format(int(i) + 1)
-                                                for i in range(self.f)),
-                                 var_attrs={'hidden': True})
+        corpus = corpus.extend_attributes(
+            X,
+            feature_names=[
+                'simhash_{}'.format(int(i) + 1) for i in range(self.f)
+            ],
+            var_attrs={'hidden': True}
+        )
         return corpus
 
     def report(self):

--- a/orangecontrib/text/widgets/owstatistics.py
+++ b/orangecontrib/text/widgets/owstatistics.py
@@ -661,17 +661,10 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
                     comput_values.append(comp_value)
         if not_computed:
             self.Warning.not_computed(", ".join(not_computed))
-        # here we will use extend_attributes function - this function add
-        # attributes to existing corpus so it must be copied first
-        # TODO: when change of pre-processing is finished change this function
-        #  to have inplace parameter which is False by default,
-        #  also I would prefer extend_attriubtes where you give variables
-        #  instead of strings on input
-        new_corpus = self.corpus.copy()
-        if to_stack:
-            new_corpus.extend_attributes(
-                np.hstack(to_stack), attributes, compute_values=comput_values
-            )
+        new_corpus = self.corpus.extend_attributes(
+            np.hstack(to_stack) if to_stack else np.empty((len(self.corpus), 0)),
+            attributes, compute_values=comput_values
+        )
         self.Outputs.corpus.send(new_corpus)
 
         # summary

--- a/orangecontrib/text/widgets/tests/test_owcorpus.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpus.py
@@ -248,9 +248,9 @@ class TestOWCorpus(WidgetTest):
         attributes = [
             ContinuousVariable("a"), ContinuousVariable("b"),
             ContinuousVariable("c")]
-        metas = [StringVariable("c"), StringVariable("d"),
-                 StringVariable("e"), StringVariable("f"),
-                 StringVariable("g"), StringVariable("h")]
+        metas = [StringVariable("d"), StringVariable("e"),
+                 StringVariable("f"), StringVariable("g"),
+                 StringVariable("h"), StringVariable("i")]
         data = Table(
             Domain(attributes, metas=metas),
             np.array([[0] * len(attributes)]),

--- a/orangecontrib/text/widgets/tests/test_owworldcloud.py
+++ b/orangecontrib/text/widgets/tests/test_owworldcloud.py
@@ -62,7 +62,7 @@ class TestWorldCloudWidget(WidgetTest):
         based on BOW weights.
         """
         data = self.corpus[:3]
-        data.extend_attributes(
+        data = data.extend_attributes(
             csr_matrix([[3, 2, 0], [0, 3, 6], [0, 1, 0]]),
             ["Word1", "Word2", "Word3"])
         for v in data.domain.attributes:
@@ -87,7 +87,7 @@ class TestWorldCloudWidget(WidgetTest):
 
         # try with one word not bow-feature
         data = self.corpus[:3]
-        data.extend_attributes(
+        data = data.extend_attributes(
             csr_matrix([[3, 2, 0], [0, 3, 6], [0, 1, 0]]),
             ["Word1", "Word2", "Word3"])
         for v in data.domain.attributes[:2]:
@@ -125,7 +125,7 @@ class TestWorldCloudWidget(WidgetTest):
         self.assertFalse(self.widget.Info.bow_weights.is_shown())
 
         # send bow data
-        data.extend_attributes(
+        data = data.extend_attributes(
             csr_matrix([[3, 2, 0], [0, 3, 6], [0, 1, 0]]),
             ["Word1", "Word2", "Word3"])
         for v in data.domain.attributes:

--- a/orangecontrib/text/widgets/utils/owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/owbasevectorizer.py
@@ -1,4 +1,3 @@
-
 from AnyQt.QtWidgets import QGroupBox, QVBoxLayout
 
 from Orange.widgets import gui


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When corpus is extended variable name uniqueness is not assured

##### Description of changes
- Make new variable names unique when adding corpus
- Change `extend_attributes` to return a new copy of the corpus

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
