### PR TITLE
[FIX] Sparse2CorpusSliceable: add support for np.ndarray as key

### DIFF
--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -439,6 +439,16 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(sel.ngram_range, c.ngram_range)
         self.assertEqual(sel.attributes, c.attributes)
 
+        ind = np.array([3, 4, 5, 6])
+        sel = c[ind]
+        self.assertEqual(len(sel), len(ind))
+        self.assertEqual(len(sel._tokens), len(ind))
+        np.testing.assert_equal(sel._tokens, c._tokens[ind])
+        self.assertEqual(sel._dictionary, c._dictionary)
+        self.assertEqual(sel.text_features, c.text_features)
+        self.assertEqual(sel.ngram_range, c.ngram_range)
+        self.assertEqual(sel.attributes, c.attributes)
+
         sel = c[...]
         self.assertEqual(sel, c)
 

--- a/orangecontrib/text/tests/test_utils.py
+++ b/orangecontrib/text/tests/test_utils.py
@@ -50,6 +50,14 @@ class TestSparse2CorpusSliceable(unittest.TestCase):
         )
         assert_array_equal(self.s2c[[1]].sparse.toarray(), self.orig_array[:, [1]])
 
+    def test_ndarray(self):
+        assert_array_equal(
+            self.s2c[np.array([1, 2])].sparse.toarray(), self.orig_array[:, [1, 2]]
+        )
+        assert_array_equal(
+            self.s2c[np.array([1])].sparse.toarray(), self.orig_array[:, [1]]
+        )
+
     def test_elipsis(self):
         assert_array_equal(self.s2c[...].sparse.toarray(), self.orig_array)
 

--- a/orangecontrib/text/util.py
+++ b/orangecontrib/text/util.py
@@ -74,7 +74,7 @@ class Sparse2CorpusSliceable(Sparse2Corpus):
     """
 
     def __getitem__(
-        self, key: Union[int, List[int], type(...), slice]
+        self, key: Union[int, List[int], np.ndarray, type(...), slice]
     ) -> Sparse2Corpus:
         """Retrieve a document vector from the corpus by its index.
 
@@ -87,7 +87,7 @@ class Sparse2CorpusSliceable(Sparse2Corpus):
         -------
         Selected subset of sparse data from self.
         """
-        if not isinstance(key, (int, list, type(...), slice)):
+        if not isinstance(key, (int, list, type(...), slice, np.ndarray)):
             raise TypeError(f"Indexing by type {type(key)} not supported.")
         sparse = self.sparse.__getitem__((slice(None, None, None), key))
         return Sparse2CorpusSliceable(sparse)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #735 

##### Description of changes
When implementing `__getitems__` for `Sparse2CorpusSliceable` I forgot for the scenario when the key is np.ndarray instead of a list. Adding this option.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
