### PR TITLE
[FIX] Corpus: fix deprecated use of array

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -359,7 +359,7 @@ class Corpus(Table):
         Args:
             tokens (list): List of lists containing tokens.
         """
-        self._tokens = np.array(tokens)
+        self._tokens = np.array(tokens, dtype=object)
         self._dictionary = dictionary or corpora.Dictionary(self.tokens)
 
     @property


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-text/issues/561


