### PR TITLE
[FIX] Import documents: normalize imported text and file names

### DIFF
--- a/orangecontrib/text/import_documents.py
+++ b/orangecontrib/text/import_documents.py
@@ -6,6 +6,7 @@ import re
 
 from collections import namedtuple
 from types import SimpleNamespace as namespace
+from unicodedata import normalize
 
 import numpy as np
 
@@ -199,9 +200,16 @@ class ImportDocuments:
         category_var = DiscreteVariable.make("category", values=values)
         for textdata in self._text_data:
             data.append(
-                [textdata.name,
-                 textdata.path,
-                 textdata.content]
+                [
+                    # some characters are written as decomposed (č is char c
+                    # and separate char for caron), with NFC normalization we
+                    # normalize them to be written as precomposed (č is one
+                    # unicode char - 0x10D)
+                    # https://docs.python.org/3/library/unicodedata.html#unicodedata.normalize
+                    normalize('NFC', textdata.name),
+                    normalize('NFC', textdata.path),
+                    normalize('NFC', textdata.content)
+                ]
             )
             category_data.append(category_var.to_val(textdata.category))
         if len(text_categories) > 1:

--- a/orangecontrib/text/widgets/tests/data/good/sample_txt.txt
+++ b/orangecontrib/text/widgets/tests/data/good/sample_txt.txt
@@ -1,1 +1,0 @@
-This is a test txt file

--- a/orangecontrib/text/widgets/tests/data/good/sample_txt_ž.txt
+++ b/orangecontrib/text/widgets/tests/data/good/sample_txt_ž.txt
@@ -1,0 +1,1 @@
+This is a test txt_ž file

--- a/orangecontrib/text/widgets/tests/test_owimportdocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owimportdocuments.py
@@ -30,14 +30,18 @@ class TestOWImportDocuments(WidgetTest):
         self.assertEqual(3, len(output.domain.metas))
         names = output.get_column_view("name")[0]
         self.assertListEqual(
-            ["sample_docx", "sample_odt", "sample_pdf", "sample_txt"],
+            # ž in sample_text_ž must be unicode char 0x17E not decomposed
+            # 0x7A + 0x30C as it is in file name
+            ["sample_docx", "sample_odt", "sample_pdf", "sample_txt_ž"],
             sorted(names.tolist()),
         )
         texts = output.get_column_view("content")[0]
         self.assertListEqual(
+            # ž in sample_text_ž must be unicode char 0x17E not decomposed
+            # 0x7A + 0x30C as it is in file name
             [
                 f"This is a test {x} file"
-                for x in ["docx", "odt", "pdf", "txt"]
+                for x in ["docx", "odt", "pdf", "txt_ž"]
             ],
             sorted([x.strip() for x in texts.tolist()]),
         )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Filename (and potentially text too) can contain characters that are written in decompose form (č is composed as a char c and separate caron). It causes problems when we filter documents (user inputs č as precomposed Unicode char).

##### Description of changes
With this PR text is normalized (all decomposed chars are changed to precomposed) before outputted from the widget

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
