### PR TITLE
[FIX] Preprocess: Retain corpus ids

### DIFF
--- a/orangecontrib/text/preprocess/preprocess.py
+++ b/orangecontrib/text/preprocess/preprocess.py
@@ -20,7 +20,9 @@ class Preprocessor:
         :return: Corpus
             Preprocessed corpus.
         """
+        ids = corpus.ids
         corpus = corpus.copy()
+        corpus.ids = ids
         corpus.used_preprocessor = self
         return corpus
 

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -109,6 +109,12 @@ class PreprocessTests(unittest.TestCase):
         corpus = p(self.corpus)
         self.assertIsNot(corpus, self.corpus)
 
+    def test_retain_ids(self):
+        corpus = self.corpus
+        for pp in self.pp_list:
+            corpus = pp(corpus)
+        self.assertTrue((corpus.ids == self.corpus.ids).all())
+
 
 class TransformationTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/4905

##### Description of changes
Copy corpus.ids when preprocessing.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
