### PR TITLE
Table lock compatibility

### DIFF
--- a/orangecontrib/text/tests/__init__.py
+++ b/orangecontrib/text/tests/__init__.py
@@ -1,2 +1,0 @@
-from Orange.data import Table
-Table.LOCKING = False

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -69,8 +69,10 @@ class PreprocessTests(unittest.TestCase):
         p = preprocess.LowercaseTransformer()
         tokens2 = self.corpus.tokens.copy()
         tokens = p(self.corpus).tokens
-        np.testing.assert_equal(tokens,
-                                [[t.lower() for t in doc] for doc in tokens2])
+        np.testing.assert_equal(
+            tokens,
+            np.array([[t.lower() for t in doc] for doc in tokens2], dtype="object")
+        )
 
     def test_tokenizer(self):
         class SpaceTokenizer(preprocess.BaseTokenizer):
@@ -94,7 +96,9 @@ class PreprocessTests(unittest.TestCase):
         tokens = p(self.corpus).tokens
 
         np.testing.assert_equal(
-            tokens, [[t.capitalize() for t in doc] for doc in tokens2])
+            tokens,
+            np.array([[t.capitalize() for t in doc] for doc in tokens2], dtype="object")
+        )
 
     def test_token_filter(self):
         class LengthFilter(preprocess.BaseTokenFilter):
@@ -123,7 +127,8 @@ class PreprocessTests(unittest.TestCase):
                    tag.AveragedPerceptronTagger(),
                    preprocess.StopwordsFilter()]
         corpus = self.corpus
-        corpus.metas[0, 0] = "This is the most beautiful day in the world"
+        with corpus.unlocked():
+            corpus.metas[0, 0] = "This is the most beautiful day in the world"
         for pp in pp_list:
             corpus = pp(corpus)
         self.assertEqual(len(corpus.tokens), len(corpus.pos_tags))
@@ -185,8 +190,9 @@ class TransformationTests(unittest.TestCase):
 
     def test_url_remover(self):
         remover = preprocess.UrlRemover()
-        self.corpus.metas[0, 0] = 'some link to https://google.com/'
-        self.corpus.metas[1, 0] = 'some link to google.com'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'some link to https://google.com/'
+            self.corpus.metas[1, 0] = 'some link to google.com'
         corpus = remover(self.corpus)
         self.assertListEqual(corpus.pp_documents[:2],
                              ['some link to ', 'some link to google.com'])
@@ -262,7 +268,8 @@ class TokenNormalizerTests(unittest.TestCase):
     def test_udpipe(self):
         """Test udpipe token lemmatization"""
         normalizer = preprocess.UDPipeLemmatizer('Slovenian')
-        self.corpus.metas[0, 0] = 'sem'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'sem'
         corpus = normalizer(self.corpus)
         self.assertListEqual(list(corpus.tokens[0]), ['biti'])
         self.assertEqual(len(corpus.used_preprocessor.preprocessors), 2)
@@ -270,7 +277,8 @@ class TokenNormalizerTests(unittest.TestCase):
     def test_udpipe_doc(self):
         """Test udpipe lemmatization with its own tokenization """
         normalizer = preprocess.UDPipeLemmatizer('Slovenian', True)
-        self.corpus.metas[0, 0] = 'Gori na gori hiša gori'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'Gori na gori hiša gori'
         corpus = normalizer(self.corpus)
         self.assertListEqual(list(corpus.tokens[0]),
                              ['gora', 'na', 'gora', 'hiša', 'goreti'])
@@ -285,7 +293,8 @@ class TokenNormalizerTests(unittest.TestCase):
                          loaded._UDPipeLemmatizer__language)
         self.assertEqual(normalizer._UDPipeLemmatizer__use_tokenizer,
                          loaded._UDPipeLemmatizer__use_tokenizer)
-        self.corpus.metas[0, 0] = 'Gori na gori hiša gori'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'Gori na gori hiša gori'
         self.assertEqual(list(loaded(self.corpus).tokens[0]),
                          ['gora', 'na', 'gora', 'hiša', 'goreti'])
 
