### PR TITLE
[FIX] Update embedder callbacks

### DIFF
--- a/orangecontrib/text/ontology.py
+++ b/orangecontrib/text/ontology.py
@@ -185,7 +185,7 @@ def generate_ontology(
             for i in range(population_size)
         ])
         fitness = fitness / fitness.sum()
-        new_generation = np.zeros(generation.shape, dtype=np.int32)
+        new_generation = np.zeros(generation.shape, dtype=int)
         parents_to_keep = np.argsort(fitness)[-keep_next_gen:]
         new_generation[:keep_next_gen, :] = generation[parents_to_keep, :]
         for i in range(keep_next_gen, population_size):

--- a/orangecontrib/text/semantic_search.py
+++ b/orangecontrib/text/semantic_search.py
@@ -76,15 +76,7 @@ class SemanticSearch:
         for chunk in chunks_:
             chunks.append([chunk, queries_enc])
 
-        # temporary callback - will be changed when ServerEmbedderCommunicator
-        # change callback - return proportion instead bool
-        ticks = iter(np.linspace(0.0, 1.0, len(chunks)))
-
-        def cb(success=True):
-            if success:
-                callback(next(ticks))
-
-        result_ = self._server_communicator.embedd_data(chunks, processed_callback=cb)
+        result_ = self._server_communicator.embedd_data(chunks, callback=callback)
         if result_ is None:
             return [None] * len(texts)
 

--- a/orangecontrib/text/tests/test_documentembedder.py
+++ b/orangecontrib/text/tests/test_documentembedder.py
@@ -153,3 +153,7 @@ class DocumentEmbedderTest(unittest.TestCase):
     def test_invalid_corpus_type(self):
         with self.assertRaises(ValueError):
             self.embedder(self.corpus[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/tests/test_guardian.py
+++ b/orangecontrib/text/tests/test_guardian.py
@@ -19,7 +19,7 @@ class TestCredentials(unittest.TestCase):
 
     def test_equal(self):
         credentials = guardian.TheGuardianCredentials(API_KEY)
-        self.assertEquals(credentials, credentials)
+        self.assertEqual(credentials, credentials)
 
 
 def skip_limit_exceeded(fun):

--- a/orangecontrib/text/topics/lsi.py
+++ b/orangecontrib/text/topics/lsi.py
@@ -24,4 +24,4 @@ class LsiWrapper(GensimWrapper):
     has_negative_weights = True
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, dtype=float64)
+        super().__init__(**kwargs, dtype=float64, random_seed=0)

--- a/orangecontrib/text/vectorization/bagofwords.py
+++ b/orangecontrib/text/vectorization/bagofwords.py
@@ -46,8 +46,8 @@ class BowVectorizer(BaseVectorizer):
 
     wlocals = OrderedDict((
         (COUNT, lambda tf: tf),
-        (BINARY, lambda tf: np.greater(tf, 0, dtype=np.int) if tf.size
-                            else np.array([], dtype=np.int)),
+        (BINARY, lambda tf: np.greater(tf, 0).astype(int) if tf.size
+                            else np.array([], dtype=int)),
         (SUBLINEAR, lambda tf: 1 + np.log(tf)),
     ))
 

--- a/orangecontrib/text/vectorization/document_embedder.py
+++ b/orangecontrib/text/vectorization/document_embedder.py
@@ -1,17 +1,18 @@
 """This module contains classes used for embedding documents
 into a vector space.
 """
-import zlib
 import base64
 import json
 import sys
 import warnings
-from typing import Tuple, Any, Optional, Union, List
+import zlib
+from typing import Any, List, Optional, Tuple, Union
+
 import numpy as np
-
 from Orange.misc.server_embedder import ServerEmbedderCommunicator
-from orangecontrib.text import Corpus
+from Orange.util import dummy_callback
 
+from orangecontrib.text import Corpus
 
 AGGREGATORS = ['Mean', 'Sum', 'Max', 'Min']
 AGGREGATORS_L = ['mean', 'sum', 'max', 'min']
@@ -93,7 +94,7 @@ class DocumentEmbedder:
                                          embedder_type='text')
 
     def __call__(
-        self, corpus: Union[Corpus, List[List[str]]], processed_callback=None
+        self, corpus: Union[Corpus, List[List[str]]], callback=dummy_callback
     ) -> Union[Tuple[Corpus, Corpus], List[Optional[List[float]]]]:
         """Adds matrix of document embeddings to a corpus.
 
@@ -118,7 +119,8 @@ class DocumentEmbedder:
             raise ValueError("Input should be instance of Corpus or list.")
         embs = self._embedder.embedd_data(
             list(corpus.ngrams) if isinstance(corpus, Corpus) else corpus,
-            processed_callback=processed_callback)
+            callback=callback,
+        )
 
         if isinstance(corpus, list):
             return embs
@@ -174,11 +176,6 @@ class DocumentEmbedder:
         return (('Language', self.language),
                 ('Aggregator', self.aggregator))
 
-    def set_cancelled(self):
-        """Cancels current embedding process"""
-        if hasattr(self, '_embedder'):
-            self._embedder.set_cancelled()
-
     def clear_cache(self):
         """Clears embedder cache"""
         if self._embedder:
@@ -187,11 +184,8 @@ class DocumentEmbedder:
     def __enter__(self):
         return self
 
-    def __exit__(self, ex_type, value, traceback):
-        self.set_cancelled()
-
-    def __del__(self):
-        self.__exit__(None, None, None)
+    def __exit__(self, _, __, ___):
+        pass
 
 
 class _ServerEmbedder(ServerEmbedderCommunicator):

--- a/orangecontrib/text/vectorization/simhash.py
+++ b/orangecontrib/text/vectorization/simhash.py
@@ -47,7 +47,7 @@ class SimhashVectorizer(BaseVectorizer):
             Corpus with `simhash` variable
         """
 
