### PR TITLE
Ontology: Load simple .owl files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tweepy >=4.0.0
 ufal.udpipe >=1.2.0.3
 wikipedia
 yake
+owlready2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When loading saved ontologies, only .pkl (as dictionary) or .json files can be loaded. Support loading ontologies, saved in .owl files.

##### Description of changes
- load locally saved .owl files
- load .owl, .pkl, .json files from url

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
