### PR TITLE
OWImportDocuments: ensure stable file order

### DIFF
--- a/orangecontrib/text/import_documents.py
+++ b/orangecontrib/text/import_documents.py
@@ -604,7 +604,7 @@ class ImportDocuments:
                          and not matches_any(fname, exclude_patterns)]
             paths = paths + [os.path.join(dirpath, fname) for fname in
                              filenames]
-        return paths
+        return sorted(paths)
 
     @staticmethod
     def scan_url(topdir: str, include_patterns: Tuple[str] = ("*",),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Import Documents read files in a different order on different systems.

##### Description of changes
Ensure file order is always stable (sorted alphabetically).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
