### PR TITLE
[FIX] Annotate documents: update to work with the latest changes in keywords

### DIFF
--- a/orangecontrib/text/annotate_documents.py
+++ b/orangecontrib/text/annotate_documents.py
@@ -230,7 +230,7 @@ def _get_characteristic_terms(
         n_keywords: int = 20,
         progress_callback: Callable = None
 ) -> List[List[Tuple[str, float]]]:
-    keywords = tfidf_keywords(corpus.tokens, progress_callback)
+    keywords = tfidf_keywords(corpus, progress_callback)
     return [sorted(k, key=lambda x: x[1], reverse=True)[:n_keywords]
             for k in keywords]
 

--- a/orangecontrib/text/tests/test_annotate_documents.py
+++ b/orangecontrib/text/tests/test_annotate_documents.py
@@ -50,7 +50,7 @@ class TestAnnotateDocuments(unittest.TestCase):
     def test_get_characteristic_terms(self):
         keywords = _get_characteristic_terms(self.corpus, 4)
         keywords = [[w for w, _ in doc_keywords] for doc_keywords in keywords]
-        self.assertEqual(["applications", "abc", "lab", "for"], keywords[0])
+        self.assertEqual(["abc", "applications", "for", "lab"], keywords[0])
 
     def test_hypergeom_clusters(self):
         labels = ClusterDocuments.gmm(self.corpus.metas[:, -2:], 3, 0.6)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Interface of keywords module was slightly changed with merging https://github.com/biolab/orange3-text/pull/834 which caused annotator widget to fail.

##### Description of changes
A small change in the annotator module to make annotation work again.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
