### PR TITLE
[FIX] Wikipedia: make widget useable again

### DIFF
--- a/orangecontrib/text/widgets/owwikipedia.py
+++ b/orangecontrib/text/widgets/owwikipedia.py
@@ -7,8 +7,7 @@ from Orange.widgets.widget import OWWidget, Msg, Output
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.language_codes import lang2code, code2lang
 from orangecontrib.text.widgets.utils import ComboBox, ListEdit, CheckListLayout, asynchronous
-
-from orangecontrib.text.wikipedia import WikipediaAPI
+from orangecontrib.text.wikipedia_api import WikipediaAPI
 
 
 class OWWikipedia(OWWidget):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Wikipedia widget was broken and not shown.

##### Description of changes
Fix import of a moved module.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
