### PR TITLE
LDA: Add random state

### DIFF
--- a/orangecontrib/text/tests/test_topic_modeling.py
+++ b/orangecontrib/text/tests/test_topic_modeling.py
@@ -96,6 +96,11 @@ class LDATests(unittest.TestCase, BaseTests):
         self.assertEqual(corpus.X.shape, (len(self.corpus), 5))
         self.assertEqual(corpus.X.dtype, np.float64)
 
+    def test_random_seed(self):
+        corpus1 = self.model.fit_transform(self.corpus)
+        corpus2 = self.model.fit_transform(self.corpus)
+        np.testing.assert_array_equal(corpus1.X, corpus2.X)
+
 
 class HdpTest(unittest.TestCase, BaseTests):
     def setUp(self):

--- a/orangecontrib/text/topics/lda.py
+++ b/orangecontrib/text/topics/lda.py
@@ -9,4 +9,4 @@ class LdaWrapper(GensimWrapper):
     Model = models.LdaModel
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, dtype=float64)
+        super().__init__(random_state=0, **kwargs, dtype=float64)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
LDA is a generative model and has thus a random state that one can preset. For Orange workflows to be reproducible, we need to set a fixed random seed.

##### Description of changes
Add a fixed random seed.

Should we instead add a checkbox for reproducible LDA in the widget?


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
