### PR TITLE
[FIX] Simhash: Fix error when hash function is None

### DIFF
--- a/orangecontrib/text/vectorization/simhash.py
+++ b/orangecontrib/text/vectorization/simhash.py
@@ -27,7 +27,11 @@ class SimhashVectorizer(BaseVectorizer):
         return map(lambda x: ''.join(x), nltk.ngrams(tokens, n))
 
     def compute_hash(self, tokens):
-        return Simhash(self.get_shingles(tokens, self.ngram_len), f=self.f, hashfunc=self.hashfunc).value
+        values = self.get_shingles(tokens, self.ngram_len)
+        if self.hashfunc is None:
+            return Simhash(values, f=self.f).value
+        else:
+            return Simhash(values, f=self.f, hashfunc=self.hashfunc).value
 
     def int2binarray(self, num):
         return [int(x) for x in self._bin_format.format(num)]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Smash slightly changed behaviour of the `Simhash` class in the version 2.0.0. The constructor does not handle `None` as a `hashfunction` parameter anymore.

##### Description of changes
Change call such that when `hashfunction` is None, the parameter is not passed and so the default parameter is used.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
