### PR TITLE
[FIX] Keywords: Always invoke preprocessor __call__

### DIFF
--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -94,7 +94,9 @@ def run(
         # Normalize words
         for preprocessor in corpus.used_preprocessor.preprocessors:
             if isinstance(preprocessor, BaseNormalizer):
-                words = [preprocessor.normalizer(w) for w in words]
+                dummy = Corpus(Domain((), metas=[StringVariable("Words")]),
+                               metas=np.array(words)[:, None])
+                words = list(preprocessor(dummy).tokens.flatten())
 
         # Filter scores using words
         existing_words = [w for w in set(words) if w in scores.index]

--- a/orangecontrib/text/widgets/tests/test_owkeywords.py
+++ b/orangecontrib/text/widgets/tests/test_owkeywords.py
@@ -85,7 +85,7 @@ class TestRunner(unittest.TestCase):
         self.assertEqual(len(results.scores), 42)
 
     def test_run_normalize_words(self):
-        normalizer = WordNetLemmatizer()
+        normalizer = LemmagenLemmatizer()
         corpus = normalizer(self.corpus)
 
         words = ["minor", "tree"]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #806

##### Description of changes
Invoke preprocessor's `__call__` instead of `normalizer`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
