### PR TITLE
[FIX] score-documents: handle document titles with newlines

### DIFF
--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -283,6 +283,13 @@ class ScoreDocumentsTableModel(PyTableModel):
         super().__init__(parent=parent)
         self._extremes = {}
 
+    @staticmethod
+    def simplify(s):
+        """Remove tab and newline characters from the string"""
+        for ch in "\n\t\r":
+            s = s.replace(ch, " ")
+        return s
+
     def data(self, index, role=Qt.DisplayRole):
         if index.column() > 0 and role == gui.BarRatioRole and index.isValid():
             # for all except first columns return ratio for distribution bar
@@ -291,6 +298,9 @@ class ScoreDocumentsTableModel(PyTableModel):
             return (value - vmin) / ((vmax - vmin) or 1)
         if role in (gui.BarRatioRole, Qt.DisplayRole):
             dat = super().data(index, Qt.EditRole)
+            if role == Qt.DisplayRole and index.column() == 0:
+                # in document title column remove newline characters from titles
+                dat = self.simplify(dat)
             return dat
         if role == Qt.BackgroundColorRole and index.column() == 0:
             return TableModel.ColorForRole[TableModel.Meta]

--- a/orangecontrib/text/widgets/tests/test_owscoredocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owscoredocuments.py
@@ -433,6 +433,15 @@ class TestOWScoreDocuments(WidgetTest):
         output = self.get_output(self.widget.Outputs.selected_documents)
         self.assertTrue("Word count (1)" in output.domain)
 
+    def test_titles_no_newline(self):
+        corpus = Corpus.from_file("andersen")
+        corpus.metas[0, 0] = corpus.metas[0, 0] + "\ntest"
+        corpus.set_title_variable("Title")
+        self.send_signal(self.widget.Inputs.corpus, corpus)
+        self.assertEqual(
+            "The Little Match-Seller test", self.widget.view.model().index(0, 0).data()
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In score documents, titles with newline characters were cropped and centered vertically

![Screenshot 2021-11-19 at 15 44 50](https://user-images.githubusercontent.com/6421558/142641755-fb0c8507-7017-4499-b91a-c0deef6a326f.png)

##### Description of changes
Remove newline characters from titles for display purpose (as table widget and corpus viewer do)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
