### PR TITLE
[FIX] Credential manager dialog at import

### DIFF
--- a/orangecontrib/text/widgets/owguardian.py
+++ b/orangecontrib/text/widgets/owguardian.py
@@ -20,7 +20,6 @@ class OWGuardian(OWWidget):
         name = 'The Guardian Credentials'
         want_main_area = False
         resizing_enabled = False
-        cm_key = CredentialManager('The Guardian API Key')
         key_input = 'test'
 
         class Error(OWWidget.Error):
@@ -28,6 +27,7 @@ class OWGuardian(OWWidget):
 
         def __init__(self, parent):
             super().__init__()
+            self.cm_key = CredentialManager('The Guardian API Key')
             self.parent = parent
             self.api = None
 

--- a/orangecontrib/text/widgets/ownyt.py
+++ b/orangecontrib/text/widgets/ownyt.py
@@ -23,7 +23,6 @@ class OWNYT(OWWidget):
         name = "New York Times API key"
         want_main_area = False
         resizing_enabled = False
-        cm_key = CredentialManager('NY Times API Key')
         key_input = ''
 
         class Error(OWWidget.Error):
@@ -32,6 +31,7 @@ class OWNYT(OWWidget):
 
         def __init__(self, parent):
             super().__init__()
+            self.cm_key = CredentialManager('NY Times API Key')
             self.parent = parent
             self.api = None
 

--- a/orangecontrib/text/widgets/owpubmed.py
+++ b/orangecontrib/text/widgets/owpubmed.py
@@ -38,7 +38,6 @@ class OWPubmed(OWWidget):
         name = "Pubmed Email"
         want_main_area = False
         resizing_enabled = False
-        email_manager = CredentialManager('Email')
         email_input = ''
 
         class Error(OWWidget.Error):
@@ -46,6 +45,7 @@ class OWPubmed(OWWidget):
 
         def __init__(self, parent):
             super().__init__()
+            self.email_manager = CredentialManager('Email')
             self.parent = parent
             self.api = None
 

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -90,10 +90,9 @@ class OWTwitter(OWWidget, ConcurrentWidgetMixin):
         want_main_area = False
         resizing_enabled = False
 
-        cm_key = CredentialManager("Twitter Bearer Token")
-
         def __init__(self, parent):
             super().__init__()
+            self.cm_key = CredentialManager("Twitter Bearer Token")
             self.parent = parent
 
             box = gui.vBox(self.controlArea, "Bearer Token")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

At least with  PyQt5 5.15.6 on linux simply running
```bash
python -c "import orangecontrib.text.widgets.ownyt"
```
pops-up a Unlock wallet/keychain,... dialog. Rejecting it then prints
```
Failed to get secret '__pyqtSignature__' of ''Orange3 - NY Times API Key''.
Traceback (most recent call last):
  File "/home/ales/devel/orange3/Orange/widgets/credentials.py", line 42, in __getattr__
    return keyring.get_password(self.service_name, item)
  File "/home/ales/.envs/orange3/lib/python3.10/site-packages/keyring/core.py", line 55, in get_password
    return get_keyring().get_password(service_name, username)
  File "/home/ales/.envs/orange3/lib/python3.10/site-packages/keyring/backends/chainer.py", line 51, in get_password
    password = keyring.get_password(service, username)
  File "/home/ales/.envs/orange3/lib/python3.10/site-packages/keyring/backends/SecretService.py", line 78, in get_password
    collection = self.get_preferred_collection()
  File "/home/ales/.envs/orange3/lib/python3.10/site-packages/keyring/backends/SecretService.py", line 67, in get_preferred_collection
    raise KeyringLocked("Failed to unlock the collection!")
keyring.errors.KeyringLocked: Failed to unlock the collection!
```

Running orange-canvas for the first time after installing orange3-text or running `orange-canvas --force-discovery` pops-up four dialogs in succession.

At least with PyQt5 5.15.6 the class scope members are inspected for `__pyqtSignature__` attribute which triggers the credential dialog at import/startup time.

##### Description of changes

Move CredentialManager out of class level scope to instance scope.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
