### PR TITLE
Score documents - search words among string vars

### DIFF
--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -358,7 +358,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         attrs = [
             a
             for a in words.domain.metas + words.domain.variables
-            if isinstance(a, (StringVariable, DiscreteVariable))
+            if isinstance(a, StringVariable)
         ]
         words_attr = next(
             (a for a in attrs if a.attributes.get("type", "") == "words"), None


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Widget tried to find words from any variable


##### Description of changes
The widget should look only for StringVariables. It matches the keywords widget behaviour


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
