### PR TITLE
[ENH] Computation in separate thread for base vectorizer; use base vectorizer for embedding

### DIFF
--- a/orangecontrib/text/tests/test_bowvectorizer.py
+++ b/orangecontrib/text/tests/test_bowvectorizer.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock, call
 
 import numpy as np
 from Orange.data import Domain, StringVariable
@@ -230,6 +231,16 @@ class BowVectorizationTest(unittest.TestCase):
         # weights computed based on numbers from training dataset
         idfs_test = self.test_counts * np.log(n / document_appearance)
         self.assert_bow_same(bow_test, idfs_test, self.terms)
+
+    def test_callback(self):
+        vect = BowVectorizer()
+        corpus = Corpus.from_file("deerwester")
+        callback = MagicMock()
+
+        result = vect.transform(corpus, callback=callback)
+        self.assertIsInstance(result, Corpus)
+        self.assertEqual(len(result.domain.variables), 43)
+        callback.assert_has_calls([call(0.3), call(0.6), call(0.9), call(1)])
 
 
 if __name__ == "__main__":

--- a/orangecontrib/text/tests/test_documentembedder.py
+++ b/orangecontrib/text/tests/test_documentembedder.py
@@ -34,22 +34,22 @@ class DocumentEmbedderTest(unittest.TestCase):
 
     @patch(PATCH_METHOD)
     def test_with_empty_corpus(self, mock):
-        self.assertIsNone(self.embedder(self.corpus[:0])[0])
-        self.assertIsNone(self.embedder(self.corpus[:0])[1])
+        self.assertIsNone(self.embedder.transform(self.corpus[:0])[0])
+        self.assertIsNone(self.embedder.transform(self.corpus[:0])[1])
         mock.request.assert_not_called()
         mock.get_response.assert_not_called()
         self.assertEqual(self.embedder._embedder._cache._cache_dict, dict())
 
     @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [0.3, 1]}'))
     def test_success_subset(self):
-        res, skipped = self.embedder(self.corpus[[0]])
+        res, skipped = self.embedder.transform(self.corpus[[0]])
         assert_array_equal(res.X, [[0.3, 1]])
         self.assertEqual(len(self.embedder._embedder._cache._cache_dict), 1)
         self.assertIsNone(skipped)
 
     @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [0.3, 1]}'))
     def test_success_shapes(self):
-        res, skipped = self.embedder(self.corpus)
+        res, skipped = self.embedder.transform(self.corpus)
         self.assertEqual(res.X.shape, (len(self.corpus), 2))
         self.assertEqual(len(res.domain.variables),
                          len(self.corpus.domain.variables) + 2)
@@ -58,7 +58,7 @@ class DocumentEmbedderTest(unittest.TestCase):
     @patch(PATCH_METHOD, make_dummy_post(b''))
     def test_empty_response(self):
         with self.assertWarns(RuntimeWarning):
-            res, skipped = self.embedder(self.corpus[[0]])
+            res, skipped = self.embedder.transform(self.corpus[[0]])
         self.assertIsNone(res)
         self.assertEqual(len(skipped), 1)
         self.assertEqual(len(self.embedder._embedder._cache._cache_dict), 0)
@@ -66,7 +66,7 @@ class DocumentEmbedderTest(unittest.TestCase):
     @patch(PATCH_METHOD, make_dummy_post(b'str'))
     def test_invalid_response(self):
         with self.assertWarns(RuntimeWarning):
-            res, skipped = self.embedder(self.corpus[[0]])
+            res, skipped = self.embedder.transform(self.corpus[[0]])
         self.assertIsNone(res)
         self.assertEqual(len(skipped), 1)
         self.assertEqual(len(self.embedder._embedder._cache._cache_dict), 0)
@@ -74,7 +74,7 @@ class DocumentEmbedderTest(unittest.TestCase):
     @patch(PATCH_METHOD, make_dummy_post(b'{"embeddings": [0.3, 1]}'))
     def test_invalid_json_key(self):
         with self.assertWarns(RuntimeWarning):
-            res, skipped = self.embedder(self.corpus[[0]])
+            res, skipped = self.embedder.transform(self.corpus[[0]])
         self.assertIsNone(res)
         self.assertEqual(len(skipped), 1)
         self.assertEqual(len(self.embedder._embedder._cache._cache_dict), 0)
@@ -82,7 +82,7 @@ class DocumentEmbedderTest(unittest.TestCase):
     @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [0.3, 1]}'))
     def test_persistent_caching(self):
         self.assertEqual(len(self.embedder._embedder._cache._cache_dict), 0)
-        self.embedder(self.corpus[[0]])
+        self.embedder.transform(self.corpus[[0]])
         self.assertEqual(len(self.embedder._embedder._cache._cache_dict), 1)
         self.embedder._embedder._cache.persist_cache()
 
@@ -98,7 +98,7 @@ class DocumentEmbedderTest(unittest.TestCase):
         embedder = DocumentEmbedder(language='sl')
         embedder.clear_cache()
         self.assertEqual(len(embedder._embedder._cache._cache_dict), 0)
-        embedder(self.corpus[[0]])
+        embedder.transform(self.corpus[[0]])
         self.assertEqual(len(embedder._embedder._cache._cache_dict), 1)
         embedder._embedder._cache.persist_cache()
 
@@ -116,43 +116,33 @@ class DocumentEmbedderTest(unittest.TestCase):
         embedder = DocumentEmbedder(aggregator='max')
         embedder.clear_cache()
         self.assertEqual(len(embedder._embedder._cache._cache_dict), 0)
