### PR TITLE
pos tag filter: Remove __call__ from subclass

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -220,12 +220,6 @@ class PosTagFilter(BaseTokenFilter):
     def __init__(self, tags=None):
         self._tags = set(i.strip().upper() for i in tags.split(","))
 
-    def __call__(self, corpus: Corpus, callback: Callable = None) -> Corpus:
-        if callback is None:
-            callback = dummy_callback
-        corpus = super().__call__(corpus, wrap_callback(callback, end=0.2))
-        return self._filter_tokens(corpus, wrap_callback(callback, start=0.2))
-
     @staticmethod
     def validate_tags(tags):
         # should we keep a dict of existing POS tags and compare them with


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`_filter_tokens` is called twice since it is called in `__call__` and `super().__call__()`

##### Description of changes
Removing `__call__` from subclass since filtering is handled by the super class `__call__`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
