### PR TITLE
Import documents - prevent double quoting

### DIFF
--- a/orangecontrib/text/import_documents.py
+++ b/orangecontrib/text/import_documents.py
@@ -185,7 +185,7 @@ class UrlReader(Reader, CoreUrlReader):
 
     def __init__(self, path, *args):
         CoreUrlReader.__init__(self, path)
-        Reader.__init__(self, self.filename, *args)
+        Reader.__init__(self, path, *args)
 
     def read_file(self):
         # unquote prevent double quoting when filename is already quoted

--- a/orangecontrib/text/import_documents.py
+++ b/orangecontrib/text/import_documents.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import re
 import yaml
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 from requests.exceptions import ConnectionError
 
 from collections import namedtuple
@@ -188,7 +188,10 @@ class UrlReader(Reader, CoreUrlReader):
         Reader.__init__(self, self.filename, *args)
 
     def read_file(self):
-        self.filename = quote(self.filename, safe="/:")
+        # unquote prevent double quoting when filename is already quoted
+        # when not quoted it doesn't change url - it is required since Orange's
+        # UrlReader quote urls in version 3.29 but not in older versions
+        self.filename = quote(unquote(self.filename), safe="/:")
         self.filename = self._trim(self._resolve_redirects(self.filename))
         with contextlib.closing(self.urlopen(self.filename)) as response:
             name = self._suggest_filename(

--- a/orangecontrib/text/tests/test_import_documents.py
+++ b/orangecontrib/text/tests/test_import_documents.py
@@ -1,11 +1,11 @@
 import unittest
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 
 from orangecontrib.text.import_documents import ImportDocuments, UrlReader, \
     TxtReader, TextData
+from pkg_resources import get_distribution
 
 
 class TestUrlReader(unittest.TestCase):
@@ -50,6 +50,18 @@ class TestUrlReader(unittest.TestCase):
         self.assertEqual(text_data.ext, [".txt"])
         self.assertEqual(text_data.category, "data")
         self.assertEqual(text_data.content, "text")
+
+    def test_remove_quoting(self):
+        """
+        Since URL quoting is implemented in Orange it can be removed from text
+        addon when minimal version of Orange is increased to 3.29.1. When this
+        test start to fail remove the test itself and lines 191 - 194 in
+        import_documents.py
+        """
+        distribution = get_distribution('orange3-text')
+        orange_spec = next(x for x in distribution.requires() if x.name == "Orange3")
+        orange_min_version = tuple(map(int, orange_spec.specs[0][1].split(".")))
+        self.assertLess(orange_min_version, (3, 29, 1))
 
 
 class TestImportDocuments(unittest.TestCase):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Since now Orange's UrlReader encodes special characters in URL https://github.com/biolab/orange3/pull/5412, special characters are getting encoded two times in import document which makes escape characters encoded and so it produces the wrong URL.

Because of changes also `self.path` is quoted and so matching with metadata fails.

##### Description of changes
- Since it is still required to keep encoding in import documents' reader to support older versions of Orange, I propose to decode and encode URLs again. If URL is not encoded, decode does not change the URL.
- Fix matching with metadata with storing non-encoded path

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
