### PR TITLE
Word enrichment - hypergeometric test speedup

### DIFF
--- a/orangecontrib/text/stats.py
+++ b/orangecontrib/text/stats.py
@@ -1,22 +1,31 @@
+from typing import List
+
 import numpy as np
 from scipy import stats, sparse
 
-def is_sorted(l):
-    return all(l[i] <= l[i+1] for i in range(len(l)-1))
 
-def hypergeom_p_values(data, selected, callback=None):
+def is_sorted(l):
+    return all(l[i] <= l[i + 1] for i in range(len(l) - 1))
+
+
+def hypergeom_p_values(data: np.ndarray, selected: np.ndarray) -> List:
     """
     Calculates p_values using Hypergeometric distribution for two numpy arrays.
-    Works on a matrices containing zeros and ones. All other values are truncated to zeros and ones.
+    Works on a matrices containing zeros and ones.
+    All other values are truncated to zeros and ones.
 
-    Args:
-        data (numpy.array): all examples in rows, theirs features in columns.
-        selected (numpy.array): selected examples in rows, theirs features in columns.
-        callback: callback function used for printing progress.
+    Parameters
+    ----------
+    data
+        all examples in rows, theirs features in columns.
+    selected
+        selected examples in rows, theirs features in columns.
 
-    Returns: p-values for features
-
+    Returns
+    -------
+    p-values for features
     """
+
     def col_sum(x):
         if sparse.issparse(x):
             return np.squeeze(np.asarray(x.sum(axis=0)))
@@ -30,19 +39,16 @@ def hypergeom_p_values(data, selected, callback=None):
     data = data > 0
     selected = selected > 0
 
-    num_features = selected.shape[1]
-    pop_size = data.shape[0]                # population size = number of all data examples
-    sam_size = selected.shape[0]            # sample size = number of selected examples
-    pop_counts = col_sum(data)              # number of observations in population = occurrences of words all data
-    sam_counts = col_sum(selected)          # number of observations in sample = occurrences of words in selected data
-    step = 250
-    p_vals = []
+    pop_size = data.shape[0]  # population size = number of all data examples
+    sam_size = selected.shape[0]  # sample size = number of selected examples
+    # number of observations in population = occurrences of words all data
+    pop_counts = col_sum(data)
+    # number of observations in sample = occurrences of words in selected data
+    sam_counts = col_sum(selected)
 
-    for i, (pc, sc) in enumerate(zip(pop_counts, sam_counts)):
-        hyper = stats.hypergeom(pop_size, pc, sam_size)
-        # since p-value is probability of equal to or "more extreme" than what was actually observed
-        # we calculate it as 1 - cdf(sc-1). sf is survival function defined as 1-cdf.
-        p_vals.append(hyper.sf(sc-1))
-        if callback and i % step == 0:
-            callback(100*i/num_features)
-    return p_vals
+    # since p-value is probability of equal to or "more extreme" than what was actually observed
+    # we calculate it as 1 - cdf(sc-1). sf is survival function defined as 1-cdf.
+    # p_vals.append(hyper.sf(sc-1))
+    p_vals = stats.hypergeom.sf(sam_counts - 1, pop_size, pop_counts, sam_size)
+
+    return p_vals.tolist()

--- a/orangecontrib/text/tests/test_stats.py
+++ b/orangecontrib/text/tests/test_stats.py
@@ -4,6 +4,7 @@ import scipy.sparse as sp
 
 from orangecontrib.text.stats import hypergeom_p_values, is_sorted
 
+
 class StatsTests(unittest.TestCase):
     x = np.array([[0, 0, 9, 0, 1],
                   [0, 1, 3, 0, 2],
@@ -32,3 +33,7 @@ class StatsTests(unittest.TestCase):
     def test_is_sorted(self):
         self.assertTrue(is_sorted(range(10)))
         self.assertFalse(is_sorted(range(10)[::-1]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -33,11 +33,12 @@ class Runner:
         state.set_status("Listing words")
         result.words = [
             i.name for i in selected_data_transformed.domain.attributes]
+
         state.set_status("Computing p-values")
         result.p_values = hypergeom_p_values(
             data.X, selected_data_transformed.X,
-            callback=state.set_progress_value
         )
+
         state.set_status("Computing FDR values")
         result.fdr_values = FDR(result.p_values)
 

--- a/orangecontrib/text/widgets/tests/test_owwordenrichment.py
+++ b/orangecontrib/text/widgets/tests/test_owwordenrichment.py
@@ -2,10 +2,16 @@ import unittest
 from unittest.mock import Mock
 
 import Orange
+import numpy as np
 from Orange.data import Table, Domain
 from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.text.corpus import Corpus
+from orangecontrib.text.preprocess import (
+    PreprocessorList,
+    BASE_TRANSFORMER,
+    RegexpTokenizer,
+)
 from orangecontrib.text.vectorization import BowVectorizer
 from orangecontrib.text.widgets.owwordenrichment import OWWordEnrichment
 
@@ -235,6 +241,31 @@ class TestWordEnrichment(WidgetTest):
         self.wait_until_finished(timeout=100000)
 
         w.send_report()
+
+    def test_result(self):
+        pp = PreprocessorList([BASE_TRANSFORMER, RegexpTokenizer()])
+        corpus = pp(Corpus.from_file("book-excerpts")[::3])
+        vect = BowVectorizer()
+        corpus_vect = vect.transform(corpus)
+
+        words = ["beheld", "events", "dragged", "basin", "visit", "have"]
+        d = Domain([corpus_vect.domain[w] for w in words])
+        corpus_vect = corpus_vect.transform(d)
+
+        self.send_signal(self.widget.Inputs.data, corpus_vect)
+        self.send_signal(self.widget.Inputs.selected_data, corpus_vect[:1])
+        self.wait_until_finished(timeout=100000)
+
+        np.testing.assert_array_almost_equal(
+            self.widget.results.p_values,
+            [0.02128, 1, 0.04255, 0.06383, 0.08511, 0.97872],
+            decimal=5,
+        )
+        np.testing.assert_array_almost_equal(
+            self.widget.results.fdr_values,
+            [0.12766, 1, 0.12766, 0.12766, 0.12766, 1],
+            decimal=5,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Word enrichment is slow when  handling datasets with many tokens

##### Description of changes
This PR speeds up the hypergeometric test such that it computes all p-values with one call instead of calling hypergeom function for each word

Speedup:
17.5s -> 0.018
21.7s -> 0.243

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
