### PR TITLE
replace old apiv2.garaza.io with api.garaza.io for embedders

### DIFF
--- a/orangecontrib/text/vectorization/document_embedder.py
+++ b/orangecontrib/text/vectorization/document_embedder.py
@@ -91,7 +91,7 @@ class DocumentEmbedder(BaseVectorizer):
         self._embedder = _ServerEmbedder(self.aggregator,
                                          model_name='fasttext-'+self.language,
                                          max_parallel_requests=100,
-                                         server_url='https://apiv2.garaza.io',
+                                         server_url='https://api.garaza.io',
                                          embedder_type='text')
 
     def _transform(

--- a/orangecontrib/text/vectorization/sbert.py
+++ b/orangecontrib/text/vectorization/sbert.py
@@ -23,7 +23,7 @@ class SBERT:
         self._server_communicator = _ServerCommunicator(
             model_name='sbert',
             max_parallel_requests=100,
-            server_url='https://apiv2.garaza.io',
+            server_url='https://api.garaza.io',
             embedder_type='text',
         )
 


### PR DESCRIPTION

While migrating between clusters, we used the `apiv2.garaza.io` address for embedders. It is deprecated and will be removed in the future. Replace it with `api.garaza.io`