-        X = np.array([self.int2binarray(self.compute_hash(doc)) for doc in corpus.tokens], dtype=np.float)
+        X = np.array([self.int2binarray(self.compute_hash(doc)) for doc in corpus.tokens], dtype=float)
         corpus = corpus.extend_attributes(
             X,
             feature_names=[

--- a/orangecontrib/text/widgets/owdocumentembedding.py
+++ b/orangecontrib/text/widgets/owdocumentembedding.py
@@ -1,5 +1,4 @@
 from typing import Any, Tuple
-import numpy as np
 
 from AnyQt.QtWidgets import QPushButton, QStyle, QLayout
 from AnyQt.QtCore import Qt, QSize
@@ -43,18 +42,14 @@ def run_pretrained_embedder(corpus: Corpus,
     Corpus
         New corpus with additional features.
     """
-    embedder = DocumentEmbedder(language=language,
-                                aggregator=aggregator)
+    embedder = DocumentEmbedder(language=language, aggregator=aggregator)
 
-    ticks = iter(np.linspace(0., 100., len(corpus)))
-
-    def advance(success=True):
+    def callback(progress):
         if state.is_interruption_requested():
-            embedder.set_cancelled()
-        if success:
-            state.set_progress_value(next(ticks))
+            raise Exception
+        state.set_progress_value(progress * 100)
 
-    new_corpus, skipped_corpus = embedder(corpus, processed_callback=advance)
+    new_corpus, skipped_corpus = embedder(corpus, callback=callback)
     return new_corpus, skipped_corpus
 
 

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -1,6 +1,5 @@
 import re
 from collections import Counter
-from contextlib import contextmanager
 from inspect import signature
 from typing import Callable, List, Tuple, Union
 
@@ -20,20 +19,18 @@ from AnyQt.QtWidgets import (
     QRadioButton,
     QTableView,
 )
-from Orange.data.util import get_unique_names
-from pandas import isnull
-from sklearn.metrics.pairwise import cosine_similarity
-
-# todo: uncomment when minimum version of Orange is 3.29.2
-# from orangecanvas.gui.utils import disconnected
-from orangewidget import gui
 from Orange.data import ContinuousVariable, Domain, StringVariable, Table
+from Orange.data.util import get_unique_names
 from Orange.util import wrap_callback
 from Orange.widgets.settings import ContextSetting, PerfectDomainContextHandler, Setting
 from Orange.widgets.utils.annotated_data import create_annotated_table
 from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 from Orange.widgets.utils.itemmodels import PyTableModel, TableModel
 from Orange.widgets.widget import Input, Msg, Output, OWWidget
+from orangecanvas.gui.utils import disconnected
+from orangewidget import gui
+from pandas import isnull
+from sklearn.metrics.pairwise import cosine_similarity
 
 from orangecontrib.text import Corpus
 from orangecontrib.text.preprocess import BaseNormalizer, BaseTransformer
@@ -41,16 +38,6 @@ from orangecontrib.text.vectorization.document_embedder import (
     LANGS_TO_ISO,
     DocumentEmbedder,
 )
-
-
-# todo: remove when minimum version of Orange is 3.29.2
-@contextmanager
-def disconnected(signal, slot, type=Qt.UniqueConnection):
-    signal.disconnect(slot)
-    try:
-        yield
-    finally:
-        signal.connect(slot, type)
 
 
 def _word_frequency(corpus: Corpus, words: List[str], callback: Callable) -> np.ndarray:
@@ -81,20 +68,17 @@ def _embedding_similarity(
     callback: Callable,
     embedding_language: str,
 ) -> np.ndarray:
-    ticks = iter(np.linspace(0, 0.8, len(corpus) + len(words)))
-
-    # TODO: currently embedding report success unify them to report progress float
-    def emb_cb(sucess: bool):
-        if sucess:
-            callback(next(ticks))
-
     language = LANGS_TO_ISO[embedding_language]
     # make sure there will be only embeddings in X after calling the embedder
     corpus = Corpus.from_table(Domain([], metas=corpus.domain.metas), corpus)
     emb = DocumentEmbedder(language)
-    documet_embeddings, skipped = emb(corpus, emb_cb)
+
+    cb_part = len(corpus) / (len(corpus) + len(words))
+    documet_embeddings, skipped = emb(corpus, wrap_callback(callback, 0, cb_part))
     assert skipped is None
-    word_embeddings = np.array(emb([[w] for w in words], emb_cb))
+    word_embeddings = np.array(
+        emb([[w] for w in words], wrap_callback(callback, cb_part, 1 - cb_part))
+    )
     return cosine_similarity(documet_embeddings.X, word_embeddings)
 
 

--- a/orangecontrib/text/widgets/tests/test_owtopicmodeling.py
+++ b/orangecontrib/text/widgets/tests/test_owtopicmodeling.py
@@ -1,13 +1,10 @@
 import unittest
-from unittest import skipIf
 
 import numpy as np
-import gensim
 from AnyQt.QtCore import QItemSelectionModel
 
 from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.text.corpus import Corpus
-from orangecontrib.text.topics import Topics
 from orangecontrib.text.widgets.owtopicmodeling import OWTopicModeling
 
 
@@ -24,14 +21,7 @@ class TestTopicModeling(WidgetTest):
         output = self.get_output(self.widget.Outputs.selected_topic)
         self.assertIsNone(output)
 
-    @skipIf(gensim.__version__ <= "4.1.2", "lsi model does not have random_seed")
     def test_saved_selection(self):
-        self.assertTrue(False)
-        # LSI does not have random_seed in gensim 4.1.2 but will have in next version
-        # when this test start to fail
-        # - remove line above
-        # - set random_seed to LSI model and set gensim requirement
-        # - remove skip on this test
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.wait_until_finished()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4
 biopython # Enables Pubmed widget.
 conllu
 docx2txt>=0.6
-gensim>=4.1.2  # https://github.com/RaRe-Technologies/gensim/issues/3226
+gensim>=4.2.0
 httpx
 lemmagen3
 lxml


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Embedder module in core Orange changed callbacks to callbacks which report percentage instead of success.

Extra: Gensim has a new release and so one of the tests in topic modelling started to fail to remind us to set the random seed for lsi.

##### Description of changes
- Updates callbacks in document embedding
- Update callbacks in semantic search
- Setting the random seed for LSI
- Fix some other deprecations found in the module

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
