### PR TITLE
[ENH] Document embedders: additional languages

### DIFF
--- a/orangecontrib/text/vectorization/document_embedder.py
+++ b/orangecontrib/text/vectorization/document_embedder.py
@@ -15,7 +15,39 @@ from orangecontrib.text import Corpus
 
 AGGREGATORS = ['Mean', 'Sum', 'Max', 'Min']
 AGGREGATORS_L = ['mean', 'sum', 'max', 'min']
-LANGS_TO_ISO = {'English': 'en', 'Slovenian': 'sl', 'German': 'de'}
+LANGS_TO_ISO = {
+    'English': 'en',
+    'Slovenian': 'sl',
+    'German': 'de',
+    'Arabic': 'ar',
+    'Azerbaijani': 'az',
+    'Bengali': 'bn',
+    'Chinese': 'zh',
+    'Danish': 'da',
+    'Dutch': 'nl',
+    'Finnish': 'fi',
+    'French': 'fr',
+    'Greek': 'el',
+    'Hebrew': 'he',
+    'Hindi': 'hi',
+    'Hungarian': 'hu',
+    'Indonesian': 'id',
+    'Italian': 'it',
+    'Japanese': 'ja',
+    'Kazakh': 'kk',
+    'Korean': 'ko',
+    'Nepali': 'ne',
+    'Norwegian (Bokm\u00e5l)': 'no',
+    'Norwegian (Nynorsk)': 'nn',
+    'Polish': 'pl',
+    'Portuguese': 'pt',
+    'Romanian': 'ro',
+    'Russian': 'ru',
+    'Spanish': 'es',
+    'Swedish': 'sv',
+    'Tajik': 'tg',
+    'Turkish': 'tr'
+}
 LANGUAGES = list(LANGS_TO_ISO.values())
 
 

--- a/orangecontrib/text/widgets/owdocumentembedding.py
+++ b/orangecontrib/text/widgets/owdocumentembedding.py
@@ -88,7 +88,7 @@ class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
         OWWidget.__init__(self)
         ConcurrentWidgetMixin.__init__(self)
 
-        self.languages = list(LANGS_TO_ISO.keys())
+        self.languages = sorted(list(LANGS_TO_ISO.keys()))
         self.aggregators = AGGREGATORS
         self.corpus = None
         self.new_corpus = None
@@ -104,13 +104,17 @@ class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
 
         widget_box = widgetBox(self.controlArea, 'Settings')
 
-        self.language_cb = comboBox(widget=widget_box,
-                                    master=self,
-                                    value='language',
-                                    label='Language: ',
-                                    orientation=Qt.Horizontal,
-                                    items=self.languages,
-                                    callback=self._option_changed)
+        self.language_cb = comboBox(
+            widget=widget_box,
+            master=self,
+            value='language',
+            label='Language: ',
+            orientation=Qt.Horizontal,
+            items=self.languages,
+            callback=self._option_changed,
+            searchable=True
+         )
+        self.language_cb.setCurrentText("English")
 
         self.aggregator_cb = comboBox(widget=widget_box,
                                       master=self,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Document embedders currently support only three languages.

##### Description of changes
With this PR we add support for 28 additional languages.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
