### PR TITLE
semantic-search: increase maximal allowed chunk size, fix error when timeout

### DIFF
--- a/orangecontrib/text/tests/test_semantic_search.py
+++ b/orangecontrib/text/tests/test_semantic_search.py
@@ -106,6 +106,18 @@ class SemanticSearchTest(unittest.TestCase):
         result = self.semantic_search(self.corpus.documents, QUERIES)
         self.assertEqual(result, IDEAL_RESPONSE)
 
+    # added None three times since server will repeate request on None response
+    # three times
+    @patch(PATCH_METHOD, make_dummy_post(iter(RESPONSE[:-1] + [None] * 3)))
+    def test_none_result(self):
+        """
+        It can happen that the result of an embedding for a chunk is None (server
+        fail to respond three times because Timeout or other error).
+        Make sure that semantic search module can handle None responses.
+        """
+        result = self.semantic_search(self.corpus.documents, QUERIES)
+        self.assertEqual(result, IDEAL_RESPONSE[:-1] + [None])
+
     @patch(PATCH_METHOD, make_dummy_post(RESPONSE[0]))
     def test_success_chunks(self):
         num_docs = len(self.corpus.documents)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
1. When doing a semantic search on laws, many of them are longer than 50000, all of them are below 300000
2. Sometimes embedding fails since timeout happens in embedding. In those cases result for a chunk is None and not a list. The current implementation fails since it wants to extend the list with None.

##### Description of changes
- handle error 2
- allow documents to be maximally 300000 long and still make chunks with max size 50000. Documents that are longer than MAX_CHUNK_SIZE will be in one request which is longer thank MAX_CHUNK_SIZE

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
