### PR TITLE
Fix proxy addresses for embedders and NLTK

### DIFF
--- a/orangecontrib/text/__init__.py
+++ b/orangecontrib/text/__init__.py
@@ -1,5 +1,42 @@
 # Set where NLTK data is downloaded
 import os
+
+# temporary solution - remove when Orange 3.33 is released
+# it must be imported before nltk_data_dir
+from typing import Optional, Dict
+from Orange.misc.utils import embedder_utils
+
+
+def _get_proxies() -> Optional[Dict[str, str]]:
+    """
+    Return dict with proxy addresses if they exist.
+    Returns
+    -------
+    proxy_dict
+        Dictionary with format {proxy type: proxy address} or None if
+        they not set.
+    """
+    def add_scheme(url: Optional[str]) -> Optional[str]:
+        if url is not None and "://" not in url:
+            # if no scheme default to http - as other libraries do (e.g. requests)
+            return f"http://{url}"
+        else:
+            return url
+
+    http_proxy = add_scheme(os.environ.get("http_proxy"))
+    https_proxy = add_scheme(os.environ.get("https_proxy"))
+    proxy_dict = {}
+    if http_proxy:
+        proxy_dict["http://"] = http_proxy
+    if https_proxy:
+        proxy_dict["https://"] = https_proxy
+    return proxy_dict if proxy_dict else None
+
+
+embedder_utils.get_proxies = _get_proxies
+# remove to here
+
+
 from orangecontrib.text.misc import nltk_data_dir
 os.environ['NLTK_DATA'] = nltk_data_dir()
 

--- a/orangecontrib/text/tests/test_documentembedder.py
+++ b/orangecontrib/text/tests/test_documentembedder.py
@@ -144,6 +144,16 @@ class DocumentEmbedderTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.embedder = DocumentEmbedder(aggregator='average')
 
+    def test_remove_temporary_proxy_solution(self):
+        """
+        When it starts to fail:
+        - remove this test
+        - remove temporary implementation of get_proxy() function in text.__inint__
+        - set minimum version of Orange on 3.33
+        """
+        import Orange
+        self.assertGreater("3.34.0", Orange.__version__)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/text/tests/test_nltk_download.py
+++ b/orangecontrib/text/tests/test_nltk_download.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+from orangecontrib.text.misc.nltk_data_download import _get_proxy_address
+
+
+class TestNLTKDownload(unittest.TestCase):
+    def setUp(self) -> None:
+        self.previous_https = os.environ.get("https_proxy")
+        os.environ.pop("https_proxy", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("https_proxy", None)
+        if self.previous_https is not None:
+            os.environ["https_proxy"] = self.previous_https
+
+    def test_get_proxy_address(self):
+        self.assertIsNone(_get_proxy_address())
+
+        os.environ["https_proxy"] = "https://test.com"
+        self.assertEqual("https://test.com:443", _get_proxy_address())
+
+        os.environ["https_proxy"] = "https://test.com:12"
+        self.assertEqual("https://test.com:12", _get_proxy_address())
+
+        os.environ["https_proxy"] = "https://test.com/test"
+        self.assertEqual("https://test.com:443/test", _get_proxy_address())
+
+        os.environ["https_proxy"] = "https://test.com/test?a=2"
+        self.assertEqual("https://test.com:443/test?a=2", _get_proxy_address())
+
+        os.environ["https_proxy"] = "test.com/test?a=2"
+        self.assertEqual("http://test.com:80/test?a=2", _get_proxy_address())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
- get_proxy from core Orange is not working properly - it document affects embeddings
- nltk needs explicit port address in proxy URL

##### Description of changes
- temporary add the same function as in https://github.com/biolab/orange3/pull/6028 to text util core Orange is released
- for NLTK add a port to the address if missing. Guess port based on the scheme. If any other port is needed user should specify it

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
