### PR TITLE
Store ngrams_corpus correctly

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -660,7 +660,8 @@ class Corpus(Table):
             new.ngram_range = orig.ngram_range
             new.attributes = orig.attributes
             new.used_preprocessor = orig.used_preprocessor
-            new.ngrams_corpus = orig._ngrams_corpus
+            if orig._ngrams_corpus is not None:
+                new.ngrams_corpus = orig._ngrams_corpus[key]
 
     def __eq__(self, other):
         def arrays_equal(a, b):

--- a/orangecontrib/text/tests/test_utils.py
+++ b/orangecontrib/text/tests/test_utils.py
@@ -2,8 +2,10 @@ import unittest
 
 import numpy as np
 import scipy.sparse as sp
+from numpy.testing import assert_array_equal
+from scipy.sparse import csc_matrix
 
-from orangecontrib.text.util import chunks, np_sp_sum
+from orangecontrib.text.util import chunks, np_sp_sum, Sparse2CorpusSliceable
 
 
 class ChunksTest(unittest.TestCase):
@@ -28,3 +30,29 @@ class TestNpSpSum(unittest.TestCase):
             self.assertEqual(np_sp_sum(data), 10)
             np.testing.assert_equal(np_sp_sum(data, axis=1), np.ones(10))
             np.testing.assert_equal(np_sp_sum(data, axis=0), np.ones(10))
+
+
+class TestSparse2CorpusSliceable(unittest.TestCase):
+    def setUp(self) -> None:
+        self.orig_array = np.array([[1, 2, 3], [4, 5, 6]])
+        self.s2c = Sparse2CorpusSliceable(csc_matrix(self.orig_array))
+
+    def test_slice(self):
+        assert_array_equal(self.s2c[:2].sparse.toarray(), self.orig_array[:, :2])
+        assert_array_equal(self.s2c[1:3].sparse.toarray(), self.orig_array[:, 1:3])
+
+    def test_index(self):
+        assert_array_equal(self.s2c[1].sparse.toarray(), self.orig_array[:, [1]])
+
+    def test_list_of_indices(self):
+        assert_array_equal(
+            self.s2c[[1, 2]].sparse.toarray(), self.orig_array[:, [1, 2]]
+        )
+        assert_array_equal(self.s2c[[1]].sparse.toarray(), self.orig_array[:, [1]])
+
+    def test_elipsis(self):
+        assert_array_equal(self.s2c[...].sparse.toarray(), self.orig_array)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/util.py
+++ b/orangecontrib/text/util.py
@@ -1,8 +1,12 @@
 from functools import wraps
 from math import ceil
+from typing import Union, List
 
 import numpy as np
 import scipy.sparse as sp
+from gensim.matutils import Sparse2Corpus
+from scipy.sparse import csc_matrix
+
 
 def chunks(iterable, chunk_size):
     """ Splits iterable objects into chunk of fixed size.
@@ -59,3 +63,31 @@ def np_sp_sum(x, axis=None):
         return r
     else:
         return np.sum(x, axis=axis)
+
+
+class Sparse2CorpusSliceable(Sparse2Corpus):
+    """
+    Sparse2Corpus support only retrieving a vector for single document.
+    This class implements slice operation on the Sparse2Corpus object.
+
+    Todo: this implementation is temporary, remove it when/if implemented in gensim
+    """
+
+    def __getitem__(
+        self, key: Union[int, List[int], type(...), slice]
+    ) -> Sparse2Corpus:
+        """Retrieve a document vector from the corpus by its index.
+
+        Parameters
+        ----------
+        key
+            Index of document or slice for documents
+
+        Returns
+        -------
+        Selected subset of sparse data from self.
+        """
+        if not isinstance(key, (int, list, type(...), slice)):
+            raise TypeError(f"Indexing by type {type(key)} not supported.")
+        sparse = self.sparse.__getitem__((slice(None, None, None), key))
+        return Sparse2CorpusSliceable(sparse)

--- a/orangecontrib/text/vectorization/base.py
+++ b/orangecontrib/text/vectorization/base.py
@@ -1,7 +1,6 @@
 from itertools import chain
 
 import numpy as np
-from gensim import matutils
 
 from Orange.data.util import SharedComputeValue
 from Orange.data import Domain
@@ -12,6 +11,8 @@ from Orange.data import Domain
 
 # remove following section when orange3=3.27 is available
 import re
+
+from orangecontrib.text.util import Sparse2CorpusSliceable
 
 RE_FIND_INDEX = r"(^{})( \((\d{{1,}})\))?$"
 
@@ -81,7 +82,7 @@ class BaseVectorizer:
             sparse=True,
             rename_existing=True
         )
-        corpus.ngrams_corpus = matutils.Sparse2Corpus(X.T)
+        corpus.ngrams_corpus = Sparse2CorpusSliceable(X.T)
         return corpus
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Bag of words didn't store results correctly to `Corpus.ngrams_corpus`.

##### Description of changes
Store `ngrams_corpus` when transforming or copying the corpus.

Now, Topic Modelling accepts pre-existing bag of words matrix. 🎉 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
