### PR TITLE
Import documents: async url reader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ biopython # Enables Pubmed widget.
 conllu
 docx2txt>=0.6
 gensim>=4.1.2  # https://github.com/RaRe-Technologies/gensim/issues/3226
+httpx
 lemmagen3
 lxml
 nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Import documents downloads files synchronously which is slower to asynchronous download.

##### Description of changes
Implement asynchronous download with HTTPX library.

Speedups:
predlogi-vladi-1k: 670s-> 47s
predlogi-vladi: now 540s for all documents (before more than 1h30m)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
