### PR TITLE
CI: Fix latest orange links

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,9 @@ deps =
     # Use newer canvas-core and widget-base to avoid segfaults on windows
     oldest: orange-canvas-core==0.1.24
     oldest: orange-widget-base==4.16.1
-    latest: git+git://github.com/biolab/orange3.git#egg=orange3
-    latest: git+git://github.com/biolab/orange3-network.git#egg=orange3-network
-    latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
+    latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
+    latest: https://github.com/biolab/orange3-network/archive/refs/heads/master.zip#egg=orange3-network
+    latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
 
     # TODO: some tests require orange3-network add-on. Skip for now, wheels not on pypi.
     # orange3-network


### PR DESCRIPTION
Github changed permissions without authentication. Use links that are able to reach without authentication.