-        embedder(self.corpus[[0]])
+        embedder.transform(self.corpus[[0]])
         self.assertEqual(len(embedder._embedder._cache._cache_dict), 1)
         embedder._embedder._cache.persist_cache()
 
         embedder = DocumentEmbedder(aggregator='min')
         self.assertEqual(len(embedder._embedder._cache._cache_dict), 1)
-        embedder(self.corpus[[0]])
+        embedder.transform(self.corpus[[0]])
         self.assertEqual(len(embedder._embedder._cache._cache_dict), 2)
-
-    @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [0.3, 1]}'))
-    def test_with_statement(self):
-        with self.embedder as embedder:
-            res, skipped = embedder(self.corpus[[0]])
-            assert_array_equal(res.X, [[0.3, 1]])
 
     @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [0.3, 1]}'))
     def test_cancel(self):
         self.assertFalse(self.embedder._embedder._cancelled)
         self.embedder._embedder._cancelled = True
         with self.assertRaises(Exception):
-            self.embedder(self.corpus[[0]])
+            self.embedder.transform(self.corpus[[0]])
 
     @patch(PATCH_METHOD, side_effect=OSError)
     def test_connection_error(self, _):
         embedder = DocumentEmbedder()
         with self.assertRaises(ConnectionError):
-            embedder(self.corpus[[0]])
+            embedder.transform(self.corpus[[0]])
 
     def test_invalid_parameters(self):
         with self.assertRaises(ValueError):
             self.embedder = DocumentEmbedder(language='eng')
         with self.assertRaises(ValueError):
             self.embedder = DocumentEmbedder(aggregator='average')
-
-    def test_invalid_corpus_type(self):
-        with self.assertRaises(ValueError):
-            self.embedder(self.corpus[0])
 
 
 if __name__ == "__main__":

--- a/orangecontrib/text/tests/test_simhash.py
+++ b/orangecontrib/text/tests/test_simhash.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock, call
 
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.vectorization import SimhashVectorizer
@@ -18,3 +19,17 @@ class TestSimhash(unittest.TestCase):
     def test_report(self):
         vect = SimhashVectorizer()
         self.assertGreater(len(vect.report()), 0)
