### PR TITLE
Document Embedder: Increase maximal package size

### DIFF
--- a/orangecontrib/text/vectorization/document_embedder.py
+++ b/orangecontrib/text/vectorization/document_embedder.py
@@ -170,8 +170,8 @@ class _ServerEmbedder(ServerEmbedderCommunicator):
         data = base64.b64encode(zlib.compress(
             data_string.encode('utf-8', 'replace'),
             level=-1)).decode('utf-8', 'replace')
-        if sys.getsizeof(data) > 50000:
-            # Document in corpus is too large. Size limit is 50 KB
+        if sys.getsizeof(data) > 500000:
+            # Document in corpus is too large. Size limit is 500 KB
             # (after compression). - document skipped
             return None
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Embedder did not embed longer text due to the limit of the maximum package size.

##### Description of changes
With this PR maximal package size is increased.
I talked with Matjaz and he said the package size of 500KB is not a problem. I also tested with longer texts and it works. With this limit, the user can embed quite a long book (500 pages).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
