### PR TITLE
[FIX] Fix infer text features

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -235,7 +235,11 @@ class Corpus(Table):
             if attr.is_string:
                 if first is None:
                     first = attr
-                if attr.attributes.get('include', 'False') == 'True':
+                incl = attr.attributes.get('include', False)
+                # variable attributes can be boolean from Orange 3.29
+                # they are string in older versions
+                # incl == True, since without == string "False" would be True
+                if incl == "True" or incl == True:
                     include_feats.append(attr)
         if len(include_feats) == 0 and first:
             include_feats.append(first)

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -248,6 +248,35 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(tf), 1)
         self.assertEqual(tf[0].name, 'Text')
 
+    def test_infer_text_features_str_include(self):
+        """
+        In orange 3.29 include attribute is read as boolean. corpus must still
+        support older versions of Orange where include attribute is a string.
+        Test behaviour with string attribute.
+        """
+        c = Corpus.from_file('andersen')
+        c.domain["Content"].attributes["include"] = "False"
+        c._infer_text_features()
+        self.assertListEqual(c.text_features, [c.domain["Title"]])
+
+        c.domain["Content"].attributes["include"] = "True"
+        c._infer_text_features()
+        self.assertListEqual(c.text_features, [c.domain["Content"]])
+
+    def test_infer_text_features_bool_include(self):
+        """
+        In orange 3.29 include attribute is read as boolean.
+        Test behaviour with boolean attribute.
+        """
+        c = Corpus.from_file('andersen')
+        c.domain["Content"].attributes["include"] = False
+        c._infer_text_features()
+        self.assertListEqual(c.text_features, [c.domain["Title"]])
+
+        c.domain["Content"].attributes["include"] = True
+        c._infer_text_features()
+        self.assertListEqual(c.text_features, [c.domain["Content"]])
+
     def test_documents(self):
         c = Corpus.from_file('book-excerpts')
         docs = c.documents

--- a/orangecontrib/text/widgets/owcorpus.py
+++ b/orangecontrib/text/widgets/owcorpus.py
@@ -307,9 +307,5 @@ class OWCorpus(OWWidget, ConcurrentWidgetMixin):
 
 
 if __name__ == '__main__':
-    from AnyQt.QtWidgets import QApplication
-    app = QApplication([])
-    widget = OWCorpus()
-    widget.show()
-    app.exec()
-    widget.saveSettings()
+    from orangewidget.utils.widgetpreview import WidgetPreview
+    WidgetPreview(OWCorpus).run()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
With https://github.com/biolab/orange3/pull/5309 include variable attributes are bool and not strings anymore. It breaks `_infer_text_features` that does not recognize attributes with `include = True`.

##### Description of changes
Fix `_infer_text_features` to handle both string and bool `include` attribute.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
