### PR TITLE
Revert "Limit NLTK version"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scipy
-nltk>=3.0.5,<3.5  # TODO: change when fixed: https://bitbucket.org/mrabarnett/mrab-regex/issues/369/please-provide-macos-wheels-on-pypi
+nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
 scikit-learn
 numpy
 python-dateutil<3.0.0  # denpendency for botocore


### PR DESCRIPTION
Reverts biolab/orange3-text#523

Regex now provide wheels for MacOS, I think it can be reverted now