+
+    def test_callback(self):
+        vect = SimhashVectorizer(shingle_len=10, f=64)
+        callback = MagicMock()
+        result = vect.transform(self.corpus, callback=callback)
+
+        self.assertIsInstance(result, Corpus)
+        self.assertEqual(len(result), len(self.corpus))
+        self.assertEqual(result.X.shape, (len(self.corpus), 64))
+        callback.assert_has_calls([call(i / len(self.corpus)) for i in range(9)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/vectorization/bagofwords.py
+++ b/orangecontrib/text/vectorization/bagofwords.py
@@ -25,6 +25,7 @@ from collections import OrderedDict
 from functools import partial
 
 import numpy as np
+from Orange.util import dummy_callback
 from gensim import corpora, models, matutils
 from sklearn.preprocessing import normalize
 
@@ -68,18 +69,23 @@ class BowVectorizer(BaseVectorizer):
         self.wlocal = wlocal
         self.wglobal = wglobal
 
-    def _transform(self, corpus, source_dict=None):
+    def _transform(self, corpus, source_dict=None, callback=dummy_callback):
+        if not (len(corpus.dictionary) or source_dict) or not len(corpus):
+            return corpus
         temp_corpus = list(corpus.ngrams_iterator(' ', include_postags=True))
         dic = corpora.Dictionary(temp_corpus, prune_at=None) if not source_dict else source_dict
+        callback(0.3)
         temp_corpus = [dic.doc2bow(doc) for doc in temp_corpus]
         model = models.TfidfModel(dictionary=dic, normalize=False,
                                   wlocal=self.wlocals[self.wlocal],
                                   wglobal=self.wglobals[self.wglobal])
+        callback(0.6)
 
         X = matutils.corpus2csc(model[temp_corpus], dtype=float, num_terms=len(dic)).T
         norm = self.norms[self.norm]
         if norm:
             X = norm(X)
+        callback(0.9)
 
         # set compute values
         shared_cv = SharedTransform(self, corpus.used_preprocessor,
@@ -88,6 +94,7 @@ class BowVectorizer(BaseVectorizer):
               for i in range(len(dic))]
 
         corpus = self.add_features(corpus, X, dic, cv, var_attrs={'bow-feature': True})
+        callback(1)
         return corpus
 
     def report(self):

--- a/orangecontrib/text/vectorization/base.py
+++ b/orangecontrib/text/vectorization/base.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from Orange.data.util import SharedComputeValue
+from Orange.util import dummy_callback
 from orangecontrib.text.util import Sparse2CorpusSliceable
 
 
@@ -8,15 +9,13 @@ class BaseVectorizer:
     """Base class for vectorization objects. """
     name = NotImplemented
 
-    def transform(self, corpus, copy=True, source_dict=None):
+    def transform(self, corpus, copy=True, source_dict=None, callback=dummy_callback):
         """Transforms a corpus to a new one with additional attributes. """
-        if not (len(corpus.dictionary) or source_dict) or not len(corpus):
-            return corpus
         if copy:
             corpus = corpus.copy()
-        return self._transform(corpus, source_dict)
+        return self._transform(corpus, source_dict, callback)
 
-    def _transform(self, corpus, source_dict):
+    def _transform(self, corpus, source_dict, callback):
         raise NotImplementedError
 
     def report(self):

--- a/orangecontrib/text/vectorization/document_embedder.py
+++ b/orangecontrib/text/vectorization/document_embedder.py
@@ -6,13 +6,14 @@ import json
 import sys
 import warnings
 import zlib
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Optional, Tuple
 
 import numpy as np
 from Orange.misc.server_embedder import ServerEmbedderCommunicator
 from Orange.util import dummy_callback
 
 from orangecontrib.text import Corpus
+from orangecontrib.text.vectorization.base import BaseVectorizer
 
 AGGREGATORS = ['Mean', 'Sum', 'Max', 'Min']
 AGGREGATORS_L = ['mean', 'sum', 'max', 'min']
@@ -52,7 +53,7 @@ LANGS_TO_ISO = {
 LANGUAGES = list(LANGS_TO_ISO.values())
 
 
-class DocumentEmbedder:
+class DocumentEmbedder(BaseVectorizer):
     """This class is used for obtaining dense embeddings of documents in
     corpus using fastText pretrained models from:
     E. Grave, P. Bojanowski, P. Gupta, A. Joulin, T. Mikolov,
@@ -93,9 +94,9 @@ class DocumentEmbedder:
                                          server_url='https://apiv2.garaza.io',
                                          embedder_type='text')
 
-    def __call__(
-        self, corpus: Union[Corpus, List[List[str]]], callback=dummy_callback
-    ) -> Union[Tuple[Corpus, Corpus], List[Optional[List[float]]]]:
+    def _transform(
+        self, corpus: Corpus, _, callback=dummy_callback
+    ) -> Tuple[Corpus, Corpus]:
         """Adds matrix of document embeddings to a corpus.
 
         Parameters
@@ -109,14 +110,7 @@ class DocumentEmbedder:
             Corpus (original or a copy) with new features added.
         Skipped documents
             Corpus of documents that were not embedded
-
-        Raises
-        ------
-        ValueError
-            If corpus is not instance of Corpus.
         """
-        if not isinstance(corpus, (Corpus, list)):
-            raise ValueError("Input should be instance of Corpus or list.")
         embs = self._embedder.embedd_data(
             list(corpus.ngrams) if isinstance(corpus, Corpus) else corpus,
             callback=callback,
@@ -135,12 +129,6 @@ class DocumentEmbedder:
         skipped_documents = [emb is None for emb in embs]
         embedded_documents = np.logical_not(skipped_documents)
 
-        variable_attrs = {
-            'hidden': True,
-            'skip-normalization': True,
-            'embedding-feature': True
-        }
-
         new_corpus = None
         if np.any(embedded_documents):
             # if at least one embedding is not None, extend attributes
@@ -150,18 +138,22 @@ class DocumentEmbedder:
                     [e for e, ns in zip(embs, embedded_documents) if ns],
                     dtype=float,
                 ),
-                ['Dim{}'.format(i + 1) for i in range(dim)],
-                var_attrs=variable_attrs
+                ["Dim{}".format(i + 1) for i in range(dim)],
+                var_attrs={
+                    "embedding-feature": True,
+                    "hidden": True,
+                },
             )
 
         skipped_corpus = None
         if np.any(skipped_documents):
             skipped_corpus = corpus[skipped_documents].copy()
             skipped_corpus.name = "Skipped documents"
-            warnings.warn(("Some documents were not embedded for " +
-                           "unknown reason. Those documents " +
-                           "are skipped."),
-                          RuntimeWarning)
+            warnings.warn(
+                "Some documents were not embedded for unknown reason. Those "
+                "documents are skipped.",
+                RuntimeWarning,
+            )
 
         return new_corpus, skipped_corpus
 
@@ -180,12 +172,6 @@ class DocumentEmbedder:
         """Clears embedder cache"""
         if self._embedder:
             self._embedder.clear_cache()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, _, __, ___):
-        pass
 
 
 class _ServerEmbedder(ServerEmbedderCommunicator):

--- a/orangecontrib/text/vectorization/simhash.py
+++ b/orangecontrib/text/vectorization/simhash.py
@@ -1,4 +1,5 @@
 import nltk
+from Orange.util import dummy_callback
 from simhash import Simhash
 import numpy as np
 
@@ -36,7 +37,7 @@ class SimhashVectorizer(BaseVectorizer):
     def int2binarray(self, num):
         return [int(x) for x in self._bin_format.format(num)]
 
-    def _transform(self, corpus, source_dict):
+    def _transform(self, corpus, _, callback=dummy_callback):
         """ Computes simhash values from the given corpus
         and creates a new one with a simhash attribute.
 
@@ -46,8 +47,13 @@ class SimhashVectorizer(BaseVectorizer):
         Returns:
             Corpus with `simhash` variable
         """
-
-        X = np.array([self.int2binarray(self.compute_hash(doc)) for doc in corpus.tokens], dtype=float)
+        if not len(corpus):
+            return corpus
+        hashes = []
+        for i, doc in enumerate(corpus.tokens):
+            hashes.append(self.int2binarray(self.compute_hash(doc)))
+            callback(i / len(corpus))
+        X = np.array(hashes, dtype=float)
         corpus = corpus.extend_attributes(
             X,
             feature_names=[

--- a/orangecontrib/text/widgets/owbagofwords.py
+++ b/orangecontrib/text/widgets/owbagofwords.py
@@ -48,16 +48,13 @@ class OWTBagOfWords(owbasevectorizer.OWBaseVectorizer):
 
         return layout
 
-    def update_method(self):
-        self.method = self.Method(norm=self.normalization,
-                                  wlocal=self.wlocal,
-                                  wglobal=self.wglobal)
+    def init_method(self):
+        return self.Method(
+            norm=self.normalization, wlocal=self.wlocal, wglobal=self.wglobal
+        )
 
 
 if __name__ == '__main__':
-    app = QApplication([])
-    widget = OWTBagOfWords()
-    widget.show()
-    corpus = Corpus.from_file('book-excerpts')
-    widget.set_data(corpus)
-    app.exec()
+    from orangewidget.utils.widgetpreview import WidgetPreview
+
+    WidgetPreview(OWTBagOfWords).run(Corpus.from_file("book-excerpts"))

--- a/orangecontrib/text/widgets/owdocumentembedding.py
+++ b/orangecontrib/text/widgets/owdocumentembedding.py
@@ -1,180 +1,115 @@
-from typing import Any, Tuple
+from typing import Dict, Optional, Any
 
-from AnyQt.QtWidgets import QPushButton, QStyle, QLayout
-from AnyQt.QtCore import Qt, QSize
-
-from Orange.widgets.gui import widgetBox, comboBox, auto_commit, hBox
-from Orange.widgets.settings import Setting
-from Orange.widgets.widget import OWWidget, Msg, Input, Output
-from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
-
+from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QGridLayout, QLabel, QPushButton, QStyle
 from Orange.misc.utils.embedder_utils import EmbeddingConnectionError
+from Orange.widgets import gui
+from Orange.widgets.settings import Setting
+from Orange.widgets.widget import Msg, Output, OWWidget
 
-from orangecontrib.text.vectorization.document_embedder import DocumentEmbedder
-from orangecontrib.text.vectorization.document_embedder import LANGS_TO_ISO, AGGREGATORS
 from orangecontrib.text.corpus import Corpus
-
+from orangecontrib.text.vectorization.document_embedder import (
+    AGGREGATORS,
+    LANGS_TO_ISO,
+    DocumentEmbedder,
+)
+from orangecontrib.text.widgets.utils import widgets
+from orangecontrib.text.widgets.utils.owbasevectorizer import (
+    OWBaseVectorizer,
+    Vectorizer,
+)
 
 LANGUAGES = sorted(list(LANGS_TO_ISO.keys()))
 
 
-def run_pretrained_embedder(corpus: Corpus,
-                            language: str,
-                            aggregator: str,
-                            state: TaskState) -> Tuple[Corpus, Corpus]:
-    """Runs DocumentEmbedder.
+class EmbeddingVectorizer(Vectorizer):
+    skipped_documents = None
 
-    Parameters
-    ----------
-    corpus : Corpus
-        Corpus on which transform is performed.
-    language : str
-        ISO 639-1 (two-letter) code of desired language.
-    aggregator : str
-        Aggregator which creates document embedding (single
-        vector) from word embeddings (multiple vectors).
-        Allowed values are mean, sum, max, min.
-    state : TaskState
-        State object.
-
-    Returns
-    -------
-    Corpus
-        New corpus with additional features.
-    """
-    embedder = DocumentEmbedder(language=language, aggregator=aggregator)
-
-    def callback(progress):
-        if state.is_interruption_requested():
-            raise Exception
-        state.set_progress_value(progress * 100)
-
-    new_corpus, skipped_corpus = embedder(corpus, callback=callback)
-    return new_corpus, skipped_corpus
+    def _transform(self, callback):
+        embeddings, skipped = self.method.transform(self.corpus, callback=callback)
+        self.new_corpus = embeddings
+        self.skipped_documents = skipped
 
 
-class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
+class OWDocumentEmbedding(OWBaseVectorizer):
     name = "Document Embedding"
     description = "Document embedding using pretrained models."
-    keywords = ['embedding', 'document embedding', 'text']
-    icon = 'icons/TextEmbedding.svg'
+    keywords = ["embedding", "document embedding", "text"]
+    icon = "icons/TextEmbedding.svg"
     priority = 300
 
-    want_main_area = False
-    _auto_apply = Setting(default=True)
+    buttons_area_orientation = Qt.Vertical
+    settings_version = 2
 
-    class Inputs:
-        corpus = Input('Corpus', Corpus)
+    Method = DocumentEmbedder
 
-    class Outputs:
-        new_corpus = Output('Embeddings', Corpus, default=True)
-        skipped = Output('Skipped documents', Corpus)
+    class Outputs(OWBaseVectorizer.Outputs):
+        skipped = Output("Skipped documents", Corpus)
 
     class Error(OWWidget.Error):
-        no_connection = Msg("No internet connection. " +
-                            "Please establish a connection or " +
-                            "use another vectorizer.")
-        unexpected_error = Msg('Embedding error: {}')
+        no_connection = Msg(
+            "No internet connection. Please establish a connection or use "
+            "another vectorizer."
+        )
+        unexpected_error = Msg("Embedding error: {}")
 
     class Warning(OWWidget.Warning):
-        unsuccessful_embeddings = Msg('Some embeddings were unsuccessful.')
+        unsuccessful_embeddings = Msg("Some embeddings were unsuccessful.")
 
-    language = Setting(default=LANGUAGES.index("English"))
-    aggregator = Setting(default=0)
+    language = Setting(default="English")
+    aggregator = Setting(default="Mean")
 
     def __init__(self):
-        OWWidget.__init__(self)
-        ConcurrentWidgetMixin.__init__(self)
-
-        self.aggregators = AGGREGATORS
-        self.corpus = None
-        self.new_corpus = None
-        self._setup_layout()
-
-    @staticmethod
-    def sizeHint():
-        return QSize(300, 300)
-
-    def _setup_layout(self):
-        self.controlArea.setMinimumWidth(self.sizeHint().width())
-        self.layout().setSizeConstraint(QLayout.SetFixedSize)
-
-        widget_box = widgetBox(self.controlArea, 'Settings')
-
-        self.language_cb = comboBox(
-            widget=widget_box,
-            master=self,
-            value='language',
-            label='Language: ',
-            orientation=Qt.Horizontal,
-            items=LANGUAGES,
-            callback=self._option_changed,
-            searchable=True
-         )
-
-        self.aggregator_cb = comboBox(widget=widget_box,
-                                      master=self,
-                                      value='aggregator',
-                                      label='Aggregator: ',
-                                      orientation=Qt.Horizontal,
-                                      items=self.aggregators,
-                                      callback=self._option_changed)
-
-        self.auto_commit_widget = auto_commit(widget=self.controlArea,
-                                              master=self,
-                                              value='_auto_apply',
-                                              label='Apply',
-                                              commit=self.commit,
-                                              box=False)
-
+        super().__init__()
         self.cancel_button = QPushButton(
-            'Cancel',
-            icon=self.style()
-            .standardIcon(QStyle.SP_DialogCancelButton))
-
+            "Cancel", icon=self.style().standardIcon(QStyle.SP_DialogCancelButton)
+        )
         self.cancel_button.clicked.connect(self.cancel)
-
-        hbox = hBox(self.controlArea)
-        hbox.layout().addWidget(self.cancel_button)
+        self.buttonsArea.layout().addWidget(self.cancel_button)
         self.cancel_button.setDisabled(True)
 
-    @Inputs.corpus
-    def set_data(self, data):
-        self.Warning.clear()
-        self.cancel()
+    def create_configuration_layout(self):
+        layout = QGridLayout()
+        layout.setSpacing(10)
 
-        if not data:
-            self.corpus = None
-            self.clear_outputs()
-            return
+        combo = widgets.ComboBox(
+            self,
+            "language",
+            items=LANGUAGES,
+        )
+        combo.currentIndexChanged.connect(self.on_change)
+        layout.addWidget(QLabel("Language:"))
+        layout.addWidget(combo, 0, 1)
 
-        self.corpus = data
-        self.unconditional_commit()
+        combo = widgets.ComboBox(self, "aggregator", items=AGGREGATORS)
+        combo.currentIndexChanged.connect(self.on_change)
+        layout.addWidget(QLabel("Aggregator:"))
+        layout.addWidget(combo, 1, 1)
 
-    def _option_changed(self):
-        self.commit()
+        return layout
 
+    def update_method(self):
+        self.vectorizer = EmbeddingVectorizer(self.init_method(), self.corpus)
+
+    def init_method(self):
+        return self.Method(
+            language=LANGS_TO_ISO[self.language], aggregator=self.aggregator
+        )
+
+    @gui.deferred
     def commit(self):
-        if self.corpus is None:
-            self.clear_outputs()
-            return
-
-        self.cancel_button.setDisabled(False)
-
-        self.start(run_pretrained_embedder,
-                   self.corpus,
-                   LANGS_TO_ISO[LANGUAGES[self.language]],
-                   self.aggregators[self.aggregator])
-
         self.Error.clear()
+        self.Warning.clear()
+        self.cancel_button.setDisabled(False)
+        super().commit()
 
-    def on_done(self, embeddings: Tuple[Corpus, Corpus]) -> None:
+    def on_done(self, _):
         self.cancel_button.setDisabled(True)
-        self._send_output_signals(embeddings[0], embeddings[1])
-
-    def on_partial_result(self, result: Any):
-        self.cancel()
-        self.Error.no_connection()
+        skipped = self.vectorizer.skipped_documents
+        self.Outputs.skipped.send(skipped)
+        if skipped is not None and len(skipped) > 0:
+            self.Warning.unsuccessful_embeddings()
+        super().on_done(_)
 
     def on_exception(self, ex: Exception):
         self.cancel_button.setDisabled(True)
@@ -183,27 +118,22 @@ class OWDocumentEmbedding(OWWidget, ConcurrentWidgetMixin):
         else:
             self.Error.unexpected_error(type(ex).__name__)
         self.cancel()
-        self.clear_outputs()
 
     def cancel(self):
+        self.Outputs.skipped.send(None)
         self.cancel_button.setDisabled(True)
         super().cancel()
 
-    def _send_output_signals(self, embeddings, skipped):
-        self.Outputs.new_corpus.send(embeddings)
-        self.Outputs.skipped.send(skipped)
-        unsuccessful = len(skipped) if skipped else 0
-        if unsuccessful > 0:
-            self.Warning.unsuccessful_embeddings()
-
-    def clear_outputs(self):
-        self._send_output_signals(None, None)
-
-    def onDeleteWidget(self):
-        self.cancel()
-        super().onDeleteWidget()
+    @classmethod
+    def migrate_settings(cls, settings: Dict[str, Any], version: Optional[int]):
+        if version is None or version < 2:
+            # before version 2 settings were indexes now they are strings
+            # with language name and selected aggregator name
+            settings["language"] = LANGUAGES[settings["language"]]
+            settings["aggregator"] = AGGREGATORS[settings["aggregator"]]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from orangewidget.utils.widgetpreview import WidgetPreview
-    WidgetPreview(OWDocumentEmbedding).run(Corpus.from_file('book-excerpts'))
+
+    WidgetPreview(OWDocumentEmbedding).run(Corpus.from_file("book-excerpts"))

--- a/orangecontrib/text/widgets/owsimhash.py
+++ b/orangecontrib/text/widgets/owsimhash.py
@@ -1,4 +1,4 @@
-from AnyQt.QtWidgets import QApplication, QFormLayout
+from AnyQt.QtWidgets import QFormLayout
 
 from Orange.widgets import gui
 from Orange.widgets import settings
@@ -22,9 +22,8 @@ class OWSimhash(owbasevectorizer.OWBaseVectorizer):
     def create_configuration_layout(self):
         layout = QFormLayout()
 
-        spin = gui.spin(self, self, 'f', minv=1,
-                        maxv=SimhashVectorizer.max_f)
-        spin.editingFinished.connect(self.on_change)
+        spin = gui.spin(self, self, "f", minv=8, maxv=SimhashVectorizer.max_f, step=8)
+        spin.editingFinished.connect(self.f_spin_changed)
         layout.addRow('Simhash size:', spin)
 
         spin = gui.spin(self, self, 'shingle_len', minv=1, maxv=100)
@@ -32,15 +31,16 @@ class OWSimhash(owbasevectorizer.OWBaseVectorizer):
         layout.addRow('Shingle length:', spin)
         return layout
 
-    def update_method(self):
-        self.method = self.Method(shingle_len=self.shingle_len,
-                                  f=self.f)
+    def init_method(self):
+        return self.Method(shingle_len=self.shingle_len, f=self.f)
+
+    def f_spin_changed(self):
+        # simhash needs f value to be multiple of 8, correct if it is not
+        self.f = 8 * round(self.f / 8)
+        self.on_change()
 
 
 if __name__ == '__main__':
-    app = QApplication([])
-    widget = OWSimhash()
-    widget.show()
-    corpus = Corpus.from_file('book-excerpts')
-    widget.set_data(corpus)
-    app.exec()
+    from orangewidget.utils.widgetpreview import WidgetPreview
+
+    WidgetPreview(OWSimhash).run(Corpus.from_file("book-excerpts"))

--- a/orangecontrib/text/widgets/tests/test_owbagofwords.py
+++ b/orangecontrib/text/widgets/tests/test_owbagofwords.py
@@ -1,6 +1,6 @@
 import unittest
 
-from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
+from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.widgets.owbagofwords import OWTBagOfWords
@@ -18,6 +18,26 @@ class TestBagOfWords(WidgetTest):
         """
         self.send_signal("Corpus", self.corpus)
         self.send_signal("Corpus", None)
+
+    def test_output(self):
+        self.send_signal("Corpus", self.corpus)
+        output = self.get_output(self.widget.Outputs.corpus)
+        self.assertEqual(len(self.corpus), len(output))
+        self.assertEqual(42, len(output.domain.attributes))
+
+        self.send_signal("Corpus", self.corpus[:2])
+        output = self.get_output(self.widget.Outputs.corpus)
+        self.assertEqual(2, len(output))
+        self.assertListEqual(
+            # fmt: off
+            [
+                "a", "abc", "applications", "computer", "for", "human", "interface",
+                "lab", "machine", "of", "opinion", "response", "survey", "system",
+                "time", "user"
+            ],
+            # fmt: on
+            [x.name for x in output.domain.attributes]
+        )
 
 
 if __name__ == "__main__":

--- a/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
+++ b/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from AnyQt.QtWidgets import QComboBox
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate
 from Orange.misc.utils.embedder_utils import EmbeddingConnectionError
@@ -15,7 +16,6 @@ async def none_method(_, __):
 
 
 class TestOWDocumentEmbedding(WidgetTest):
-
     def setUp(self):
         self.widget = self.create_widget(OWDocumentEmbedding)
         self.corpus = Corpus.from_file('deerwester')
@@ -33,21 +33,23 @@ class TestOWDocumentEmbedding(WidgetTest):
     @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [1.3, 1]}'))
     def test_output(self):
         self.send_signal("Corpus", None)
-        self.assertIsNone(self.get_output(self.widget.Outputs.new_corpus))
+        self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
 
         self.send_signal("Corpus", self.corpus)
         self.wait_until_finished()
-        result = self.get_output(self.widget.Outputs.new_corpus)
+        result = self.get_output(self.widget.Outputs.corpus)
         self.assertIsNotNone(result)
         self.assertIsInstance(result, Corpus)
         self.assertEqual(len(self.corpus), len(result))
 
     @patch(PATCH_METHOD, make_dummy_post(b''))
     def test_some_failed(self):
-        simulate.combobox_activate_index(self.widget.controls.aggregator, 1)
+        simulate.combobox_activate_index(
+            self.widget.controlArea.findChildren(QComboBox)[1], 1
+        )
         self.send_signal("Corpus", self.corpus)
         self.wait_until_finished()
-        result = self.get_output(self.widget.Outputs.new_corpus)
+        result = self.get_output(self.widget.Outputs.corpus)
         skipped = self.get_output(self.widget.Outputs.skipped)
         self.assertIsNone(result)
         self.assertEqual(len(skipped), len(self.corpus))
@@ -58,7 +60,7 @@ class TestOWDocumentEmbedding(WidgetTest):
         self.send_signal("Corpus", self.larger_corpus)
         self.widget.cancel_button.click()
         self.wait_until_finished()
-        self.assertIsNone(self.get_output(self.widget.Outputs.new_corpus))
+        self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
 
     @patch('orangecontrib.text.vectorization.document_embedder' +
            '._ServerEmbedder.embedd_data',
@@ -66,42 +68,40 @@ class TestOWDocumentEmbedding(WidgetTest):
     def test_connection_error(self, _):
         self.send_signal("Corpus", self.corpus)
         self.wait_until_finished()
-        self.assertIsNone(self.get_output(self.widget.Outputs.new_corpus))
+        self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
         self.assertTrue(self.widget.Error.no_connection.is_shown())
 
-    @patch('orangecontrib.text.vectorization.document_embedder' +
-           '.DocumentEmbedder.__call__',
-           side_effect=OSError)
+    @patch(
+        "orangecontrib.text.vectorization.document_embedder"
+        + ".DocumentEmbedder.transform",
+        side_effect=OSError,
+    )
     def test_unexpected_error(self, _):
         self.send_signal("Corpus", self.corpus)
         self.wait_until_finished()
-        self.assertIsNone(self.get_output(self.widget.Outputs.new_corpus))
+        self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
         self.assertTrue(self.widget.Error.unexpected_error.is_shown())
 
     @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [1.3, 1]}'))
     def test_rerun_on_new_data(self):
         """ Check if embedding is automatically re-run on new data """
         self.widget._auto_apply = False
-        self.assertIsNone(self.get_output(self.widget.Outputs.new_corpus))
+        self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
 
         self.send_signal(self.widget.Inputs.corpus, self.corpus[:3])
         self.wait_until_finished()
-        self.assertEqual(
-            3, len(self.get_output(self.widget.Outputs.new_corpus))
-        )
+        self.assertEqual(3, len(self.get_output(self.widget.Outputs.corpus)))
 
         self.send_signal(self.widget.Inputs.corpus, self.corpus[:1])
         self.wait_until_finished()
-        self.assertEqual(
-            1, len(self.get_output(self.widget.Outputs.new_corpus))
-        )
+        self.assertEqual(1, len(self.get_output(self.widget.Outputs.corpus)))
 
     @patch('orangecontrib.text.vectorization.document_embedder' +
            '._ServerEmbedder._encode_data_instance', none_method)
     def test_skipped_documents(self):
         self.send_signal("Corpus", self.corpus)
         self.wait_until_finished()
-        self.assertIsNone(self.get_output(self.widget.Outputs.new_corpus))
+        self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
         self.assertEqual(len(self.get_output(self.widget.Outputs.skipped)), len(self.corpus))
         self.assertTrue(self.widget.Warning.unsuccessful_embeddings.is_shown())
 

--- a/orangecontrib/text/widgets/tests/test_owsimhash.py
+++ b/orangecontrib/text/widgets/tests/test_owsimhash.py
@@ -1,0 +1,30 @@
+import unittest
+
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.text.corpus import Corpus
+from orangecontrib.text.widgets.owsimhash import OWSimhash
+
+
+class TestOWSimhash(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWSimhash)
+        self.corpus = Corpus.from_file("deerwester")
+
+    def test_corpus(self):
+        """
+        Just basic test.
+        GH-247
+        """
+        self.send_signal("Corpus", self.corpus)
+        self.send_signal("Corpus", None)
+
+    def test_output(self):
+        self.send_signal("Corpus", self.corpus)
+        output = self.get_output(self.widget.Outputs.corpus)
+        self.assertEqual(len(self.corpus), len(output))
+        self.assertEqual(64, len(output.domain.attributes))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/widgets/utils/owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/owbasevectorizer.py
@@ -125,7 +125,3 @@ class OWBaseVectorizer(OWWidget, ConcurrentWidgetMixin, openclass=True):
     def cancel(self):
         self.Outputs.corpus.send(None)
         super().cancel()
-
-    def onDeleteWidget(self):
-        self.cancel()
-        super().onDeleteWidget()

--- a/orangecontrib/text/widgets/utils/owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/owbasevectorizer.py
@@ -1,23 +1,57 @@
-from AnyQt.QtWidgets import QGroupBox, QVBoxLayout
+from typing import Any
+
+from AnyQt.QtWidgets import QGroupBox
 
 from Orange.widgets import gui
 from Orange.widgets import settings
+from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 from Orange.widgets.widget import OWWidget, Input, Output
 from orangecontrib.text.corpus import Corpus
 
 
-class OWBaseVectorizer(OWWidget):
-    """ A base class for feature extraction methods.
+class Vectorizer:
+    new_corpus = None
+    new_attributes = {}
+    method = None
 
-    Notes:
-        Ensure that `create_configuration_layout` and `update_method` are overwritten.
-    """
+    def __init__(self, method, corpus):
+        self.method = method
+        self.corpus = corpus
+
+    def _hide_attrs(self, hidden: bool) -> None:
+        if self.new_corpus is not None:
+            new_attrs = {f.name for f in self.new_corpus.domain.attributes} - {
+                f.name for f in self.corpus.domain.attributes
+            }
+            new_domain = self.new_corpus.domain
+            for f in new_domain.attributes:
+                if f.name in new_attrs:
+                    f.attributes["hidden"] = hidden
+            self.new_corpus = self.new_corpus.transform(new_domain)
+
+    def _transform(self, callback):
+        self.new_corpus = self.method.transform(self.corpus, callback=callback)
+
+    def run(self, hidden: bool, task_state: TaskState):
+        def callback(progress):
+            if task_state.is_interruption_requested():
+                raise Exception
+            task_state.set_progress_value(progress * 100)
+
+        if self.new_corpus is None:
+            self._transform(callback)
+        self._hide_attrs(hidden)
+
+
+class OWBaseVectorizer(OWWidget, ConcurrentWidgetMixin, openclass=True):
+    """A base class for feature extraction methods."""
+
     # Input/output
     class Inputs:
         corpus = Input("Corpus", Corpus)
 
     class Outputs:
-        corpus = Output("Corpus", Corpus)
+        corpus = Output("Corpus", Corpus, default=True, replaces=["Embeddings"])
 
     want_main_area = False
     resizing_enabled = False
@@ -30,62 +64,68 @@ class OWBaseVectorizer(OWWidget):
 
     def __init__(self):
         super().__init__()
+        ConcurrentWidgetMixin.__init__(self)
         self.corpus = None
-        self.method = None
-        self.new_corpus = None
-        self.new_attrs = None
+        self.vectorizer = None
 
-        box = QGroupBox(title='Options')
+        box = QGroupBox(title="Options")
         box.setLayout(self.create_configuration_layout())
         self.controlArea.layout().addWidget(box)
 
         output_layout = gui.hBox(self.controlArea)
-        gui.checkBox(output_layout, self, "hidden_cb", "Hide bow attributes",
-                     callback=self.hide_attrs)
+        gui.checkBox(
+            output_layout,
+            self,
+            "hidden_cb",
+            "Hide bow attributes",
+            callback=self.commit.deferred,
+        )
 
-        buttons_layout = gui.hBox(self.controlArea)
-        gui.auto_commit(buttons_layout, self, 'autocommit', 'Commit', box=False)
+        gui.auto_commit(self.buttonsArea, self, "autocommit", "Commit")
         self.update_method()
 
     @Inputs.corpus
     def set_data(self, data):
         self.corpus = data
-        if self.corpus is None:
-            self.new_corpus, self.new_attrs = None, None
-        self.invalidate()
+        self.update_method()
+        self.commit.now()
 
-    def hide_attrs(self):
-        if self.new_corpus:
-            new_domain = self.new_corpus.domain
-            for f in new_domain.attributes:
-                if f.name in self.new_attrs:
-                    f.attributes['hidden'] = self.hidden_cb
-            self.new_corpus = self.new_corpus.transform(new_domain)
-            self.commit()
-
+    @gui.deferred
     def commit(self):
-        self.Outputs.corpus.send(self.new_corpus)
-
-    def apply(self):
         if self.corpus is not None:
-            self.new_corpus = self.method.transform(self.corpus)
-            self.new_attrs = {f.name for f in self.new_corpus.domain.attributes} \
-                - {f.name for f in self.corpus.domain.attributes}
+            self.start(self.vectorizer.run, self.hidden_cb)
+        else:
+            self.cancel()
 
-    def invalidate(self):
-        self.apply()
-        self.hide_attrs()
-        self.commit()
+    def on_done(self, _) -> None:
+        self.Outputs.corpus.send(self.vectorizer.new_corpus)
+
+    def on_partial_result(self, result: Any):
+        pass
+
+    def on_exception(self, ex: Exception):
+        raise ex
 
     def update_method(self):
-        self.method = self.Method()
+        self.vectorizer = Vectorizer(self.init_method(), self.corpus)
+
+    def init_method(self):
+        raise NotImplementedError
 
     def on_change(self):
         self.update_method()
-        self.invalidate()
+        self.commit.deferred()
 
     def send_report(self):
         self.report_items(self.method.report())
 
     def create_configuration_layout(self):
-        return QVBoxLayout()
+        raise NotImplementedError
+
+    def cancel(self):
+        self.Outputs.corpus.send(None)
+        super().cancel()
+
+    def onDeleteWidget(self):
+        self.cancel()
+        super().onDeleteWidget()

--- a/orangecontrib/text/widgets/utils/tests/test_owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/tests/test_owbasevectorizer.py
@@ -1,15 +1,22 @@
+import unittest
+
+from AnyQt.QtWidgets import QVBoxLayout
+
 from orangecontrib.text import Corpus
 from orangecontrib.text.vectorization import BowVectorizer
 from orangecontrib.text.widgets.utils.owbasevectorizer import OWBaseVectorizer
-try:
-    from orangewidget.tests.base import WidgetTest
-except:
-    from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.base import WidgetTest
 
 
 class TestableBaseVectWidget(OWBaseVectorizer):
     name = "TBV"
     Method = BowVectorizer
+
+    def create_configuration_layout(self):
+        return QVBoxLayout()
+
+    def update_method(self):
+        self.method = self.Method()
 
 
 class TestOWBaseVectorizer(WidgetTest):
@@ -35,3 +42,7 @@ class TestOWBaseVectorizer(WidgetTest):
 
         self.send_signal("Corpus", None)
         self.assertFalse(self.get_output("Corpus"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/widgets/utils/tests/test_owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/tests/test_owbasevectorizer.py
@@ -15,8 +15,8 @@ class TestableBaseVectWidget(OWBaseVectorizer):
     def create_configuration_layout(self):
         return QVBoxLayout()
 
-    def update_method(self):
-        self.method = self.Method()
+    def init_method(self):
+        return self.Method()
 
 
 class TestOWBaseVectorizer(WidgetTest):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The original issue is that the Embedder widget and embedder method is not based on the base vectorizer.
To enable basing on `BaseVectorizer`/`OWBaseVectorizer` several changes need to be made in both classes

##### Description of changes
- Implement concurrent mixin in OWBaseVectorizer (consequently it is used in Simhash and Bow)
- Reimplement commit (do not compute if the commit is unchecked until the button pressed)
- Use deferred commit
- Change embedded to base on BaseVectorizer
- Add some tests

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
