### PR TITLE
OWWordEnrichment: don't crash on selected data as Table input

### DIFF
--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -157,6 +157,10 @@ class OWWordEnrichment(OWWidget, ConcurrentWidgetMixin):
 
     def check_data(self):
         self.Error.clear()
+        if self.selected_data and not isinstance(self.selected_data, Corpus):
+            self.Error.no_bow_features()
+            self.clear()
+            return
         if isinstance(self.data, Table) and \
                 isinstance(self.selected_data, Table):
             if len(self.selected_data) == 0:

--- a/orangecontrib/text/widgets/tests/test_owwordenrichment.py
+++ b/orangecontrib/text/widgets/tests/test_owwordenrichment.py
@@ -105,6 +105,18 @@ class TestWordEnrichment(WidgetTest):
         self.send_signal(w.Inputs.selected_data, None)
         self.assertFalse(self.widget.Error.no_bow_features.is_shown())
 
+    def test_selected_data_is_table(self):
+        w = self.widget
+        iris = Table("iris")
+
+        self.send_signal(w.Inputs.data, self.corpus_vect)
+        self.send_signal(w.Inputs.selected_data, iris[:10])
+        self.assertTrue(self.widget.Error.no_bow_features.is_shown())
+
+        self.send_signal(w.Inputs.data, self.corpus_vect)
+        self.send_signal(w.Inputs.selected_data, self.subset_corpus)
+        self.assertFalse(self.widget.Error.no_bow_features.is_shown())
+
     def test_all_selected(self):
         w = self.widget
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #775. 

##### Description of changes
Handle selected data input being Table.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
