### PR TITLE
Temporarily limit gensim to <4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,10 @@ nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
 scikit-learn
 numpy
 python-dateutil<3.0.0  # denpendency for botocore
-gensim>=0.12.3,!=4.0.0,!=4.0.1  # LDA's show topics unified in 0.12.3; 4.0 and 4.0.1 require numpy>=1.17 but do not have that in requirements - text addon do not work in envs with numpy<1.17
+# gensim 4.0 and 4.0.1 require numpy>=1.17 but do not have that in requirements - text addon do not work in envs with numpy<1.17
+# 4.1 have some build problems
+# TODO: change <4 probably to >4.1.1 when https://github.com/RaRe-Technologies/gensim/issues/3226 resolved
+gensim>=0.12.3,<4
 setuptools-git
 Orange3 >=3.28.0
 tweepy


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Gensim 4.1.0 and 4.1.1 have issue with building wheels https://github.com/RaRe-Technologies/gensim/issues/3226
It works with newset numpy but does not work with numpy used in installer - 1.19
4.0.* had issues before already 

##### Description of changes
Temporarily limiting Gensim to <4. It should be changed when they provide a working version.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
