### PR TITLE
Delete requirements-doc.txt

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,0 @@
-beautifulsoup4
-docutils
-numpydoc
-recommonmark>=0.1.1
-Sphinx>=1.3
-PyQt5


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Up to date requirements for the documentation build are in extras_require in setup.py. This file is not required anymore and is not up to date.

##### Description of changes
Removing requirements-doc.txt
Now use: `pip install .[doc]` to isntall documentation requirements

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
