### PR TITLE
Score documents - speedup slow scorer on non-preprocessed documents

### DIFF
--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -34,10 +34,11 @@ def _word_frequency(
     corpus: Corpus, words: List[str], callback: Callable
 ) -> np.ndarray:
     res = []
-    for i, t in enumerate(corpus.tokens):
+    tokens = corpus.tokens
+    for i, t in enumerate(tokens):
         counts = Counter(t)
         res.append([counts.get(w, 0) for w in words])
-        callback((i + 1) / len(corpus.tokens))
+        callback((i + 1) / len(tokens))
     return np.array(res)
 
 
@@ -45,10 +46,11 @@ def _word_appearance(
     corpus: Corpus, words: List[str], callback: Callable
 ) -> np.ndarray:
     res = []
-    for i, t in enumerate(corpus.tokens):
+    tokens = corpus.tokens
+    for i, t in enumerate(tokens):
         t = set(t)
         res.append([w in t for w in words])
-        callback((i + 1) / len(corpus.tokens))
+        callback((i + 1) / len(tokens))
     return np.array(res)
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Score documents widget is slow on a corpus that is not preprocessed since `corpus.tokens` is called regularly and each time they are regenerated when the corpus is not previously preprocessed by the preprocess widget

##### Description of changes
Call `corpus.tokens` only once per scoring.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
