### PR TITLE
Sentiment Analysis: prevent preprocessing of NoneType and computing mean of an empty array

### DIFF
--- a/orangecontrib/text/sentiment/__init__.py
+++ b/orangecontrib/text/sentiment/__init__.py
@@ -235,9 +235,10 @@ class SentiArt(Sentiment):
     def get_scores(self, corpus):
         scores = []
         for doc in corpus.tokens:
-            score = np.array([list(self.dictionary[word].values()) for word in\
-                                   doc if word in self.dictionary]).mean(axis=0)
-            scores.append(score)
+            score = np.array([list(self.dictionary[word].values()) for word in
+                              doc if word in self.dictionary])
+            scores.append(score.mean(axis=0) if score.shape[0] > 0
+                          else np.zeros(len(self.sentiments)))
         return scores
 
 

--- a/orangecontrib/text/tests/test_sentiment.py
+++ b/orangecontrib/text/tests/test_sentiment.py
@@ -1,5 +1,7 @@
 import unittest
 
+from numpy.testing import assert_allclose
+
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.sentiment import LiuHuSentiment, VaderSentiment, \
     MultiSentiment, SentiArt
@@ -96,8 +98,14 @@ class MultiSentimentTest(LiuHuTest):
 class SentiArtTest(LiuHuTest):
     def setUp(self):
         self.corpus = Corpus.from_file('deerwester')
+        self.slo_corpus = Corpus.from_file('slo-opinion-corpus')[83:85]
         self.method = SentiArt()
         self.new_cols = 7
+
+    def test_empty_slice_mean(self):
+        # this should execute without raising an exception
+        result = self.method.transform(self.slo_corpus)
+        assert_allclose(result.X[0, -self.new_cols:], 0)
 
 
 if __name__ == "__main__":

--- a/orangecontrib/text/widgets/owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/owsentimentanalysis.py
@@ -189,11 +189,12 @@ class OWSentimentAnalysis(OWWidget):
     @Inputs.corpus
     def set_corpus(self, data=None):
         self.corpus = data
-        # create preprocessed corpus upon setting data to avoid preprocessing
-        # at each method run
-        pp_list = [preprocess.LowercaseTransformer(),
-                   preprocess.WordPunctTokenizer()]
-        self.pp_corpus = PreprocessorList(pp_list)(self.corpus)
+        if self.corpus is not None:
+            # create preprocessed corpus upon setting data to avoid preprocessing
+            # at each method run
+            pp_list = [preprocess.LowercaseTransformer(),
+                       preprocess.WordPunctTokenizer()]
+            self.pp_corpus = PreprocessorList(pp_list)(self.corpus)
         self.commit()
 
     def _method_changed(self):

--- a/orangecontrib/text/widgets/owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/owsentimentanalysis.py
@@ -185,7 +185,6 @@ class OWSentimentAnalysis(OWWidget):
             else:
                 self.Warning.senti_offline_no_lang()
 
-
     @Inputs.corpus
     def set_corpus(self, data=None):
         self.corpus = data

--- a/orangecontrib/text/widgets/tests/test_owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/tests/test_owsentimentanalysis.py
@@ -1,4 +1,5 @@
 import os
+import time
 import numpy as np
 
 from unittest import mock, skip
@@ -109,3 +110,7 @@ class TestSentimentWidget(WidgetTest):
         widget.vader.click()
         self.assertFalse(widget.Warning.one_dict_only.is_shown())
         self.assertFalse(widget.Warning.no_dicts_loaded.is_shown())
+
+    def test_none_type_input(self):
+        # this should not raise an exception
+        self.send_signal("Corpus", None)


### PR DESCRIPTION
##### Issue
Fixes #739 and another error in Sentiment Analysis.

##### Description of changes
- OWSentimentAnalysis: fixed the part of code that calls preprocessors on NoneType.  
- SentiArt: fixed the part of code that causes an error when a document doesn't contain any word from dictionary. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
