### PR TITLE
[FIX] Corpus: extend_attributes retain preprocessing

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -363,7 +363,7 @@ class Corpus(Table):
                 class_vars=curr_class_var,
                 metas=curr_metas
         )
-        return Corpus(
+        c = Corpus(
             new_domain,
             X,
             self.Y.copy(),
@@ -371,6 +371,8 @@ class Corpus(Table):
             self.W.copy(),
             copy(self.text_features)
         )
+        Corpus.retain_preprocessing(self, c)
+        return c
 
     @property
     def documents(self):

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -144,6 +144,24 @@ class CorpusTests(unittest.TestCase):
         new_c = c.extend_attributes(X, ['Text', '2',], rename_existing=True)
         self.assertEqual(new_c.X.shape, (len(c), 2))
 
+    def test_extend_attributes_keep_preprocessing(self):
+        """
+        Test if preprocessing remains when extending attributes
+        """
+        c = Corpus.from_file("book-excerpts")
+        c.store_tokens(c.tokens)
+
+        X = np.random.random((len(c), 3))
+        new_c = c.extend_attributes(X, ["1", "2", "3"])
+        self.assertEqual(new_c.X.shape, (len(c), 3))
+
+        self.assertEqual(len(new_c._tokens), len(c))
+        np.testing.assert_equal(new_c._tokens, new_c._tokens)
+        self.assertEqual(new_c._dictionary, c._dictionary)
+        self.assertEqual(new_c.text_features, c.text_features)
+        self.assertEqual(new_c.ngram_range, c.ngram_range)
+        self.assertEqual(new_c.attributes, c.attributes)
+
     def test_corpus_not_eq(self):
         c = Corpus.from_file('book-excerpts')
         n_doc = c.X.shape[0]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Extend attributes creates a new corpus but do not retain preprocessing.

##### Description of changes
Fix extend attributes to retain the preprocessing.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
