### PR TITLE
Keywords: Move selection box to buttons area

### DIFF
--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -176,6 +176,8 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
     priority = 1100
     keywords = ["characteristic", "term"]
 
+    buttons_area_orientation = Qt.Vertical
+
     DEFAULT_SORTING = (1, Qt.DescendingOrder)
 
     settingsHandler = DomainContextHandler()
@@ -247,7 +249,7 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
             callback=self.update_scores
         )
 
-        box = gui.vBox(self.controlArea, "Select Words")
+        box = gui.vBox(self.buttonsArea, "Select Words")
         grid = QGridLayout()
         grid.setContentsMargins(0, 0, 0, 0)
         box.layout().addLayout(grid)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes
Move `Select words` box to button area to make the widget consistent with core Orange widgets.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
