### PR TITLE
[ENH] Mark "Words" outputs as non-dynamic

### DIFF
--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -199,7 +199,7 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
         words = Input("Words", Table)
 
     class Outputs:
-        words = Output("Words", Corpus)
+        words = Output("Words", Table, dynamic=False)
 
     class Warning(OWWidget.Warning):
         no_words_column = Msg("Input is missing 'Words' column.")

--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -503,7 +503,7 @@ class OWOntology(OWWidget, ConcurrentWidgetMixin):
         words = Input("Words", Table)
 
     class Outputs:
-        words = Output("Words", Table)
+        words = Output("Words", Table, dynamic=False)
 
     class Warning(OWWidget.Warning):
         no_words_column = Msg("Input is missing 'Words' column.")

--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -58,7 +58,7 @@ class OWWordEnrichment(OWWidget, ConcurrentWidgetMixin):
         data = Input("Data", Table)
 
     class Outputs:
-        words = Output("Words", Table)
+        words = Output("Words", Table, dynamic=False)
 
     want_main_area = True
 

--- a/orangecontrib/text/widgets/owwordlist.py
+++ b/orangecontrib/text/widgets/owwordlist.py
@@ -155,7 +155,7 @@ class OWWordList(OWWidget):
 
     class Outputs:
         selected_words = Output("Selected Words", Table)
-        words = Output("Words", Table)
+        words = Output("Words", Table, dynamic=False)
 
     class Warning(OWWidget.Warning):
         no_string_vars = Msg("Input needs at least one Text variable.")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref: https://github.com/biolab/orange-canvas-core/issues/230

##### Description of changes
Mark "Words" outputs as non-dynamic
They are always a Table and not a subtype. This improves auto connection hinting since it never makes sense to connect them to Corpus inputs.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
