### PR TITLE
OW Corpus Viewer: Add annotated corpus output

### DIFF
--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -15,6 +15,7 @@ from AnyQt.QtWidgets import (QListView, QSizePolicy, QTableView,
 from Orange.data.domain import filter_visible
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting, ContextSetting, PerfectDomainContextHandler
+from Orange.widgets.utils.annotated_data import create_annotated_table
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from orangecontrib.text.corpus import Corpus
 
@@ -31,6 +32,7 @@ class OWCorpusViewer(OWWidget):
     class Outputs:
         matching_docs = Output("Matching Docs", Corpus, default=True)
         other_docs = Output("Other Docs", Corpus)
+        corpus = Output("Corpus", Corpus)
 
     settingsHandler = PerfectDomainContextHandler(
         match_values = PerfectDomainContextHandler.MATCH_VALUES_ALL
@@ -422,7 +424,7 @@ class OWCorpusViewer(OWWidget):
             self.ngram_range = ''
 
     def commit(self):
-        matched = unmatched = None
+        matched = unmatched = annotated_corpus = None
         corpus = self.corpus
         if corpus is not None:
             # it returns a set of selected documents which are in view
@@ -437,8 +439,10 @@ class OWCorpusViewer(OWWidget):
 
             matched = corpus[matched_mask] if len(matched_mask) else None
             unmatched = corpus[unmatched_mask] if len(unmatched_mask) else None
+            annotated_corpus = create_annotated_table(corpus, matched_mask)
         self.Outputs.matching_docs.send(matched)
         self.Outputs.other_docs.send(unmatched)
+        self.Outputs.corpus.send(annotated_corpus)
 
     def send_report(self):
         self.report_items((

--- a/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
@@ -81,6 +81,10 @@ class TestCorpusViewerWidget(WidgetTest):
         self.assertEqual(
             9, len(self.get_output(self.widget.Outputs.other_docs))
         )
+        self.assertEqual(
+            len(self.corpus.domain.metas) + 1,
+            len(self.get_output(self.widget.Outputs.corpus).domain.metas)
+        )
 
         self.widget.doc_list.selectAll()  # selects current documents in list
         self.assertEqual(
@@ -89,14 +93,22 @@ class TestCorpusViewerWidget(WidgetTest):
         self.assertEqual(
             5, len(self.get_output(self.widget.Outputs.other_docs))
         )
+        output = self.get_output(self.widget.Outputs.corpus)
+        self.assertEqual(
+            len(self.get_output(self.widget.Outputs.matching_docs)),
+            sum(output.get_column_view("Selected")[0])
+        )
 
         self.widget.regexp_filter = "human"
         self.process_events()
-        # empty because none of mathching documents is selected
+        # empty because none of matching documents is selected
         self.assertIsNone(self.get_output(self.widget.Outputs.matching_docs))
         self.assertEqual(
             9, len(self.get_output(self.widget.Outputs.other_docs))
         )
+        output = self.get_output(self.widget.Outputs.corpus)
+        self.assertEqual(0,
+                         sum(output.get_column_view("Selected")[0]))
 
         self.widget.doc_list.selectAll()
         self.assertEqual(
@@ -105,10 +117,16 @@ class TestCorpusViewerWidget(WidgetTest):
         self.assertEqual(
             4, len(self.get_output(self.widget.Outputs.other_docs))
         )
+        output = self.get_output(self.widget.Outputs.corpus)
+        self.assertEqual(
+            len(self.get_output(self.widget.Outputs.matching_docs)),
+            sum(output.get_column_view("Selected")[0])
+        )
 
         self.send_signal(self.widget.Inputs.corpus, None)
         self.assertIsNone(self.get_output(self.widget.Outputs.matching_docs))
         self.assertIsNone(self.get_output(self.widget.Outputs.other_docs))
+        self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
 
     def test_empty_corpus(self):
         self.send_signal(self.widget.Inputs.corpus, self.corpus[:0])


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #658.

##### Description of changes
Add an additional output that matches the "Data" output in selection widgets in Orange.
The column adds a meta attribute denoting whether a row was selected or not.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
