### PR TITLE
[FIX] Preprocess Text: set highest absolute frequency

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -210,6 +210,8 @@ class FrequencyFilter(FitDictionaryFilter):
     @property
     def max_df(self):
         if isinstance(self._max_df, int):
+            if self._max_df <= self._min_df:
+                return 1.
             return self._max_df / self._corpus_len if self._corpus_len else 1.
         else:
             return self._max_df


### PR DESCRIPTION
##### Issue
Fixes #669

##### Description of changes
Changes the behaviour of absolute frequency filter to return no upper cutoff point when the values of both boxes are equal.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
