### PR TITLE
fixed ZeroDivisionError on line 233 in perc_unique

### DIFF
--- a/orangecontrib/text/widgets/owstatistics.py
+++ b/orangecontrib/text/widgets/owstatistics.py
@@ -230,6 +230,8 @@ def per_cent_unique_words(
 
     def perc_unique(tokens: str):
         callback()
+        if not tokens:
+            return np.nan
         return len(set(tokens)) / len(tokens)
 
     return np.c_[list(map(perc_unique, corpus.tokens))], ["% unique words"]

--- a/orangecontrib/text/widgets/tests/test_owstatistics.py
+++ b/orangecontrib/text/widgets/tests/test_owstatistics.py
@@ -168,6 +168,12 @@ class TestStatisticsWidget(WidgetTest):
             data.X.flatten(), [1, 1, 0.909091, 1]
         )
 
+        self.corpus[1][-1] = ""
+        data = self._compute_features("Per cent unique words")
+        np.testing.assert_array_almost_equal(
+            data.X.flatten(), [1, np.nan, 0.909091, 1]
+        )
+        
         self.send_signal(self.widget.Inputs.corpus, None)
         self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
 


### PR DESCRIPTION
##### Issue
- Statistics: division by zero #573



##### Description of changes
- fixed the bug on line 233 (function perc_unique) in orangecontrib/text/widgets/owstatistics.py

- _Included_ conditional check of the tokens