### PR TITLE
Score documents - remember sorting

### DIFF
--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -233,7 +233,8 @@ class ScoreDocumentsProxyModel(QSortFilterProxyModel):
         if left_ind.column() == 0 and right_ind.column() == 0:
             left = self.sourceModel().data(left_ind, role=Qt.DisplayRole)
             right = self.sourceModel().data(right_ind, role=Qt.DisplayRole)
-            return self._alphanum_key(left) < self._alphanum_key(right)
+            if left is not None and right is not None:
+                return self._alphanum_key(left) < self._alphanum_key(right)
         return super().lessThan(left_ind, right_ind)
 
 
@@ -253,12 +254,16 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
     icon = "icons/ScoreDocuments.svg"
     priority = 500
 
+    # default order - table sorted in input order
+    DEFAULT_SORTING = (-1, Qt.AscendingOrder)
+
     auto_commit: bool = Setting(True)
     aggregation: int = Setting(0)
 
     word_frequency: bool = Setting(True)
     word_appearance: bool = Setting(False)
     embedding_similarity: bool = Setting(False)
+    sort_column_order: Tuple[int, int] = Setting(DEFAULT_SORTING)
     embedding_language = Setting(0)
 
     class Inputs:
@@ -331,6 +336,9 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
 
         self.view = view = ScoreDocumentsTableView()
         self.mainArea.layout().addWidget(view)
+        # by default data are sorted in the Table order
+        header = self.view.horizontalHeader()
+        header.sectionClicked.connect(self.__on_horizontal_header_clicked)
 
         proxy_model = ScoreDocumentsProxyModel()
         proxy_model.setFilterKeyColumn(0)
@@ -342,6 +350,10 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         model = self.view.model()
         model.setFilterFixedString(self._filter_line_edit.text().strip())
 
+    def __on_horizontal_header_clicked(self, index: int):
+        header = self.view.horizontalHeader()
+        self.sort_column_order = (index, header.sortIndicatorOrder())
+
     @Inputs.corpus
     def set_data(self, corpus: Corpus) -> None:
         self.Warning.corpus_not_normalized.clear()
@@ -350,7 +362,6 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
             if not self._is_corpus_normalized(corpus):
                 self.Warning.corpus_not_normalized()
         self.corpus = corpus
-        # todo: rename
         self._clear_and_run()
 
     @staticmethod
@@ -450,8 +461,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         self.model.setHorizontalHeaderLabels(labels)
         self.view.update_column_widths()
 
-        # documents are not ordered by default by any column
-        self.view.horizontalHeader().setSortIndicator(-1, Qt.AscendingOrder)
+        self.view.horizontalHeader().setSortIndicator(*self.sort_column_order)
 
     def _fill_and_output(self) -> None:
         """ Fill the table in the widget and send the output """

--- a/orangecontrib/text/widgets/tests/test_owscoredocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owscoredocuments.py
@@ -297,6 +297,45 @@ class TestOWScoreDocuments(WidgetTest):
         data = [model.data(model.index(i, 0)) for i in range(model.rowCount())]
         self.assertListEqual(data, natural_sorted(self.corpus.titles)[::-1])
 
+    def test_sort_setting(self):
+        """
+        Test if sorting is correctly memorized in setting and restored
+        """
+        view = self.widget.view
+        model = view.model()
+        self.widget.sort_column_order = (1, Qt.DescendingOrder)
+        self.send_signal(self.widget.Inputs.corpus, self.corpus)
+        self.send_signal(self.widget.Inputs.words, self.words)
+        self.wait_until_finished()
+
+        header = self.widget.view.horizontalHeader()
+        current_sorting = (header.sortIndicatorSection(), header.sortIndicatorOrder())
+        data = [model.data(model.index(i, 1)) for i in range(model.rowCount())]
+        self.assertTupleEqual((1, Qt.DescendingOrder), current_sorting)
+        self.assertListEqual(sorted(data, reverse=True), data)
+
+        self.send_signal(self.widget.Inputs.words, None)
+        self.send_signal(self.widget.Inputs.words, self.words)
+        self.wait_until_finished()
+
+        header = self.widget.view.horizontalHeader()
+        current_sorting = (header.sortIndicatorSection(), header.sortIndicatorOrder())
+        data = [model.data(model.index(i, 1)) for i in range(model.rowCount())]
+        self.assertTupleEqual((1, Qt.DescendingOrder), current_sorting)
+        self.assertListEqual(sorted(data, reverse=True), data)
+
+        self.send_signal(self.widget.Inputs.corpus, None)
+        self.send_signal(self.widget.Inputs.words, None)
+        self.send_signal(self.widget.Inputs.corpus, self.corpus)
+        self.send_signal(self.widget.Inputs.words, self.words)
+        self.wait_until_finished()
+
+        header = self.widget.view.horizontalHeader()
+        current_sorting = (header.sortIndicatorSection(), header.sortIndicatorOrder())
+        data = [model.data(model.index(i, 1)) for i in range(model.rowCount())]
+        self.assertTupleEqual((1, Qt.DescendingOrder), current_sorting)
+        self.assertListEqual(sorted(data, reverse=True), data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Order of the elements in the table is not remembered by Score Documents widget

##### Description of changes
Remember order as a setting

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
