### PR TITLE
Semantic search: optimization

### DIFF
--- a/orangecontrib/text/semantic_search.py
+++ b/orangecontrib/text/semantic_search.py
@@ -4,17 +4,11 @@ import zlib
 import sys
 from typing import Any, List, Optional, Callable, Union
 
-import numpy as np
-
 from Orange.misc.server_embedder import ServerEmbedderCommunicator
 from Orange.util import dummy_callback
 
 # maximum document size that we still send to the server
 MAX_PACKAGE_SIZE = 3000000
-# maximum size of a chunk - when one document is longer send is as a chunk with
-# a single document
-MAX_CHUNK_SIZE = 50000
-MIN_CHUNKS = 20
 
 
 class SemanticSearch:
@@ -22,7 +16,7 @@ class SemanticSearch:
         self._server_communicator = _ServerCommunicator(
             model_name='semantic-search',
             max_parallel_requests=100,
-            server_url='https://apiv2.garaza.io',
+            server_url='https://api.garaza.io',
             embedder_type='text',
         )
 
@@ -46,99 +40,66 @@ class SemanticSearch:
         ((start_idx, end_idx), score). Note that tuples are actually
         lists since JSON (that the server returns) does not support tuples.
         """
-
         if len(texts) == 0 or len(queries) == 0:
             return [None] * len(texts)
 
-        skipped = list()
-        queries_enc = base64.b64encode(
-            zlib.compress(
-                json.dumps(queries).encode('utf-8', 'replace'),
-                level=-1
+        enc_words = self.encode_queries(queries)
+
+        encoded_texts = []
+        for text in texts:
+            enc_text = self.encode_text(text)
+            size = sys.getsizeof(enc_text)
+            encoded_texts.append(
+                [enc_text, enc_words] if size < MAX_PACKAGE_SIZE else None
             )
-        ).decode('utf-8', 'replace')
 
-        encoded_texts = list()
-        sizes = list()
-        chunks = list()
-        for i, text in enumerate(texts):
-            encoded = base64.b64encode(zlib.compress(
-                text.encode('utf-8', 'replace'), level=-1)
-            ).decode('utf-8', 'replace')
-            size = sys.getsizeof(encoded)
-            if size > MAX_PACKAGE_SIZE:
-                skipped.append(i)
-                continue
-            encoded_texts.append(encoded)
-            sizes.append(size)
+        # sort text by their lengths that longer texts start to embed first. It
+        # prevents that long text with long embedding times start embedding
+        # at the end and thus add extra time to the complete embedding time
+        sorted_texts = sorted(
+            enumerate(encoded_texts),
+            key=lambda x: len(x[1][0]) if x[1] is not None else 0,
+            reverse=True
+        )
+        indices, queries = zip(*sorted_texts)
 
-        chunks_ = self._make_chunks(encoded_texts, sizes)
-        for chunk in chunks_:
-            chunks.append([chunk, queries_enc])
-
-        result_ = self._server_communicator.embedd_data(chunks, callback=callback)
+        # send data to the server
+        result_ = self._server_communicator.embedd_data(queries, callback=callback)
         if result_ is None:
             return [None] * len(texts)
 
-        result = list()
-        assert len(result_) == len(chunks)
-        for res_chunk, orig_chunk in zip(result_, chunks):
-            if res_chunk is None:
-                # when embedder fails (Timeout or other error) result will be None
-                result.extend([None] * len(orig_chunk[0]))
-            else:
-                result.extend(res_chunk)
-
-        results = list()
-        idx = 0
-        for i in range(len(texts)):
-            if i in skipped:
-                results.append(None)
-            else:
-                results.append(result[idx])
-                idx += 1
-
+        # restore the original order of the data
+        results = [x for _, x in sorted(zip(indices, result_))]
         return results
 
-    def _make_chunks(self, encoded_texts, sizes, depth=0):
-        chunks = np.array_split(encoded_texts, MIN_CHUNKS if depth == 0 else 2)
-        chunk_sizes = np.array_split(sizes, MIN_CHUNKS if depth == 0 else 2)
-        result = list()
-        for i in range(len(chunks)):
-            # checking that more than one text in chunk prevent recursion to infinity
-            # when one text is bigger than MAX_CHUNK_SIZE
-            if len(chunks[i]) > 1 and np.sum(chunk_sizes[i]) > MAX_CHUNK_SIZE:
-                result.extend(self._make_chunks(chunks[i], chunk_sizes[i], depth + 1))
-            else:
-                result.append(chunks[i])
-        return [list(r) for r in result if len(r) > 0]
+    @staticmethod
+    def encode_queries(queries):
+        return base64.b64encode(
+            zlib.compress(json.dumps(queries).encode('utf-8', 'replace'), level=-1)
+        ).decode('utf-8', 'replace')
 
-    def set_cancelled(self):
-        if hasattr(self, '_server_communicator'):
-            self._server_communicator.set_cancelled()
+    @staticmethod
+    def encode_text(text):
+        return base64.b64encode(
+            zlib.compress(text.encode('utf-8', 'replace'), level=-1)
+        ).decode('utf-8', 'replace')
 
     def clear_cache(self):
         if self._server_communicator:
             self._server_communicator.clear_cache()
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, ex_type, value, traceback):
-        self.set_cancelled()
-
-    def __del__(self):
-        self.__exit__(None, None, None)
-
 
 class _ServerCommunicator(ServerEmbedderCommunicator):
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.content_type = 'application/json'
+        self.timeout = 300
 
     async def _encode_data_instance(self, data_instance: Any) -> Optional[bytes]:
-        return json.dumps(data_instance).encode('utf-8', 'replace')
+        if data_instance is None:
+            return None
+        else:
+            return json.dumps(data_instance).encode('utf-8', 'replace')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Semantic search embedder is slow (computation last up to 60 s for long documents in average 13s).

##### Description of changes
This PR does not speed it up much (just a bit) with the following changes:
- api.garaza.io replaces deprecated apiv2.gara.io
- requests are sent per document (not in batches anymore) - it improves the caching since it does not depend on completely the same batch - it does not slow down since the bottleneck is slow embedded (sending is not a problem)
- sort documents by their size before sending them to the server  - long documents should start embedding first since they can embed for even more than a minute on the CPU - if one such embedding starts embedding towards the end the process just wait for this document to be done

Some more improvements will follow with GPU embedder coming soon

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
