### PR TITLE
Update requirements

### DIFF
--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -11,7 +11,7 @@ from Orange.widgets.settings import Setting
 from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.statistics.util import FDR
-from PyQt5.QtCore import QSize
+from AnyQt.QtCore import QSize
 from orangecontrib.text import Corpus
 from orangecontrib.text.util import np_sp_sum
 from orangecontrib.text.stats import hypergeom_p_values

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,27 @@
-scipy
-nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
-scikit-learn
-numpy
-python-dateutil<3.0.0  # denpendency for botocore
-gensim>=4.1.2  # https://github.com/RaRe-Technologies/gensim/issues/3226
-setuptools-git
-Orange3 >=3.28.0
-tweepy
+anyqt
 beautifulsoup4
-simhash >=1.11
-wikipedia
-pdfminer3k>=1.3.1
-odfpy>=1.3.5
-docx2txt>=0.6
-lxml
 biopython # Enables Pubmed widget.
-ufal.udpipe >=1.2.0.3
-orange-widget-base >=4.12.0
-yake
 conllu
+docx2txt>=0.6
+gensim>=4.1.2  # https://github.com/RaRe-Technologies/gensim/issues/3226
 lemmagen3
+lxml
+nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
+numpy
+odfpy>=1.3.5
+Orange3 >=3.28.0
+orange-widget-base >=4.12.0
+pandas
+pdfminer3k>=1.3.1
+pyqtgraph
+pyyaml
+requests
+scikit-learn
+scipy
+serverfiles
+simhash >=1.11
+six
+tweepy
+ufal.udpipe >=1.2.0.3
+wikipedia
+yake


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The requirements file is missing some requirements that are Orange's requirements. Anyway if we import something it is nice to be in requirements.txt.
Created based on: https://github.com/conda-forge/orange3-text-feedstock/pull/46

##### Description of changes
Removing:
- setuptools-git - since we use Manifest.in now.
- python-dateutil - it was here as a botocore dependency since pip resolver had issues with installing the correct version. With a new resolver, I think it is not required anymore.

Adding packages that are imported but not in requirements.


##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
