### PR TITLE
LSI fix add_documents function update

### DIFF
--- a/orangecontrib/text/topics/lsi.py
+++ b/orangecontrib/text/topics/lsi.py
@@ -1,15 +1,26 @@
 from numpy import float64
-from gensim import models
+from gensim.models import LsiModel
 
 from .topics import GensimWrapper
 
-models.LsiModel.update = models.LsiModel.add_documents
-models.LsiModel.add_documents = lambda self, *args, **kwargs: self.update(*args, **kwargs)
+
+class LsiModelProxy(LsiModel):
+    update = LsiModel.add_documents
+
+    def add_documents(self, corpus, chunksize=None, decay=None):
+        """
+        add_documents calls update which is equal to super().add_documents
+
+        It is made because of mechanism in topics.py which disables update in
+        some cases. In case of Lsi disabling update must results in disabling
+        add_documents.
+        """
+        self.update(corpus, chunksize, decay)
 
 
 class LsiWrapper(GensimWrapper):
     name = 'Latent Semantic Indexing'
-    Model = models.LsiModel
+    Model = LsiModelProxy
     has_negative_weights = True
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In current implementation we insert update function in between add_documents call with:
```
models.LsiModel.update = models.LsiModel.add_documents	
models.LsiModel.add_documents = lambda self, *args, **kwargs: self.update(*args, **kwargs)
```
It causes problems when a module that does it is imported multiple time. In the first import `update` points to `add_documents` function in the Lsi module and it is ok. In the second import happens that `update` points to previously change `add_documents` which then recursively call itself.

It was working but is dangerous in cases when this module is imported multiple times.

##### Description of changes
Implementing the same behaviour with the inheritance - safe to multiple imports since we do not change the base module.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
