### PR TITLE
Import Documents: Read metas as the right type

### DIFF
--- a/orangecontrib/text/import_documents.py
+++ b/orangecontrib/text/import_documents.py
@@ -181,6 +181,9 @@ class YamlMetaReader(Reader):
     def read_file(self):
         with open(self.path, "r") as f:
             self.content = yaml.safe_load(f)
+            for k in self.content:
+                if self.content[k] is None:
+                    self.content[k] = ""
 
 
 class UrlReader(Reader, CoreUrlReader):
@@ -287,8 +290,6 @@ class ImportDocuments:
                 content = data.content
                 if isinstance(content, dict):
                     content = pd.DataFrame(content, index=[0])
-                # if reader is YamlMetaReader:
-                #     content = content.replace("None", np.nan)
                 meta_dfs.append(content)
             else:
                 errors.append(error)

--- a/orangecontrib/text/tests/test_import_documents.py
+++ b/orangecontrib/text/tests/test_import_documents.py
@@ -130,16 +130,16 @@ class TestImportDocuments(unittest.TestCase):
         importer = ImportDocuments(path, True)
         corpus2, _ = importer.run()
         self.assertGreater(len(corpus1), 0)
-        self.assertEqual(corpus1.metas[mask].tolist(),
-                         corpus2.metas[mask].tolist())
+        np.testing.assert_array_equal(corpus1.metas[mask].tolist(),
+                                      corpus2.metas[mask].tolist())
 
         path = "http://file.biolab.si/text-semantics/data" \
                "/predlogi-vladi-sample"
         importer = ImportDocuments(path, True)
         corpus3, _ = importer.run()
         self.assertGreater(len(corpus2), 0)
-        self.assertEqual(corpus1.metas[mask].tolist(),
-                         corpus3.metas[mask].tolist())
+        np.testing.assert_array_equal(corpus1.metas[mask].tolist(),
+                                      corpus3.metas[mask].tolist())
 
     def test_run_url_special_characters(self):
         path = "http://file.biolab.si/text-semantics/data/" \


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Import Documents added meta files if found, but they were all read as StringVariables not as their own proper types.

##### Description of changes
~Use table_from_frame to translate numeric values to ContinuousVariables and categorical to DiscreteVariables.~

~CONS: now some attributes are in X, not in metas. Any easy way to fix this?~

Decided to follow @VesnaT suggestion and sanitize variables before sending them to `guess_data_type`, which is now used instead of StringVariable.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
