### PR TITLE
Score Documents: Fix crashes with wrong inputs

### DIFF
--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -493,8 +493,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
                 array_ = words.get_column_view(attr)[0]
                 array_ = array_[~isnull(array_)]
                 return sum(len(a.split()) for a in array_) / len(array_)
-
-            _, attr = sorted((avg_len(a), a) for a in attrs)[0]
+            _, _, attr = sorted((avg_len(a), a.name, a) for a in attrs)[0]
             return words.get_column_view(attr)[0].tolist()
 
     @Inputs.words

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -324,6 +324,8 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         missing_words = Msg("Provide words on the input")
         missing_corpus = Msg("Provide corpus on the input")
         corpus_not_normalized = Msg("Use Preprocess Text to normalize corpus.")
+        not_corpus = Msg("Provide corpus on the input. Use Corpus to "
+                         "transform Table to Corpus.")
 
     class Error(OWWidget.Error):
         custom_err = Msg("{}")
@@ -457,6 +459,11 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
     def set_data(self, corpus: Corpus) -> None:
         self.closeContext()
         self.Warning.corpus_not_normalized.clear()
+        self.Warning.not_corpus.clear()
+        if not isinstance(corpus, Corpus):
+            self.corpus = None
+            self.Warning.not_corpus()
+            return
         if corpus is not None:
             self.Warning.missing_corpus.clear()
             if not self._is_corpus_normalized(corpus):

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -460,7 +460,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         self.closeContext()
         self.Warning.corpus_not_normalized.clear()
         self.Warning.not_corpus.clear()
-        if not isinstance(corpus, Corpus):
+        if not isinstance(corpus, Table):
             self.corpus = None
             self.Warning.not_corpus()
             return
@@ -481,6 +481,8 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
             for a in words.domain.metas + words.domain.variables
             if isinstance(a, StringVariable)
         ]
+        if not attrs:
+            return None
         words_attr = next(
             (a for a in attrs if a.attributes.get("type", "") == "words"), None
         )
@@ -493,7 +495,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
                 array_ = words.get_column_view(attr)[0]
                 array_ = array_[~isnull(array_)]
                 return sum(len(a.split()) for a in array_) / len(array_)
-            _, _, attr = sorted((avg_len(a), a.name, a) for a in attrs)[0]
+            attr = sorted(attrs, key=avg_len)[0]
             return words.get_column_view(attr)[0].tolist()
 
     @Inputs.words

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -321,8 +321,6 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         corpus = Output("Corpus", Corpus)
 
     class Warning(OWWidget.Warning):
-        missing_words = Msg("Provide words on the input")
-        missing_corpus = Msg("Provide corpus on the input")
         corpus_not_normalized = Msg("Use Preprocess Text to normalize corpus.")
         not_corpus = Msg("Provide corpus on the input. Use Corpus to "
                          "transform Table to Corpus.")
@@ -460,14 +458,17 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         self.closeContext()
         self.Warning.corpus_not_normalized.clear()
         self.Warning.not_corpus.clear()
-        if not isinstance(corpus, Table):
+        if corpus is None:
+            self.corpus = None
+            self._clear_and_run()
+            return
+        if not isinstance(corpus, Corpus):
             self.corpus = None
             self.Warning.not_corpus()
+            self._clear_and_run()
             return
-        if corpus is not None:
-            self.Warning.missing_corpus.clear()
-            if not self._is_corpus_normalized(corpus):
-                self.Warning.corpus_not_normalized()
+        if not self._is_corpus_normalized(corpus):
+            self.Warning.corpus_not_normalized()
         self.corpus = corpus
         self.selected_rows = []
         self.openContext(corpus)
@@ -503,7 +504,6 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         if words is None or len(words.domain.variables + words.domain.metas) == 0:
             self.words = None
         else:
-            self.Warning.missing_words.clear()
             self.words = self._get_word_attribute(words)
         self._clear_and_run()
 
@@ -607,12 +607,8 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
     def commit(self) -> None:
         self.Error.custom_err.clear()
         self.cancel()
-        if self.corpus is None and self.words is None:
+        if self.corpus is None or self.words is None:
             return
-        elif self.corpus is None:
-            self.Warning.missing_corpus()
-        elif self.words is None:
-            self.Warning.missing_words()
         else:
             scorers = self._get_active_scorers()
             aggregation = self._get_active_aggregation()

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -322,8 +322,6 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
 
     class Warning(OWWidget.Warning):
         corpus_not_normalized = Msg("Use Preprocess Text to normalize corpus.")
