### PR TITLE
Corpus Viewer: Run search when finished typing the query (on enter).

### DIFF
--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -92,8 +92,8 @@ class OWCorpusViewer(OWWidget):
                                          orientation=Qt.Horizontal,
                                          sizePolicy=QSizePolicy(QSizePolicy.MinimumExpanding,
                                                                 QSizePolicy.Fixed),
-                                         label='RegExp Filter:')
-        self.filter_input.textChanged.connect(self.refresh_search)
+                                         label='RegExp Filter:',
+                                         callback=self.refresh_search)
 
         # Main area
         self.splitter = QSplitter(

--- a/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
@@ -22,6 +22,7 @@ class TestCorpusViewerWidget(WidgetTest):
     def test_search(self):
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.widget.regexp_filter = "Human"
+        self.widget.refresh_search()
         self.process_events()
         out_corpus = self.get_output(self.widget.Outputs.matching_docs)
         self.assertEqual(len(out_corpus), 1)
@@ -30,6 +31,7 @@ class TestCorpusViewerWidget(WidgetTest):
         # first document is selected, when filter with word that is not in
         # selected document out_corpus is None
         self.widget.regexp_filter = "graph"
+        self.widget.refresh_search()
         self.process_events()
         out_corpus = self.get_output(self.widget.Outputs.matching_docs)
         self.assertIsNone(out_corpus)
@@ -38,6 +40,7 @@ class TestCorpusViewerWidget(WidgetTest):
 
         # when filter is removed, matched words is 0
         self.widget.regexp_filter = ""
+        self.widget.refresh_search()
         self.process_events()
         self.assertEqual(self.widget.matches, 0)
 
@@ -73,6 +76,7 @@ class TestCorpusViewerWidget(WidgetTest):
 
         self.send_signal(self.widget.Inputs.corpus, corpus)
         self.widget.regexp_filter = "\\bсад\\b"
+        self.widget.refresh_search()
         self.process_events()
         self.widget.doc_webview.html()
         spy = QSignalSpy(self.widget.doc_webview.loadFinished)
@@ -84,6 +88,7 @@ class TestCorpusViewerWidget(WidgetTest):
         """ Output is intersection between selection and filter """
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.widget.regexp_filter = "graph"
+        self.widget.refresh_search()
         self.process_events()
         self.assertIsNone(self.get_output(self.widget.Outputs.matching_docs))
         self.assertEqual(
@@ -108,6 +113,7 @@ class TestCorpusViewerWidget(WidgetTest):
         )
 
         self.widget.regexp_filter = "human"
+        self.widget.refresh_search()
         self.process_events()
         # empty because none of matching documents is selected
         self.assertIsNone(self.get_output(self.widget.Outputs.matching_docs))


### PR DESCRIPTION
##### Issue
Fixes #704 using Option 1.


##### Description of changes
Do not run search after every keypress (slow), but only once after typing the whole query and pressing Enter.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
