### PR TITLE
Corpus Viewer: fix QSplitter size

### DIFF
--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -460,7 +460,7 @@ class OWCorpusViewer(OWWidget):
         w1, w2 = self.splitter.sizes()
         ws = w1 + w2
         if w2 < 2/3 * ws:
-            self.splitter.setSizes([ws * 1/3, ws * 2/3])
+            self.splitter.setSizes([int(ws * 1/3), int(ws * 2/3)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### Issue
Corpus Viewer contains a line of code that changes the size of QSplitter. This line causes the widget to crash when executed since it uses wrong data type for size parameters. 

##### Description of changes
- Fixed the issue.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
