### PR TITLE
Replace deprecated windows-2016 with 2019

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2016]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
         python-version: [3.7, 3.8]
         tox_env: [py-orange-released]
         experimental: [false]
@@ -34,7 +34,7 @@ jobs:
             experimental: true
             name: Big Sur
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.7
             tox_env: py-orange-oldest
             experimental: false
@@ -50,7 +50,7 @@ jobs:
             name: Oldest
             experimental: false
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.8
             tox_env: py-orange-latest
             experimental: false


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
windows-2016 workers were deprecated and removed from March 15

##### Description of changes
Replace windows-2016 with windows-2019 workers

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
