### PR TITLE
[FIX] Topic - remove topic computations in chuck which results in poor topics

### DIFF
--- a/orangecontrib/text/topics/lda.py
+++ b/orangecontrib/text/topics/lda.py
@@ -9,4 +9,6 @@ class LdaWrapper(GensimWrapper):
     Model = models.LdaModel
 
     def __init__(self, **kwargs):
-        super().__init__(random_state=0, **kwargs, dtype=float64)
+        # with 200 iterations on pass (default) is usually not enough for all
+        # documents to converge - with 5 it converged in all my cases
+        super().__init__(random_state=0, **kwargs, dtype=float64, iterations=200, passes=5)

--- a/orangecontrib/text/vectorization/bagofwords.py
+++ b/orangecontrib/text/vectorization/bagofwords.py
@@ -76,7 +76,7 @@ class BowVectorizer(BaseVectorizer):
                                   wlocal=self.wlocals[self.wlocal],
                                   wglobal=self.wglobals[self.wglobal])
 
-        X = matutils.corpus2csc(model[temp_corpus], dtype=np.float, num_terms=len(dic)).T
+        X = matutils.corpus2csc(model[temp_corpus], dtype=float, num_terms=len(dic)).T
         norm = self.norms[self.norm]
         if norm:
             X = norm(X)

--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -109,7 +109,7 @@ def _run(corpus: Corpus, model: GensimWrapper, state: TaskState):
         if state.is_interruption_requested():
             raise Exception
 
-    return model.fit_transform(corpus.copy(), chunk_number=100, on_progress=callback)
+    return model.fit_transform(corpus.copy(), on_progress=callback)
 
 
 class OWTopicModeling(OWWidget, ConcurrentWidgetMixin):

--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -227,6 +227,7 @@ class OWTopicModeling(OWWidget, ConcurrentWidgetMixin):
             widget.setVisible(i == self.method_index)
 
     def apply(self):
+        self.cancel()
         self.topic_desc.clear()
         if self.corpus is not None:
             self.Warning.less_topics_found.clear()

--- a/orangecontrib/text/widgets/tests/test_owtopicmodeling.py
+++ b/orangecontrib/text/widgets/tests/test_owtopicmodeling.py
@@ -1,6 +1,8 @@
 import unittest
+from unittest import skipIf
 
 import numpy as np
+import gensim
 from AnyQt.QtCore import QItemSelectionModel
 
 from Orange.widgets.tests.base import WidgetTest
@@ -22,7 +24,14 @@ class TestTopicModeling(WidgetTest):
         output = self.get_output(self.widget.Outputs.selected_topic)
         self.assertIsNone(output)
 
+    @skipIf(gensim.__version__ <= "4.1.2", "lsi model does not have random_seed")
     def test_saved_selection(self):
+        self.assertTrue(False)
+        # LSI does not have random_seed in gensim 4.1.2 but will have in next version
+        # when this test start to fail
+        # - remove line above
+        # - set random_seed to LSI model and set gensim requirement
+        # - remove skip on this test
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.wait_until_finished()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Current topic implementation train models such that they get chunks of documents at a time. For small corpora, it means that one chunk is 1 or 2 documents big. This kind of topic training also results in bad results. 

The problem with LDA is that it is usually not trained enough (all documents do not converge).

##### Description of changes
- train topic models in one shot and use callback for progress instead of training in chunks (the problem here is that only LDA supports callbacks which means that the other two models will not have progress in the widget 👎  )
- increase the number of passes and iterations for LDA - it solves the second problem from the above list (with more passes and iterations model will take more time to train than before). Setting passes to 5 is not optimal since it varies depending on the data. As I read there is currently no way for early stopping. One possibility would be to give a number of passes as a parameter to the widget and report on convergence, that the user can select the best setting for himself.
- methods update and reset_model are deprecated and will be removed later in case anyone uses them directly
- replace deprecated np.float in bag-of-words
- fix widget that error when data disconnected while processing (fixes https://github.com/biolab/orange3-text/issues/753)


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
