### PR TITLE
Topic Modeling: set dtype of models to float64

### DIFF
--- a/orangecontrib/text/tests/test_topic_modeling.py
+++ b/orangecontrib/text/tests/test_topic_modeling.py
@@ -92,6 +92,7 @@ class LDATests(unittest.TestCase, BaseTests):
         corpus = super().test_fit_transform()
         self.assertEqual(len(corpus.domain.attributes), 5)
         self.assertEqual(corpus.X.shape, (len(self.corpus), 5))
+        self.assertEqual(corpus.X.dtype, np.float64)
 
 
 class HdpTest(unittest.TestCase, BaseTests):

--- a/orangecontrib/text/topics/lda.py
+++ b/orangecontrib/text/topics/lda.py
@@ -1,3 +1,4 @@
+from numpy import float64
 from gensim import models
 
 from .topics import GensimWrapper
@@ -6,3 +7,6 @@ from .topics import GensimWrapper
 class LdaWrapper(GensimWrapper):
     name = 'Latent Dirichlet Allocation'
     Model = models.LdaModel
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs, dtype=float64)

--- a/orangecontrib/text/topics/lsi.py
+++ b/orangecontrib/text/topics/lsi.py
@@ -1,3 +1,4 @@
+from numpy import float64
 from gensim import models
 
 from .topics import GensimWrapper
@@ -10,3 +11,6 @@ class LsiWrapper(GensimWrapper):
     name = 'Latent Semantic Indexing'
     Model = models.LsiModel
     has_negative_weights = True
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs, dtype=float64)

--- a/orangecontrib/text/topics/topics.py
+++ b/orangecontrib/text/topics/topics.py
@@ -75,7 +75,7 @@ class GensimWrapper:
         topics = self.model[corpus.ngrams_corpus]
         self.actual_topics = self.model.get_topics().shape[0]
         matrix = matutils.corpus2dense(topics, num_docs=len(corpus),
-                                       num_terms=self.num_topics).T
+                                       num_terms=self.num_topics).T.astype(np.float64)
         corpus.extend_attributes(matrix[:, :self.actual_topics],
                                  self.topic_names[:self.actual_topics])
         self.doc_topic = matrix[:, :self.actual_topics]

--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -369,7 +369,7 @@ class HTMLDelegate(QStyledItemDelegate):
         doc = QtGui.QTextDocument()
         doc.setHtml(options.text)
         doc.setTextWidth(options.rect.width())
-        return QtCore.QSize(doc.idealWidth(), doc.size().height())
+        return QtCore.QSize(int(doc.idealWidth()), int(doc.size().height()))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/4877.
Topic Modeling output matrix of dtype float32, which caused HeatMap to crash.

##### Description of changes
Cast matrix to float64.
Set explicit SizeHint to remove deprecation warning.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
