### PR TITLE
Sparse2CorpusSliceable: enable slicing with range

### DIFF
--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -449,6 +449,16 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(sel.ngram_range, c.ngram_range)
         self.assertEqual(sel.attributes, c.attributes)
 
+        ind = range(3, 7)
+        sel = c[ind]
+        self.assertEqual(len(sel), len(ind))
+        self.assertEqual(len(sel._tokens), len(ind))
+        np.testing.assert_equal(sel._tokens, c._tokens[list(ind)])
+        self.assertEqual(sel._dictionary, c._dictionary)
+        self.assertEqual(sel.text_features, c.text_features)
+        self.assertEqual(sel.ngram_range, c.ngram_range)
+        self.assertEqual(sel.attributes, c.attributes)
+
         sel = c[...]
         self.assertEqual(sel, c)
 

--- a/orangecontrib/text/tests/test_utils.py
+++ b/orangecontrib/text/tests/test_utils.py
@@ -58,6 +58,14 @@ class TestSparse2CorpusSliceable(unittest.TestCase):
             self.s2c[np.array([1])].sparse.toarray(), self.orig_array[:, [1]]
         )
 
+    def test_range(self):
+        assert_array_equal(
+            self.s2c[range(1, 3)].sparse.toarray(), self.orig_array[:, [1, 2]]
+        )
+        assert_array_equal(
+            self.s2c[range(1, 2)].sparse.toarray(), self.orig_array[:, [1]]
+        )
+
     def test_elipsis(self):
         assert_array_equal(self.s2c[...].sparse.toarray(), self.orig_array)
 

--- a/orangecontrib/text/util.py
+++ b/orangecontrib/text/util.py
@@ -87,7 +87,5 @@ class Sparse2CorpusSliceable(Sparse2Corpus):
         -------
         Selected subset of sparse data from self.
         """
-        if not isinstance(key, (int, list, type(...), slice, np.ndarray)):
-            raise TypeError(f"Indexing by type {type(key)} not supported.")
         sparse = self.sparse.__getitem__((slice(None, None, None), key))
         return Sparse2CorpusSliceable(sparse)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Sparse2CorpusSliceable didn't enable slicing for range and other types of generators


##### Description of changes
Enable slicing for range and other similar generators. With this PR I remove custom check about type since CSC can do that on its own. Extra checks just increase the chance for errors.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
