### PR TITLE
[FIX]Corpus fix from_numpy and from_list; modify widget to work with corpuses without text_features

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -554,14 +554,20 @@ class Corpus(Table):
 
     @classmethod
     def from_numpy(cls, *args, **kwargs):
-        c = super().from_numpy(*args, **kwargs)
-        c._set_unique_titles()
+        t = super().from_numpy(*args, **kwargs)
+        # t is corpus but its constructor was not called since from_numpy
+        # calls just class method __new__, call it here to set default values
+        # for attributes such as _titles, _tokens, preprocessors, text_features
+        c = Corpus(t.domain, t.X, t.Y, t.metas, t.W, ids=t.ids)
         return c
 
     @classmethod
     def from_list(cls, domain, rows, weights=None):
-        c = super().from_list(domain, rows, weights)
-        c._set_unique_titles()
+        t = super().from_list(domain, rows, weights)
+        # t is corpus but its constructor was not called since from_numpy
+        # calls just class method __new__, call it here to set default values
+        # for attributes such as _titles, _tokens, preprocessors, text_features
+        c = Corpus(t.domain, t.X, t.Y, t.metas, t.W, ids=t.ids)
         return c
 
     @classmethod

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -53,6 +53,32 @@ class CorpusTests(unittest.TestCase):
         c2 = Corpus.from_file('book-excerpts.tab')
         self.assertEqual(c, c2)
 
+    def test_corpus_from_numpy(self):
+        domain = Domain(
+            [], metas=[StringVariable("title"), StringVariable("a")]
+        )
+        corpus = Corpus.from_numpy(
+            domain,
+            np.empty((2, 0)),
+            metas=np.array([["title1", "a"], ["title2", "b"]])
+        )
+        self.assertEqual(2, len(corpus))
+        assert_array_equal(["Document 1", "Document 2"], corpus.titles)
+        self.assertListEqual([StringVariable("title")], corpus.text_features)
+        self.assertIsNone(corpus._tokens)
+        self.assertListEqual([], corpus.used_preprocessor.preprocessors)
+
+    def test_corpus_from_list(self):
+        domain = Domain(
+            [], metas=[StringVariable("title"), StringVariable("a")]
+        )
+        corpus = Corpus.from_list(domain, [["title1", "a"], ["title2", "b"]])
+        self.assertEqual(2, len(corpus))
+        assert_array_equal(["Document 1", "Document 2"], corpus.titles)
+        self.assertListEqual([StringVariable("title")], corpus.text_features)
+        self.assertIsNone(corpus._tokens)
+        self.assertListEqual([], corpus.used_preprocessor.preprocessors)
+
     def test_corpus_from_file_missing(self):
         with self.assertRaises(FileNotFoundError):
             Corpus.from_file('missing_file')

--- a/orangecontrib/text/widgets/owcorpus.py
+++ b/orangecontrib/text/widgets/owcorpus.py
@@ -82,7 +82,7 @@ class OWCorpus(OWWidget, ConcurrentWidgetMixin):
 
         # Used Text Features
         fbox = gui.widgetBox(self.controlArea, orientation=0)
-        ubox = gui.widgetBox(fbox, "Used text features", addSpace=False)
+        ubox = gui.widgetBox(fbox, "Used text features")
         self.used_attrs_model = VariableListModel(enable_dnd=True)
         self.used_attrs_view = VariablesListItemView()
         self.used_attrs_view.setModel(self.used_attrs_model)
@@ -94,7 +94,7 @@ class OWCorpus(OWWidget, ConcurrentWidgetMixin):
         aa.rowsRemoved.connect(self.update_feature_selection)
 
         # Ignored Text Features
-        ibox = gui.widgetBox(fbox, "Ignored text features", addSpace=False)
+        ibox = gui.widgetBox(fbox, "Ignored text features")
         self.unused_attrs_model = VariableListModel(enable_dnd=True)
         self.unused_attrs_view = VariablesListItemView()
         self.unused_attrs_view.setModel(self.unused_attrs_model)
@@ -146,6 +146,7 @@ class OWCorpus(OWWidget, ConcurrentWidgetMixin):
     def open_file(self, path=None, data=None):
         self.closeContext()
         self.Error.clear()
+        self.cancel()
         self.unused_attrs_model[:] = []
         self.used_attrs_model[:] = []
         self.start(self._load_corpus, path, data)
@@ -158,7 +159,8 @@ class OWCorpus(OWWidget, ConcurrentWidgetMixin):
         self.update_output_info()
         self._setup_title_dropdown()
         self.used_attrs = list(self.corpus.text_features)
-        if not self.corpus.text_features:
+        all_str_features = [f for f in self.corpus.domain.metas if f.is_string]
+        if not all_str_features:
             self.Error.corpus_without_text_features()
             self.Outputs.corpus.send(None)
             return


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-text/issues/625

##### Description of changes
- Fix from_numpy which didn't initialize text_features and other variables correctly
- The Corpus widget showed an error when the `text_features` list was empty and didn't initialize Used and unused features fields. Fix to initialize fields anyways. Now error only present when no text features in the domain
- Remove deprecated `addSpace` attribute in widgetBoxs.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
