### PR TITLE
Remove duplicated code for 'word' table creation

### DIFF
--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -23,8 +23,9 @@ from orangecontrib.text import Corpus
 from orangecontrib.text.keywords import ScoringMethods, AggregationMethods, \
     YAKE_LANGUAGE_MAPPING, RAKE_LANGUAGES, EMBEDDING_LANGUAGE_MAPPING
 from orangecontrib.text.preprocess import BaseNormalizer
+from orangecontrib.text.widgets.utils.words import create_words_table, \
+    WORDS_COLUMN_NAME
 
-WORDS_COLUMN_NAME = "Words"
 YAKE_LANGUAGES = list(YAKE_LANGUAGE_MAPPING.keys())
 EMBEDDING_LANGUAGES = list(EMBEDDING_LANGUAGE_MAPPING.keys())
 
@@ -456,9 +457,6 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
                            header.sortIndicatorOrder())
         if current_sorting != self.sort_column_order:
             header.setSortIndicator(*self.sort_column_order)
-            # needed to sort nans; 1. column has strings
-            # if self.sort_column_order[0] > 0:
-            #     self.model.sort(*self.sort_column_order)
 
     def onDeleteWidget(self):
         self.shutdown()
@@ -467,18 +465,20 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
     def commit(self):
         words = None
         if self.selected_words:
-            words_var = StringVariable(WORDS_COLUMN_NAME)
-            words_var.attributes = {"type": "words"}
+            sort_column, reverse = self.sort_column_order
             model = self.model
             attrs = [ContinuousVariable(model.headerData(i, Qt.Horizontal))
                      for i in range(1, model.columnCount())]
-            domain = Domain(attrs, metas=[words_var])
 
-            sort_column, reverse = self.sort_column_order
             data = sorted(model, key=lambda a: a[sort_column], reverse=reverse)
-            data = [s[1:] + s[:1] for s in data if s[0] in self.selected_words]
-            words = Table.from_list(domain, data)
-            words.name = "Words"
+            words_data = [s[0] for s in data if s[0] in self.selected_words]
+
+            words = create_words_table(words_data)
+            words = words.transform(Domain(attrs, metas=words.domain.metas))
+            with words.unlocked(words.X):
+                for i in range(len(attrs)):
+                    words.X[:, i] = [data[j][i + 1] for j in range(len(data))
+                                     if data[j][0] in self.selected_words]
 
         self.Outputs.words.send(words)
 
@@ -495,11 +495,7 @@ if __name__ == "__main__":
     # pylint: disable=ungrouped-imports
     from Orange.widgets.utils.widgetpreview import WidgetPreview
 
