### PR TITLE
UDPipe lemmatizer - make it picklable

### DIFF
--- a/orangecontrib/text/preprocess/normalize.py
+++ b/orangecontrib/text/preprocess/normalize.py
@@ -170,3 +170,17 @@ class UDPipeLemmatizer(BaseNormalizer):
             tokens.extend([t['properties']['lemma']
                            for t in json.loads(output)['nodes']])
         return tokens
+
+    def __getstate__(self):
+        """
+        This function remove udpipe.Model that cannot be pickled
+
+        Note: __setstate__ is not required since we do not make any harm if
+              model is not restored. It will be loaded on __call__
+        """
+        # copy to avoid editing original dict
+        state = self.__dict__.copy()
+        # Remove the unpicklable Model and output format.
+        state['_UDPipeLemmatizer__model'] = None
+        state['_UDPipeLemmatizer__output_format'] = None
+        return state

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -255,6 +255,8 @@ class TokenNormalizerTests(unittest.TestCase):
 
     def test_udpipe_pickle(self):
         normalizer = preprocess.UDPipeLemmatizer('Slovenian', True)
+        # udpipe store model after first call - model is not picklable
+        normalizer(self.corpus)
         loaded = pickle.loads(pickle.dumps(normalizer))
         self.assertEqual(normalizer._UDPipeLemmatizer__language,
                          loaded._UDPipeLemmatizer__language)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
UDPipe lemmatizer is not picklable after first call since udpipe.Model is not picklable. The authors decided that they will not support pickling for the model.

##### Description of changes
Drop model from __dict__ while pickling

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
