### PR TITLE
[ENH] Keywords: Add 'Embedding' scoring method

### DIFF
--- a/orangecontrib/text/keywords/__init__.py
+++ b/orangecontrib/text/keywords/__init__.py
@@ -13,7 +13,8 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from Orange.util import dummy_callback
 
 from orangecontrib.text.keywords.rake import Rake
-from orangecontrib.text.keywords.embedding import embedding_keywords, EMBEDDING_LANGUAGE_MAPPING
+from orangecontrib.text.keywords.embedding import embedding_keywords, \
+    EMBEDDING_LANGUAGE_MAPPING
 from orangecontrib.text.preprocess import StopwordsFilter
 
 # all available languages for RAKE
@@ -175,8 +176,10 @@ class ScoringMethods:
     Scoring methods enum.
     """
     TF_IDF, RAKE, YAKE, EMBEDDING = "TF-IDF", "Rake", "YAKE!", "Embedding"
-    ITEMS = list(zip((TF_IDF, YAKE, RAKE),
-                     (tfidf_keywords, yake_keywords, rake_keywords)))
+    ITEMS = list(zip(
+        (TF_IDF, YAKE, RAKE, EMBEDDING),
+        (tfidf_keywords, yake_keywords, rake_keywords, embedding_keywords)
+    ))
 
     TOKEN_METHODS = TF_IDF, EMBEDDING
     DOCUMENT_METHODS = RAKE, YAKE

--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -21,11 +21,12 @@ from Orange.widgets.widget import Input, Output, OWWidget, Msg
 
 from orangecontrib.text import Corpus
 from orangecontrib.text.keywords import ScoringMethods, AggregationMethods, \
-    YAKE_LANGUAGE_MAPPING, RAKE_LANGUAGES
+    YAKE_LANGUAGE_MAPPING, RAKE_LANGUAGES, EMBEDDING_LANGUAGE_MAPPING
 from orangecontrib.text.preprocess import BaseNormalizer
 
 WORDS_COLUMN_NAME = "Words"
 YAKE_LANGUAGES = list(YAKE_LANGUAGE_MAPPING.keys())
+EMBEDDING_LANGUAGES = list(EMBEDDING_LANGUAGE_MAPPING.keys())
 
 
 class Results(SimpleNamespace):
@@ -181,6 +182,7 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
     selected_scoring_methods: Set[str] = Setting({ScoringMethods.TF_IDF})
     yake_lang_index: int = Setting(YAKE_LANGUAGES.index("English"))
     rake_lang_index: int = Setting(RAKE_LANGUAGES.index("English"))
+    embedding_lang_index: int = Setting(EMBEDDING_LANGUAGES.index("English"))
     agg_method: int = Setting(AggregationMethods.MEAN)
     sel_method: int = ContextSetting(SelectionMethods.N_BEST)
     n_selected: int = ContextSetting(3)
@@ -219,6 +221,10 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
             self.controlArea, self, "rake_lang_index", items=RAKE_LANGUAGES,
             callback=self.__on_rake_lang_changed
         )
+        embedding_cb = gui.comboBox(
+            self.controlArea, self, "embedding_lang_index",
+            items=EMBEDDING_LANGUAGES, callback=self.__on_emb_lang_changed
+        )
 
         for i, (method_name, _) in enumerate(ScoringMethods.ITEMS):
             check_box = QCheckBox(method_name, self)
@@ -232,6 +238,8 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
                 box.layout().addWidget(yake_cb, i, 1)
             if method_name == ScoringMethods.RAKE:
                 box.layout().addWidget(rake_cb, i, 1)
+            if method_name == ScoringMethods.EMBEDDING:
+                box.layout().addWidget(embedding_cb, i, 1)
 
         box = gui.vBox(self.controlArea, "Aggregation")
         gui.comboBox(
@@ -308,6 +316,12 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
                 del self.__cached_keywords[ScoringMethods.RAKE]
             self.update_scores()
 
+    def __on_emb_lang_changed(self):
+        if ScoringMethods.EMBEDDING in self.selected_scoring_methods:
+            if ScoringMethods.EMBEDDING in self.__cached_keywords:
+                del self.__cached_keywords[ScoringMethods.EMBEDDING]
+            self.update_scores()
+
     def __on_filter_changed(self):
         model = self.view.model()
         model.setFilterFixedString(self.__filter_line_edit.text().strip())
@@ -368,6 +382,9 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
             ScoringMethods.RAKE: {
                 "language": RAKE_LANGUAGES[self.rake_lang_index],
                 "max_len": self.corpus.ngram_range[1] if self.corpus else 1
+            },
+            ScoringMethods.EMBEDDING: {
+                "language": EMBEDDING_LANGUAGES[self.embedding_lang_index],
             },
         }
         self.start(run, self.corpus, self.words, self.__cached_keywords,

--- a/orangecontrib/text/widgets/tests/test_owkeywords.py
+++ b/orangecontrib/text/widgets/tests/test_owkeywords.py
@@ -10,7 +10,7 @@ from Orange.widgets.tests.base import WidgetTest, simulate
 
 from orangecontrib.text import Corpus
 from orangecontrib.text.keywords import tfidf_keywords, yake_keywords, \
-    rake_keywords, embedding_keywords
+    rake_keywords
 from orangecontrib.text.preprocess import *
 from orangecontrib.text.widgets.owkeywords import OWKeywords, run, \
     AggregationMethods, ScoringMethods
@@ -182,10 +182,14 @@ class TestOWKeywords(WidgetTest):
                              ["System", "Widths", "opinion"])
 
     def test_scoring_methods(self):
+        # speed-up the test execution
+        def dummy_embedding(tokens, language, progress_callback=None):
+            return tfidf_keywords(tokens, progress_callback)
+
         methods = [("TF-IDF", Mock(wraps=tfidf_keywords)),
                    ("YAKE!", Mock(wraps=yake_keywords)),
                    ("Rake", Mock(wraps=rake_keywords)),
-                   ("Embedding", Mock(wraps=embedding_keywords))]
+                   ("Embedding", Mock(side_effect=dummy_embedding))]
         with patch.object(ScoringMethods, "ITEMS", methods) as m:
             scores = {"TF-IDF", "YAKE!", "Rake", "Embedding"}
             settings = {"selected_scoring_methods": scores}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`Embedding` scoring method is missing in the `Keywords` widget.

##### Description of changes
Add `Embedding` scoring method to the `Keywords` widget.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
