### PR TITLE
Word Cloud: change scaling

### DIFF
--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -361,7 +361,7 @@ span.selected {color:red !important}
         # sometimes words are longer in average and word sizes in pt are bigger
         # in average - with this parameter we combine this in size scaling
         self.combined_size_length = sum([
-            len(word) * float(weight) for word, weight in
+            len(word) * float(weight) ** 2 for word, weight in
             self.wordlist
         ])
         self.on_cloud_pref_change()

--- a/orangecontrib/text/widgets/resources/wordcloud-script.js
+++ b/orangecontrib/text/widgets/resources/wordcloud-script.js
@@ -83,13 +83,14 @@ function weight_factor(size) {
     const recalculated_width = combined_width();
     // with this parameter we partially bring in the average word size
     // combined with lenght (many big characters mean decrease size more)
-    size = size * (1/2 + 1/2 * 9000/textAreaEstimation);
+    var area = recalculated_width * document.getElementById("canvas").clientHeight * Math.PI / 4 / 2;
+    size = size * Math.sqrt(area / textAreaEstimation);
 
     // in basis with resizing from 300 to 700 the font size increases for
     // this factor
     const factor = 0.85;
     if(recalculated_width < 300){
-        return size;
+        return size * factor;
     } else if(recalculated_width <= 700){
         return size * (1 + ((recalculated_width - 300) / 400)) * factor;
     } else {


### PR DESCRIPTION
##### Issue
Fixes #829. 

##### Description of changes
Modified font size scaling such that it depends on the area of the word cloud. Results before (top row) and after (bottom row) the modification:

![word-cloud](https://user-images.githubusercontent.com/36742647/165785249-3a645be5-53c5-4598-aa7e-0f7cdf19da8f.png)

##### Includes

- [X] Code changes
- [ ] Tests
- [ ] Documentation