-    words_var_ = StringVariable(WORDS_COLUMN_NAME)
-    words_var_.attributes = {"type": "words"}
-    lists = [[w] for w in ["human", "graph", "minors", "trees"]]
-    words_ = Table.from_list(Domain([], metas=[words_var_]), lists)
-    words_.name = "Words"
+    words_ = create_words_table(["human", "graph", "minors", "trees"])
     WidgetPreview(OWKeywords).run(
         set_corpus=Corpus.from_file("deerwester"),  # deerwester book-excerpts
         # set_words=words_

--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -22,9 +22,10 @@ from Orange.widgets.utils.itemmodels import ModelActionsWidget, PyListModel
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 
 from orangecontrib.text.ontology import OntologyHandler
+from orangecontrib.text.widgets.utils.words import create_words_table, \
+    WORDS_COLUMN_NAME
 
 OntoType = Tuple[Dict[str, "OntoType"], bool]
-WORDS_COLUMN_NAME = "Words"
 resources_path = os.path.join(os.path.dirname(__file__), "resources")
 
 
@@ -38,16 +39,6 @@ def _run(handler: Callable, args: Tuple, state: TaskState) -> Dict:
 
     callback(0, "Calculating...")
     return handler(*args, callback=callback)
-
-    # if len(words) > 1:
-    #     words = [w.lower() for w in words]
-    #     return handler(words)
-    #     handler = OntologyHandler()
-    #     return handler.generate(words)
-    # elif len(words) == 1:
-    #     return {words[0].lower(): {}}
-    # else:
-    #     return {}
 
 
 def _model_to_tree(
@@ -732,12 +723,7 @@ class OWOntology(OWWidget, ConcurrentWidgetMixin):
     def _create_output_table(words: List[str]) -> Optional[Table]:
         if not words:
             return None
-        words_var = StringVariable("Words")
-        words_var.attributes = {"type": "words"}
-        domain = Domain([], metas=[words_var])
-        words = Table.from_list(domain, [[w] for w in words])
-        words.name = "Words"
-        return words
+        return create_words_table(words)
 
     def _cancel_tasks(self):
         self.cancel()
@@ -880,8 +866,5 @@ if __name__ == "__main__":
         "Odločba",
         "Sklep",
     ]
-    words_var_ = StringVariable("Words")
-    words_var_.attributes = {"type": "words"}
-    words_ = Table.from_list(Domain([], metas=[words_var_]), [[w] for w in ls])
-    words_.name = "Words"
+    words_ = create_words_table(ls)
     WidgetPreview(OWOntology).run(words_)

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -38,7 +38,7 @@ from orangecontrib.text.vectorization.document_embedder import (
     LANGS_TO_ISO,
     DocumentEmbedder,
 )
-
+from orangecontrib.text.widgets.utils.words import create_words_table
 
 def _word_frequency(corpus: Corpus, words: List[str], callback: Callable) -> np.ndarray:
     res = []
@@ -737,12 +737,5 @@ if __name__ == "__main__":
     for p in pp_list:
         corpus = p(corpus)
 
-    w = StringVariable("Words")
-    w.attributes["type"] = "words"
-    words = ["house", "doctor", "boy", "way", "Rum"]
-    words = Table(
-        Domain([], metas=[w]),
-        np.empty((len(words), 0)),
-        metas=np.array(words).reshape((-1, 1)),
-    )
+    words = create_words_table(["house", "doctor", "boy", "way", "Rum"])
     WidgetPreview(OWScoreDocuments).run(set_data=corpus, set_words=words)

--- a/orangecontrib/text/widgets/owsemanticviewer.py
+++ b/orangecontrib/text/widgets/owsemanticviewer.py
@@ -18,10 +18,11 @@ from Orange.widgets.widget import Input, Output, OWWidget, Msg
 
 from orangecontrib.text import Corpus
 from orangecontrib.text.semantic_search import SemanticSearch
+from orangecontrib.text.widgets.utils.words import create_words_table, \
+    WORDS_COLUMN_NAME
 
 IndexRole = next(gui.OrangeUserRole)
 
-WORDS_COLUMN_NAME = "Words"
 HTML = '''
 <!doctype html>
 <html>
@@ -421,11 +422,7 @@ if __name__ == "__main__":
     # pylint: disable=ungrouped-imports
     from Orange.widgets.utils.widgetpreview import WidgetPreview
 
-    words_var_ = StringVariable(WORDS_COLUMN_NAME)
-    words_var_.attributes = {"type": "words"}
-    lists = [[w] for w in ["human", "graph", "minors", "trees"]]
-    words_ = Table.from_list(Domain([], metas=[words_var_]), lists)
-    words_.name = "Words"
+    words_ = create_words_table(["human", "graph", "minors", "trees"])
     WidgetPreview(OWSemanticViewer).run(
         set_corpus=Corpus.from_file("deerwester"),  # deerwester book-excerpts
         set_words=words_

--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -15,6 +15,7 @@ from AnyQt.QtCore import QSize
 from orangecontrib.text import Corpus
 from orangecontrib.text.util import np_sp_sum
 from orangecontrib.text.stats import hypergeom_p_values
+from orangecontrib.text.widgets.utils.words import create_words_table
 
 
 class Result(SimpleNamespace):
@@ -267,17 +268,14 @@ class OWWordEnrichment(OWWidget, ConcurrentWidgetMixin):
             self.Outputs.words.send(None)
         # retrieve the data except the header
         tree = np.array(self.tree_to_table(), dtype=object)[1:]
-        words_var = StringVariable("Words")
-        words_var.attributes = {"type": "words"}
-        attrs = [ContinuousVariable("p-values"),
-                 ContinuousVariable("FDR values")]
-        domain = Domain(attrs, metas=[words_var])
-
-        X = tree.take([1, 2], axis=1).astype(float)
-        metas = tree.take([0], axis=1)
-        words = Table.from_numpy(domain, X=X, metas=metas)
-        words.name = "Words"
-
+        attrs = (ContinuousVariable("p-values"),
+                 ContinuousVariable("FDR values"))
+        words = create_words_table(tree[:, 0])
+        words = words.transform(Domain(attrs, metas=words.domain.metas))
+        if len(tree[:, 0]):
+            with words.unlocked(words.X):
+                words.X[:, 0] = tree[:, 1]
+                words.X[:, 1] = tree[:, 2]
         self.Outputs.words.send(words)
 
     def send_report(self):

--- a/orangecontrib/text/widgets/owwordlist.py
+++ b/orangecontrib/text/widgets/owwordlist.py
@@ -12,6 +12,7 @@ from AnyQt.QtWidgets import QListView, QSizePolicy, QGridLayout, QLineEdit, \
     QRadioButton, QGroupBox, QToolButton, QMenu, QAction, QFileDialog, \
     QStyledItemDelegate, QStyleOptionViewItem, QWidget
 
+from orangecontrib.text.widgets.utils.words import create_words_table
 from orangewidget.utils.listview import ListViewSearch
 
 from Orange.data import Table, StringVariable, Domain
@@ -500,11 +501,7 @@ class OWWordList(OWWidget):
 
         words, selected_words = None, None
         if self.words_model:
-            words_var = StringVariable("Words")
-            words_var.attributes = {"type": "words"}
-            domain = Domain([], metas=[words_var])
-            _words = Table.from_list(domain, [[w] for w in self.words_model])
-            _words.name = "Words"
+            _words = create_words_table(self.words_model)
             if selection:
                 selected_words = _words[selection]
             words = create_annotated_table(_words, selection)

--- a/orangecontrib/text/widgets/tests/test_owkeywords.py
+++ b/orangecontrib/text/widgets/tests/test_owkeywords.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 
-from Orange.data import StringVariable, Table, Domain
+from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest, simulate
 
 from orangecontrib.text import Corpus
@@ -14,16 +14,7 @@ from orangecontrib.text.keywords import tfidf_keywords, yake_keywords, \
 from orangecontrib.text.preprocess import *
 from orangecontrib.text.widgets.owkeywords import OWKeywords, run, \
     AggregationMethods, ScoringMethods
-
-
-def create_words_table(words: List) -> Table:
-    words_var = StringVariable("Words")
-    words_var.attributes = {"type": "words"}
-    domain = Domain([], metas=[words_var])
-    data = [[w] for w in words]
-    words = Table.from_list(domain, data)
-    words.name = "Words"
-    return words
+from orangecontrib.text.widgets.utils.words import create_words_table
 
 
 class TestRunner(unittest.TestCase):

--- a/orangecontrib/text/widgets/tests/test_owontology.py
+++ b/orangecontrib/text/widgets/tests/test_owontology.py
@@ -3,28 +3,18 @@ import os
 import pickle
 import tempfile
 import unittest
-from typing import List
 from unittest.mock import Mock, patch
 
 from AnyQt.QtCore import Qt, QItemSelectionModel, QItemSelection, \
     QItemSelectionRange
 from AnyQt.QtWidgets import QFileDialog
 
-from Orange.data import StringVariable, Table, Domain
+from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.text.ontology import OntologyHandler
 from orangecontrib.text.widgets.owontology import OWOntology, _run, \
     EditableTreeView, _tree_to_html
-
-
-def create_words_table(words: List) -> Table:
-    words_var = StringVariable("Words")
-    words_var.attributes = {"type": "words"}
-    domain = Domain([], metas=[words_var])
-    data = [[w] for w in words]
-    words = Table.from_list(domain, data)
-    words.name = "Words"
-    return words
+from orangecontrib.text.widgets.utils.words import create_words_table
 
 
 class TestUtils(unittest.TestCase):

--- a/orangecontrib/text/widgets/tests/test_owscoredocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owscoredocuments.py
@@ -19,6 +19,7 @@ from orangecontrib.text.widgets.owscoredocuments import (
     SelectionMethods,
     _preprocess_words,
 )
+from orangecontrib.text.widgets.utils.words import create_words_table
 
 
 def embedding_mock(_, corpus, __):
@@ -35,16 +36,6 @@ def embedding_mock(_, corpus, __):
 
 
 class TestOWScoreDocuments(WidgetTest):
-    @staticmethod
-    def create_words_table(words: List[str]) -> Table:
-        w = StringVariable("Words")
-        w.attributes["type"] = "words"
-        return Table(
-            Domain([], metas=[w]),
-            np.empty((len(words), 0)),
-            metas=np.array(words).reshape((-1, 1)),
-        )
-
     def setUp(self) -> None:
         self.widget: OWScoreDocuments = self.create_widget(OWScoreDocuments)
 
@@ -61,7 +52,7 @@ class TestOWScoreDocuments(WidgetTest):
 
         # create words table
         words = ["house", "doctor", "boy", "way", "Rum"]
-        self.words = self.create_words_table(words)
+        self.words = create_words_table(words)
 
     def test_set_data(self):
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
@@ -183,7 +174,7 @@ class TestOWScoreDocuments(WidgetTest):
                 "lorem ipsum eu",
             ]
         )
-        words = self.create_words_table(["lorem", "ipsum", "eu"])
+        words = create_words_table(["lorem", "ipsum", "eu"])
         self.send_signal(self.widget.Inputs.corpus, corpus)
         self.send_signal(self.widget.Inputs.words, words)
         self.wait_until_finished()
@@ -210,7 +201,7 @@ class TestOWScoreDocuments(WidgetTest):
                 "lorem ipsum eu",
             ]
         )
-        words = self.create_words_table(["lorem", "ipsum", "eu"])
+        words = create_words_table(["lorem", "ipsum", "eu"])
         self.send_signal(self.widget.Inputs.corpus, corpus)
         self.send_signal(self.widget.Inputs.words, words)
         # unselect word_frequency and select word_ratio
@@ -241,7 +232,7 @@ class TestOWScoreDocuments(WidgetTest):
                 "lorem ipsum eu",
             ]
         )
-        words = self.create_words_table(["lorem", "ipsum", "eu"])
+        words = create_words_table(["lorem", "ipsum", "eu"])
         self.send_signal(self.widget.Inputs.corpus, corpus)
         self.send_signal(self.widget.Inputs.words, words)
         # unselect word_frequency and select embedding_similarity
@@ -426,7 +417,7 @@ class TestOWScoreDocuments(WidgetTest):
         var = ContinuousVariable("Word count")
         corpus = corpus.add_column(var, np.array([1 for _ in range(len(
             corpus))]))
-        words = self.create_words_table(["doctor", "rum", "house"])
+        words = create_words_table(["doctor", "rum", "house"])
         self.send_signal(self.widget.Inputs.corpus, corpus)
         self.send_signal(self.widget.Inputs.words, words)
         self.wait_until_finished()

--- a/orangecontrib/text/widgets/tests/test_owsemanticviewer.py
+++ b/orangecontrib/text/widgets/tests/test_owsemanticviewer.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 import unittest
-from typing import List
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -8,23 +7,13 @@ from AnyQt.QtCore import Qt
 from AnyQt.QtTest import QSignalSpy
 from AnyQt.QtWidgets import QTableView
 
-from Orange.data import StringVariable, Table, Domain
 from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.text import Corpus
 from orangecontrib.text.semantic_search import SemanticSearch
 from orangecontrib.text.widgets.owsemanticviewer import OWSemanticViewer, \
     run, DisplayDocument, DocumentsModel, SemanticListView
-
-
-def create_words_table(words: List) -> Table:
-    words_var = StringVariable("Words")
-    words_var.attributes = {"type": "words"}
-    domain = Domain([], metas=[words_var])
-    data = [[w] for w in words]
-    words = Table.from_list(domain, data)
-    words.name = "Words"
-    return words
+from orangecontrib.text.widgets.utils.words import create_words_table
 
 
 class TestRunner(unittest.TestCase):

--- a/orangecontrib/text/widgets/utils/tests/test_words.py
+++ b/orangecontrib/text/widgets/utils/tests/test_words.py
@@ -1,0 +1,30 @@
+import unittest
+
+from Orange.data import StringVariable
+from orangecontrib.text.widgets.tests.test_owkeywords import create_words_table
+
+
+class WordsTable(unittest.TestCase):
+    def test_create_words_name(self):
+        table = create_words_table(["foo", "bar"])
+        self.assertEqual(table.name, "Words")
+
+    def test_create_words_domain(self):
+        table = create_words_table(["foo", "bar"])
+        self.assertEqual(len(table.domain), 1)
+
+    def test_create_words_var(self):
+        table = create_words_table(["foo", "bar"])
+        var = table.domain.metas[0]
+        self.assertEqual(var.name, "Words")
+        self.assertEqual(var.attributes, {"type": "words"})
+        self.assertIsInstance(var, StringVariable)
+
+    def test_create_words_data(self):
+        words = ["foo", "bar"]
+        table = create_words_table(words)
+        self.assertEqual(list(table.metas[:, 0]), words)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/orangecontrib/text/widgets/utils/words.py
+++ b/orangecontrib/text/widgets/utils/words.py
@@ -1,0 +1,15 @@
+from typing import Iterable
+
+from Orange.data import StringVariable, Table, Domain
+
+WORDS_COLUMN_NAME = "Words"
+
+
+def create_words_table(words: Iterable) -> Table:
+    words_var = StringVariable(WORDS_COLUMN_NAME)
+    words_var.attributes = {"type": "words"}
+    domain = Domain([], metas=[words_var])
+    data = [[w] for w in words]
+    words = Table.from_list(domain, data)
+    words.name = "Words"
+    return words


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Similar code for `word` table creation appears in many widgets.

##### Description of changes
Eliminate the duplicated code by creating a new module `words`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