@@ -296,14 +305,16 @@ class TokenNormalizerTests(unittest.TestCase):
                          copied._UDPipeLemmatizer__language)
         self.assertEqual(normalizer._UDPipeLemmatizer__use_tokenizer,
                          copied._UDPipeLemmatizer__use_tokenizer)
-        self.corpus.metas[0, 0] = 'Gori na gori hiša gori'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'Gori na gori hiša gori'
         self.assertEqual(list(copied(self.corpus).tokens[0]),
                          ['gora', 'na', 'gora', 'hiša', 'goreti'])
 
     def test_lemmagen(self):
         normalizer = preprocess.LemmagenLemmatizer('Slovenian')
         sentence = 'Gori na gori hiša gori'
-        self.corpus.metas[0, 0] = sentence
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = sentence
         self.assertEqual(
             [Lemmatizer("sl").lemmatize(t) for t in sentence.split()],
             normalizer(self.corpus).tokens[0],
@@ -319,7 +330,8 @@ class TokenNormalizerTests(unittest.TestCase):
 
     def test_cache(self):
         normalizer = preprocess.UDPipeLemmatizer('Slovenian')
-        self.corpus.metas[0, 0] = 'sem'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'sem'
         normalizer(self.corpus)
         self.assertEqual(normalizer._normalization_cache['sem'], 'biti')
         self.assertEqual(40, len(normalizer._normalization_cache))
@@ -392,7 +404,8 @@ class FilteringTests(unittest.TestCase):
         f = preprocess.StopwordsFilter('english')
         self.assertFalse(f._check('a'))
         self.assertTrue(f._check('filter'))
-        self.corpus.metas[0, 0] = 'a snake is in a house'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'a snake is in a house'
         corpus = f(self.corpus)
         self.assertListEqual(["snake", "house"], corpus.tokens[0])
         self.assertEqual(len(corpus.used_preprocessor.preprocessors), 2)
@@ -401,7 +414,8 @@ class FilteringTests(unittest.TestCase):
         f = preprocess.StopwordsFilter('slovene')
         self.assertFalse(f._check('in'))
         self.assertTrue(f._check('abeceda'))
-        self.corpus.metas[0, 0] = 'kača je v hiši'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'kača je v hiši'
         corpus = f(self.corpus)
         self.assertListEqual(["kača", "hiši"], corpus.tokens[0])
         self.assertEqual(len(corpus.used_preprocessor.preprocessors), 2)
@@ -470,15 +484,14 @@ class FilteringTests(unittest.TestCase):
         self.assertTrue(preprocess.RegexpFilter.validate_regexp('\?'))
 
         reg_filter = preprocess.RegexpFilter(r'.')
-        corpus = self.corpus
-        filtered = reg_filter(corpus)
-        self.assertFalse(filtered.tokens[0])
+        filtered = reg_filter(self.corpus)
+        self.assertEqual(0, len(filtered.tokens[0]))
         self.assertEqual(len(filtered.used_preprocessor.preprocessors), 2)
 
         reg_filter = preprocess.RegexpFilter('foo')
-        corpus = self.corpus
-        corpus.metas[0, 0] = 'foo bar'
-        filtered = reg_filter(corpus)
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'foo bar'
+        filtered = reg_filter(self.corpus)
         self.assertEqual(filtered.tokens[0], ['bar'])
         self.assertEqual(len(filtered.used_preprocessor.preprocessors), 2)
 
@@ -503,12 +516,14 @@ class FilteringTests(unittest.TestCase):
 
     def test_can_deepcopy(self):
         copied = copy.deepcopy(self.regexp)
-        self.corpus.metas[0, 0] = 'foo bar'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'foo bar'
         self.assertEqual(copied(self.corpus).tokens[0], ['bar'])
 
     def test_can_pickle(self):
         loaded = pickle.loads(pickle.dumps(self.regexp))
-        self.corpus.metas[0, 0] = 'foo bar'
+        with self.corpus.unlocked():
+            self.corpus.metas[0, 0] = 'foo bar'
         self.assertEqual(loaded(self.corpus).tokens[0], ['bar'])
 
 

--- a/orangecontrib/text/topics/topics.py
+++ b/orangecontrib/text/topics/topics.py
@@ -159,11 +159,10 @@ class GensimWrapper:
         metas[-1]._out_format = '%.2e'
 
         domain = Domain([], metas=metas)
-        t = Topic.from_numpy(domain,
-                             X=np.zeros((num_words, 0)),
-                             metas=data)
-        t.W = data[:, 1]
-        t.name = 'Topic {}'.format(topic_id + 1)
+        t = Topic.from_numpy(
+            domain, X=np.zeros((num_words, 0)), metas=data, W=data[:, 1]
+        )
+        t.name = "Topic {}".format(topic_id + 1)
 
         # needed for coloring in word cloud
         t.attributes["topic-method-name"] = self.model.__class__.__name__

--- a/orangecontrib/text/vectorization/base.py
+++ b/orangecontrib/text/vectorization/base.py
@@ -1,44 +1,7 @@
-from itertools import chain
-
 import numpy as np
 
 from Orange.data.util import SharedComputeValue
-from Orange.data import Domain
-
-# uncomment when Orange3==3.27 is available
-# from Orange.data.util import get_unique_names
-
-
-# remove following section when orange3=3.27 is available
-import re
-
 from orangecontrib.text.util import Sparse2CorpusSliceable
-
-RE_FIND_INDEX = r"(^{})( \((\d{{1,}})\))?$"
-
-
-def get_indices(names, name):
-    return [int(a.group(3) or 0) for x in filter(None, names)
-            for a in re.finditer(RE_FIND_INDEX.format(re.escape(name)), x)]
-
-
-def get_unique_names(names, proposed, equal_numbers=True):
-    # prevent cyclic import: pylint: disable=import-outside-toplevel
-    if isinstance(names, Domain):
-        names = [var.name for var in chain(names.variables, names.metas)]
-    if isinstance(proposed, str):
-        return get_unique_names(names, [proposed])[0]
-    indices = {name: get_indices(names, name) for name in proposed}
-    indices = {name: max(ind) + 1 for name, ind in indices.items() if ind}
-    if not (set(proposed) & set(names) or indices):
-        return proposed
-    if equal_numbers:
-        max_index = max(indices.values())
-        return [f"{name} ({max_index})" for name in proposed]
-    else:
-        return [f"{name} ({indices[name]})" if name in indices else name
-                for name in proposed]
-# ----
 
 
 class BaseVectorizer:

--- a/orangecontrib/text/widgets/tests/__init__.py
+++ b/orangecontrib/text/widgets/tests/__init__.py
@@ -1,2 +1,0 @@
-from Orange.data import Table
-Table.LOCKING = False

--- a/orangecontrib/text/widgets/tests/test_owcorpus.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpus.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import Mock
 
 import numpy as np
 from Orange.data import Table, Domain, StringVariable, ContinuousVariable

--- a/orangecontrib/text/widgets/tests/test_owduplicates.py
+++ b/orangecontrib/text/widgets/tests/test_owduplicates.py
@@ -31,5 +31,11 @@ class TestDuplicatesWidget(WidgetTest):
         out_corpus = self.get_output(self.widget.Outputs.duplicates)
         self.assertIsNone(out_corpus)
 
+    def test_output_corpus(self):
+        self.send_signal(self.widget.Inputs.distances, self.distances)
+        out_corpus = self.get_output(self.widget.Outputs.corpus)
+        self.assertIn(out_corpus.domain["Duplicates Cluster"], out_corpus.domain.metas)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/text/widgets/tests/test_owscoredocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owscoredocuments.py
@@ -435,7 +435,8 @@ class TestOWScoreDocuments(WidgetTest):
 
     def test_titles_no_newline(self):
         corpus = Corpus.from_file("andersen")
-        corpus.metas[0, 0] = corpus.metas[0, 0] + "\ntest"
+        with corpus.unlocked():
+            corpus.metas[0, 0] = corpus.metas[0, 0] + "\ntest"
         corpus.set_title_variable("Title")
         self.send_signal(self.widget.Inputs.corpus, corpus)
         self.assertEqual(

--- a/orangecontrib/text/widgets/tests/test_owstatistics.py
+++ b/orangecontrib/text/widgets/tests/test_owstatistics.py
@@ -1,8 +1,6 @@
 import unittest
-from unittest.mock import Mock
 
 import numpy as np
-import pkg_resources
 from AnyQt.QtWidgets import QPushButton
 
 from Orange.data import Domain, StringVariable
@@ -27,12 +25,12 @@ class TestStatisticsWidget(WidgetTest):
         """
         metas = np.array(
             [
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                "Duis viverra elit eu mi blandit, {et} sollicitudin nisi ",
-                " a porta\tleo. Duis vitae ultrices massa. Mauris ut pulvinar a",
-                "tortor. Class (aptent) taciti\nsociosqu ad lit1ora torquent per",
+                ["Lorem ipsum dolor sit amet, consectetur adipiscing elit."],
+                ["Duis viverra elit eu mi blandit, {et} sollicitudin nisi "],
+                [" a porta\tleo. Duis vitae ultrices massa. Mauris ut pulvinar a"],
+                ["tortor. Class (aptent) taciti\nsociosqu ad lit1ora torquent per"],
             ]
-        ).reshape(-1, 1)
+        )
         text_var = StringVariable("text")
         domain = Domain([], metas=[text_var])
         self.corpus = Corpus(
@@ -168,7 +166,8 @@ class TestStatisticsWidget(WidgetTest):
             data.X.flatten(), [1, 1, 0.909091, 1]
         )
 
-        self.corpus[1][-1] = ""
+        with self.corpus.unlocked():
+            self.corpus[1][-1] = ""
         data = self._compute_features("Per cent unique words")
         np.testing.assert_array_almost_equal(
             data.X.flatten(), [1, np.nan, 0.909091, 1]
@@ -266,7 +265,8 @@ class TestStatisticsWidget(WidgetTest):
         self.assertEqual(0, res.X.shape[1])
         self.assertTrue(self.widget.Warning.not_computed.is_shown())
 
-        self.corpus[1][-1] = "simple"
+        with self.corpus.unlocked():
+            self.corpus[1][-1] = "simple"
         tagger = AveragedPerceptronTagger()
         result = tagger(self.corpus)
 
@@ -284,7 +284,8 @@ class TestStatisticsWidget(WidgetTest):
         """
         Test LIX readability score.
         """
-        self.corpus[1][-1] = "simple. simple."
+        with self.corpus.unlocked():
+            self.corpus[1][-1] = "simple. simple."
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self._set_feature("LIX index")
         self.widget.apply()

--- a/orangecontrib/text/widgets/tests/test_owwordcloud.py
+++ b/orangecontrib/text/widgets/tests/test_owwordcloud.py
@@ -12,10 +12,6 @@ from orangecontrib.text.topics import Topic
 from orangecontrib.text.widgets.owwordcloud import OWWordCloud
 
 
-@unittest.skipIf(
-    pkg_resources.get_distribution("orange3").version < "3.24.0",
-    "Wait until finished not implemented in lower version"
-)
 class TestWordCloudWidget(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWWordCloud)
@@ -154,7 +150,8 @@ class TestWordCloudWidget(WidgetTest):
         In some very rare cases (when all text strings empty) word cloud all
         token lists empty. Widget must work in those cases.
         """
-        self.corpus.metas = np.array([[" "]] * len(self.corpus))
+        with self.corpus.unlocked():
+            self.corpus.metas = np.array([[" "]] * len(self.corpus))
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.wait_until_finished()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Text add-on have disabled table lock

##### Description of changes
Enable table lock and resolve all table lock incompatibilities

This PR also:
- moves clusters to metas in duplicates widget's output table (similarly than it is made in other widgets). Before it was decided by the user via combo box which is now removed
- updated Corpus.from_file to search for files in `dataset_dirs` instead of having its own logic
- deprecate `extend_corpus` since it is not compatible with the idea of not changing table, it is also not used in the add-on
- remove temporary function `get_unique_names` which can be now imported from Orange 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
