### PR TITLE
Preprocess: Reset tags on tokenization

### DIFF
--- a/orangecontrib/text/preprocess/preprocess.py
+++ b/orangecontrib/text/preprocess/preprocess.py
@@ -79,6 +79,7 @@ class Preprocessor:
         for i, doc in enumerate(corpus.pp_documents):
             callback(i / n)
             tokens.append(self._preprocess(doc))
+        corpus.pos_tags = None
         corpus.store_tokens(tokens)
         return corpus
 

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -503,6 +503,15 @@ class TokenizerTests(unittest.TestCase):
         tokenizer = preprocess.RegexpTokenizer(pattern=r'\w')
         pickle.loads(pickle.dumps(tokenizer))
 
+    def test_reset_pos_tags(self):
+        corpus = Corpus.from_file('deerwester')
+        tagger = tag.AveragedPerceptronTagger()
+        tagged_corpus = tagger(corpus)
+        self.assertTrue(len(tagged_corpus.pos_tags))
+        tokenizer = preprocess.RegexpTokenizer(pattern=r'\w')
+        tokenized_corpus = tokenizer(corpus)
+        self.assertFalse(tokenized_corpus.pos_tags)
+
 
 class NGramsTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
With the recent conllu reader (#675) one could import just POS tags without lemmas. We allow the user to do that, but in Preprocess Text tags would be used with new tokens, which causes severe mismatch. 

##### Description of changes
Reset POS tags when running tokenization.
This would also solve issues with the wrong ordering.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
