### PR TITLE
Increase minimum supported version of Orange to 3.31.1

### DIFF
--- a/orangecontrib/text/import_documents.py
+++ b/orangecontrib/text/import_documents.py
@@ -205,10 +205,6 @@ class UrlReader(Reader, CoreUrlReader):
         Reader.__init__(self, path, *args)
 
     def read_file(self):
-        # unquote prevent double quoting when filename is already quoted
-        # when not quoted it doesn't change url - it is required since Orange's
-        # UrlReader quote urls in version 3.29 but not in older versions
-        self.filename = quote(unquote(self.filename), safe="/:")
         self.filename = self._trim(self._resolve_redirects(self.filename))
         with contextlib.closing(self.urlopen(self.filename)) as response:
             name = self._suggest_filename(

--- a/orangecontrib/text/misc/nltk_data_download.py
+++ b/orangecontrib/text/misc/nltk_data_download.py
@@ -17,6 +17,7 @@ NLTK_DATA = [
     'vader_lexicon',
     'averaged_perceptron_tagger',
     'maxent_treebank_pos_tagger',
+    'omw-1.4',
 ]
 
 

--- a/orangecontrib/text/tests/test_import_documents.py
+++ b/orangecontrib/text/tests/test_import_documents.py
@@ -52,18 +52,6 @@ class TestUrlReader(unittest.TestCase):
         self.assertEqual(text_data.category, "data")
         self.assertEqual(text_data.content, "text")
 
-    def test_remove_quoting(self):
-        """
-        Since URL quoting is implemented in Orange it can be removed from text
-        addon when minimal version of Orange is increased to 3.29.1. When this
-        test start to fail remove the test itself and lines 191 - 194 in
-        import_documents.py
-        """
-        distribution = get_distribution('orange3-text')
-        orange_spec = next(x for x in distribution.requires() if x.name == "Orange3")
-        orange_min_version = tuple(map(int, orange_spec.specs[0][1].split(".")))
-        self.assertLess(orange_min_version, (3, 29, 1))
-
 
 class TestImportDocuments(unittest.TestCase):
     def test_scan_url(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml
 nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
 numpy
 odfpy>=1.3.5
-Orange3 >=3.28.0
+Orange3 >=3.31.1
 orange-widget-base >=4.14.0
 pandas
 pdfminer3k>=1.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,12 @@ setenv =
 deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
-    oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.28.0
+    oldest: scikit-learn~=0.23.1
+    oldest: orange3==3.31.1
 
     # Use newer canvas-core and widget-base to avoid segfaults on windows
-    oldest: orange-canvas-core==0.1.20
-    oldest: orange-widget-base==4.14.0
+    oldest: orange-canvas-core==0.1.24
+    oldest: orange-widget-base==4.16.1
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange3-network.git#egg=orange3-network
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Orange<3.31.1 does not support numpy>=1.22. Since there is no guarantee that numpy version will be <1.22 we must increase the Orange version to 3.31.1 otherwise Orange3-text does not work. Orange3-text even trigger updating numpy since one of its dependencies needs a higher version than is packed in the Orange3 installer.

##### Description of changes
With this PR I increased oldest supported version of Orange to 3.31.1

Also:
- fix nltk incompatiblity
- remove unneeded quoting in import documents


##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
