### PR TITLE
Document embedder handle skipped and long documents

### DIFF
--- a/orangecontrib/text/vectorization/document_embedder.py
+++ b/orangecontrib/text/vectorization/document_embedder.py
@@ -59,7 +59,7 @@ class DocumentEmbedder:
                                          server_url='https://apiv2.garaza.io',
                                          embedder_type='text')
 
-    def __call__(self, corpus: Corpus, processed_callback=None) -> Corpus:
+    def __call__(self, corpus: Corpus, processed_callback=None) -> Tuple[Corpus, Corpus]:
         """Adds matrix of document embeddings to a corpus.
 
         Parameters
@@ -69,8 +69,10 @@ class DocumentEmbedder:
 
         Returns
         -------
-        Corpus
+        Embeddings
             Corpus (original or a copy) with new features added.
+        Skipped images
+            Corpus of images that were not embedded
 
         Raises
         ------
@@ -94,38 +96,35 @@ class DocumentEmbedder:
                 break
         # Check if some documents in corpus in weren't embedded
         # for some reason. This is a very rare case.
-        inds = list()
-        for i, emb in enumerate(embs):
-            if emb is not None:
-                inds.append(i)
-            else:
-                embs[i] = np.zeros(dim) * np.nan
-                send_warning = True
+        skipped_documents = [emb is None for emb in embs]
+        embedded_documents = np.logical_not(skipped_documents)
 
         variable_attrs = {
             'hidden': True,
             'skip-normalization': True,
             'embedding-feature': True
         }
-        embs = np.array(embs)
-        new_corpus = corpus[inds]
 
-        if len(inds) > 0:
-            # if at least one embedding is not None,
-            # extend attributes
+        new_corpus = None
+        if np.any(embedded_documents):
+            # if at least one embedding is not None, extend attributes
+            new_corpus = corpus[embedded_documents]
             new_corpus = new_corpus.extend_attributes(
-                np.array(embs[inds]),
+                np.array([e for e, ns in zip(embs, embedded_documents) if ns], dtype=float),
                 ['Dim{}'.format(i + 1) for i in range(dim)],
                 var_attrs=variable_attrs
             )
 
-        if send_warning:
+        skipped_corpus = None
+        if np.any(skipped_documents):
+            skipped_corpus = corpus[skipped_documents].copy()
+            skipped_corpus.name = "Skipped documents"
             warnings.warn(("Some documents were not embedded for " +
                            "unknown reason. Those documents " +
                            "are skipped."),
                           RuntimeWarning)
 
-        return new_corpus
+        return new_corpus, skipped_corpus
 
     def report(self) -> Tuple[Tuple[str, str], Tuple[str, str]]:
         """Reports on current parameters of DocumentEmbedder.
@@ -169,10 +168,10 @@ class _ServerEmbedder(ServerEmbedderCommunicator):
         data = base64.b64encode(zlib.compress(
             data_string.encode('utf-8', 'replace'),
             level=-1)).decode('utf-8', 'replace')
-
         if sys.getsizeof(data) > 50000:
-            raise RuntimeError("Document in corpus is too large. \
-                                Size limit is 50 KB (after compression).")
+            # Document in corpus is too large. Size limit is 50 KB
+            # (after compression). - document skipped
+            return None
 
         data_dict = {
             "data": data,

--- a/orangecontrib/text/vectorization/document_embedder.py
+++ b/orangecontrib/text/vectorization/document_embedder.py
@@ -24,7 +24,8 @@ class DocumentEmbedder:
     corpus using fastText pretrained models from:
     E. Grave, P. Bojanowski, P. Gupta, A. Joulin, T. Mikolov,
     Learning Word Vectors for 157 Languages.
-    Proceedings of the International Conference on Language Resources and Evaluation, 2018.
+    Proceedings of the International Conference on Language Resources and
+    Evaluation, 2018.
 
     Embedding is performed on server so the internet connection is a
     prerequisite for using the class. Currently supported languages are:
@@ -59,7 +60,9 @@ class DocumentEmbedder:
                                          server_url='https://apiv2.garaza.io',
                                          embedder_type='text')
 
-    def __call__(self, corpus: Corpus, processed_callback=None) -> Tuple[Corpus, Corpus]:
+    def __call__(
+        self, corpus: Corpus, processed_callback=None
+    ) -> Tuple[Corpus, Corpus]:
         """Adds matrix of document embeddings to a corpus.
 
         Parameters
@@ -71,16 +74,13 @@ class DocumentEmbedder:
         -------
         Embeddings
             Corpus (original or a copy) with new features added.
-        Skipped images
-            Corpus of images that were not embedded
+        Skipped documents
+            Corpus of documents that were not embedded
 
         Raises
         ------
         ValueError
             If corpus is not instance of Corpus.
-        RuntimeError
-            If document in corpus is larger than
-            50 KB after compression.
         """
         if not isinstance(corpus, Corpus):
             raise ValueError("Input should be instance of Corpus.")
@@ -89,7 +89,6 @@ class DocumentEmbedder:
             processed_callback=processed_callback)
 
         dim = None
-        send_warning = False
         for emb in embs:  # find embedding dimension
             if emb is not None:
                 dim = len(emb)
@@ -110,7 +109,10 @@ class DocumentEmbedder:
             # if at least one embedding is not None, extend attributes
             new_corpus = corpus[embedded_documents]
             new_corpus = new_corpus.extend_attributes(
-                np.array([e for e, ns in zip(embs, embedded_documents) if ns], dtype=float),
+                np.array(
+                    [e for e, ns in zip(embs, embedded_documents) if ns],
+                    dtype=float,
+                ),
                 ['Dim{}'.format(i + 1) for i in range(dim)],
                 var_attrs=variable_attrs
             )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Hopefully fixes https://github.com/biolab/orange3-text/issues/571

In my case, the problem is that some documents are too long and we limit the maximum length of the document that can be sent to the server. In those cases, a runtime error is raised.

##### Description of changes
With this PR:
- we enable that only documents that re too long are skipped and that embedding process is not interrupted than before
- we add a signal to the widget that shows the skipped documents - similarly than in Image Embedding widget

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
