### PR TITLE
Dependency update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ setuptools-git
 Orange3 >=3.25.0
 tweepy
 beautifulsoup4
-simhash~=1.9.0  # simhash 1.10 requires gmpy2 which needs additional libraries for compilation and does not have mac/linux precompiled pypi packages
+simhash >=1.11
 wikipedia
 pdfminer3k>=1.3.1
 odfpy>=1.3.5
@@ -17,4 +17,3 @@ docx2txt>=0.6
 lxml
 biopython # Enables Pubmed widget.
 ufal.udpipe >=1.2.0.3
-ply  # temporary fix for: https://github.com/canserhat77/pdfminer3k/issues


### PR DESCRIPTION
- simhash got rid of gmpy2 in >=1.11, so dependency can be unfixed.
- pdfminer got fixed and ply is not necessary anymore