### PR TITLE
Topic Modelling: Topic probabilites have to be floats

### DIFF
--- a/orangecontrib/text/tests/test_topic_modeling.py
+++ b/orangecontrib/text/tests/test_topic_modeling.py
@@ -27,6 +27,8 @@ class BaseTests:
         self.model.fit_transform(self.corpus)
         topics = self.model.get_all_topics_table()
         self.assertEqual(len(topics), self.model.actual_topics)
+        self.assertTrue(np.all([isinstance(i, float) for i in
+                                topics.metas[:, 1]]))
 
     def test_top_words_by_topic(self):
         self.model.fit(self.corpus)

--- a/orangecontrib/text/topics/topics.py
+++ b/orangecontrib/text/topics/topics.py
@@ -143,14 +143,18 @@ class GensimWrapper:
             X.append(weights)
         X = np.array(X)
 
+
         # take only first n_topics; e.g. when user requested 10, but gensim
         # returns only 9 — when the rank is lower than num_topics requested
-        names = np.array(self.topic_names[:n_topics])[:, None]
+        names = np.array(self.topic_names[:n_topics], dtype=object)[:, None]
+
         attrs = [ContinuousVariable(w) for w in sorted_words]
         metas = [StringVariable('Topics'),
                  ContinuousVariable('Marginal Topic Probability')]
 
-        topic_proba = self._marginal_probability(self.tokens, self.doc_topic)
+        topic_proba = np.array(self._marginal_probability(self.tokens,
+                                                          self.doc_topic),
+                               dtype=object)
 
         t = Table.from_numpy(Domain(attrs, metas=metas), X=X,
                              metas=np.hstack((names, topic_proba)))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
All topic output cast topic probabilities as strings, but the variable was declared as continuous. Caused issues downstream.

##### Description of changes
Cast metas to object, which keeps topic probabilities as floats.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
