### PR TITLE
Keywords: Corpus as default input

### DIFF
--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -191,7 +191,7 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
     auto_apply: bool = Setting(True)
 
     class Inputs:
-        corpus = Input("Corpus", Corpus)
+        corpus = Input("Corpus", Corpus, default=True)
         words = Input("Words", Table)
 
     class Outputs:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget part of https://github.com/biolab/orange-canvas-core/pull/201.

##### Description of changes
Set `Corpus` input as a default one (https://github.com/biolab/orange-canvas-core/pull/201 makes `Corpus` and `Words` inputs equally weighted) .

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
