### PR TITLE
OWPreprocess Text: add option to filter on POS tags

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -85,7 +85,7 @@ class Corpus(Table):
         self._ngrams_corpus = None
         self.ngram_range = (1, 1)
         self.attributes = {}
-        self.pos_tags = None
+        self._pos_tags = None
         from orangecontrib.text.preprocess import PreprocessorList
         self.__used_preprocessor = PreprocessorList([])   # required for compute values
         self._titles: Optional[np.ndarray] = None
@@ -447,6 +447,20 @@ class Corpus(Table):
         if self._dictionary is None:
             return self._base_tokens()[1]
         return self._dictionary
+
+    @property
+    def pos_tags(self):
+        """
+            np.ndarray: A list of lists containing POS tags. If there are no
+            POS tags available, return None.
+        """
+        if self._pos_tags is None:
+            return None
+        return np.array(self._pos_tags, dtype=object)
+
+    @pos_tags.setter
+    def pos_tags(self, pos_tags):
+        self._pos_tags = pos_tags
 
     def ngrams_iterator(self, join_with=' ', include_postags=False):
         if self.pos_tags is None:

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -435,6 +435,18 @@ class FilteringTests(unittest.TestCase):
         self.assertEqual(filtered.tokens[0], [' http'])
         self.assertEqual(len(filtered.used_preprocessor.preprocessors), 2)
 
+    def test_pos_filter(self):
+        pos_filter = preprocess.PosTagFilter("NN")
+        pp_list = [preprocess.WordPunctTokenizer(),
+                   tag.AveragedPerceptronTagger()]
+        corpus = self.corpus
+        for pp in pp_list:
+            corpus = pp(corpus)
+        filtered = pos_filter(corpus)
+        self.assertTrue(len(filtered.pos_tags))
+        self.assertEqual(len(filtered.pos_tags[0]), 5)
+        self.assertEqual(len(filtered.tokens[0]), 5)
+
     def test_can_deepcopy(self):
         copied = copy.deepcopy(self.regexp)
         self.corpus.metas[0, 0] = 'foo bar'

--- a/orangecontrib/text/widgets/tests/test_owpreprocess.py
+++ b/orangecontrib/text/widgets/tests/test_owpreprocess.py
@@ -485,7 +485,8 @@ class TestFilterModule(WidgetTest):
                   "freq_type": 0,
                   "rel_start": 0.1, "rel_end": 0.9,
                   "abs_start": 1, "abs_end": 10,
-                  "n_tokens": 100, "invalidated": False}
+                  "n_tokens": 100, "pos_tags": "NOUN,VERB",
+                  "invalidated": False}
         self.assertDictEqual(self.editor.parameters(), params)
 
     def test_set_parameters(self):
@@ -499,7 +500,8 @@ class TestFilterModule(WidgetTest):
                   "freq_type": 1,
                   "rel_start": 0.2, "rel_end": 0.7,
                   "abs_start": 2, "abs_end": 15,
-                  "n_tokens": 10, "invalidated": False}
+                  "n_tokens": 10,  "pos_tags": "JJ",
+                  "invalidated": False}
         self.editor.setParameters(params)
         self.assertDictEqual(self.editor.parameters(), params)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements #678. 

##### Description of changes
Add option to filter POS tags directly in Preprocess Text.
Add setter and getter to Corpus for easier pos_tag handling.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
