### PR TITLE
OWSentimentAnalysis: Handle preprocessed corpus

### DIFF
--- a/orangecontrib/text/widgets/owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/owsentimentanalysis.py
@@ -213,12 +213,16 @@ class OWSentimentAnalysis(OWWidget):
     @Inputs.corpus
     def set_corpus(self, data=None):
         self.corpus = data
-        if self.corpus is not None and not self.corpus.has_tokens():
-            # create preprocessed corpus upon setting data to avoid preprocessing
-            # at each method run
-            pp_list = [preprocess.LowercaseTransformer(),
-                       preprocess.WordPunctTokenizer()]
-            self.pp_corpus = PreprocessorList(pp_list)(self.corpus)
+        self.pp_corpus = None
+        if self.corpus is not None:
+            if not self.corpus.has_tokens():
+                # create preprocessed corpus upon setting data to avoid
+                # preprocessing at each method run
+                pp_list = [preprocess.LowercaseTransformer(),
+                           preprocess.WordPunctTokenizer()]
+                self.pp_corpus = PreprocessorList(pp_list)(self.corpus)
+            else:
+                self.pp_corpus = self.corpus
         self.commit()
 
     def _method_changed(self):

--- a/orangecontrib/text/widgets/tests/test_owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/tests/test_owsentimentanalysis.py
@@ -11,6 +11,7 @@ from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate
 
 from orangecontrib.text.corpus import Corpus
+from orangecontrib.text import preprocess
 from orangecontrib.text.widgets.owsentimentanalysis import OWSentimentAnalysis
 
 
@@ -126,3 +127,18 @@ class TestSentimentWidget(WidgetTest):
         settings = {"method_idx": 4}
         OWSentimentAnalysis.migrate_settings(settings, version=None)
         self.assertTrue(settings.get("method_idx", 5))
+
+    def test_preprocessed(self):
+        widget = self.create_widget(OWSentimentAnalysis)
+        corpus = self.corpus.copy()
+        pp_list = [preprocess.LowercaseTransformer(),
+                   preprocess.WordPunctTokenizer()]
+        for pp in pp_list:
+            corpus = pp(corpus)
+        self.send_signal(widget.Inputs.corpus, corpus)
+        self.assertTrue(widget.pp_corpus)
+        widget.liu_hu.click()
+        simulate.combobox_activate_item(widget.liu_lang, "English")
+        self.assertTrue(widget.pp_corpus)
+        self.send_signal(widget.Inputs.corpus, None)
+        self.assertIsNone(widget.pp_corpus)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #864.

##### Description of changes
Handle preprocessed corpus in Sentiment Analysis.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