-        not_corpus = Msg("Provide corpus on the input. Use Corpus to "
-                         "transform Table to Corpus.")
 
     class Error(OWWidget.Error):
         custom_err = Msg("{}")
@@ -457,14 +455,8 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
     def set_data(self, corpus: Corpus) -> None:
         self.closeContext()
         self.Warning.corpus_not_normalized.clear()
-        self.Warning.not_corpus.clear()
         if corpus is None:
             self.corpus = None
-            self._clear_and_run()
-            return
-        if not isinstance(corpus, Corpus):
-            self.corpus = None
-            self.Warning.not_corpus()
             self._clear_and_run()
             return
         if not self._is_corpus_normalized(corpus):
@@ -607,9 +599,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
     def commit(self) -> None:
         self.Error.custom_err.clear()
         self.cancel()
-        if self.corpus is None or self.words is None:
-            return
-        else:
+        if self.corpus is not None and self.words is not None:
             scorers = self._get_active_scorers()
             aggregation = self._get_active_aggregation()
             new_scores = [s for s in scorers if (s, aggregation) not in self.scores]

--- a/orangecontrib/text/widgets/tests/test_owscoredocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owscoredocuments.py
@@ -66,10 +66,8 @@ class TestOWScoreDocuments(WidgetTest):
     def test_set_data(self):
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.assertEqual([x[0] for x in self.widget.model], self.corpus.titles.tolist())
-        self.assertTrue(self.widget.Warning.missing_words.is_shown())
 
         self.send_signal(self.widget.Inputs.words, self.words)
-        self.assertFalse(self.widget.Warning.missing_words.is_shown())
         self.wait_until_finished()
         self.assertEqual(len(self.widget.model), len(self.corpus))
         self.assertTrue(all(len(x) == 2 for x in self.widget.model))
@@ -138,14 +136,13 @@ class TestOWScoreDocuments(WidgetTest):
         self.assertIsNone(self.widget.words)
 
     def test_missing_corpus(self):
-        self.assertFalse(self.widget.Warning.missing_corpus.is_shown())
+        self.assertFalse(self.widget.Warning.not_corpus.is_shown())
         self.send_signal(self.widget.Inputs.words, self.words)
-        self.assertTrue(self.widget.Warning.missing_corpus.is_shown())
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
-        self.assertFalse(self.widget.Warning.missing_corpus.is_shown())
+        self.assertFalse(self.widget.Warning.not_corpus.is_shown())
         self.assertIsNotNone(self.get_output(self.widget.Outputs.corpus))
         self.send_signal(self.widget.Inputs.corpus, None)
-        self.assertTrue(self.widget.Warning.missing_corpus.is_shown())
+        self.assertFalse(self.widget.Warning.not_corpus.is_shown())
         self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
 
     @patch.object(DocumentEmbedder, "__call__", new=embedding_mock)

--- a/orangecontrib/text/widgets/tests/test_owscoredocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owscoredocuments.py
@@ -135,16 +135,6 @@ class TestOWScoreDocuments(WidgetTest):
         self.send_signal(self.widget.Inputs.words, None)
         self.assertIsNone(self.widget.words)
 
-    def test_missing_corpus(self):
-        self.assertFalse(self.widget.Warning.not_corpus.is_shown())
-        self.send_signal(self.widget.Inputs.words, self.words)
-        self.send_signal(self.widget.Inputs.corpus, self.corpus)
-        self.assertFalse(self.widget.Warning.not_corpus.is_shown())
-        self.assertIsNotNone(self.get_output(self.widget.Outputs.corpus))
-        self.send_signal(self.widget.Inputs.corpus, None)
-        self.assertFalse(self.widget.Warning.not_corpus.is_shown())
-        self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
-
     @patch.object(DocumentEmbedder, "__call__", new=embedding_mock)
     def test_change_scorer(self):
         model = self.widget.model


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
1. If Score Documents received Table as Corpus input, it crashed since all checks for corpus objects would fail (`self._is_corpus_normalized`, etc.).
2. If Score Documents received generic Table as Words input, it crashed since it tried to sort by average length, but if variables had the same average length, it would try to sort by Variable object, which resulted in a crash.

##### Description of changes
1. Return None and a Warning if input data is not of type Corpus.
2. Sort by variable name, which, if I am not mistaken, are always unique and hence `sorted()` would never get to the final tuple object, which is a Variable.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
