### PR TITLE
Word cloud - add type to the selected words output

### DIFF
--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -17,6 +17,7 @@ from Orange.widgets.utils.itemmodels import PyTableModel
 from Orange.widgets.widget import Input, Output, OWWidget
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.topics import Topic
+from orangecontrib.text.widgets.utils.words import create_words_table
 
 COLORS = ["#da1", "#629", "#787"]
 GRAY_COLORS = ["#000", "#444", "#777", "#aaa"]
@@ -477,16 +478,12 @@ span.selected {color:red !important}
             out = self.corpus[rows]
         self.Outputs.corpus.send(out)
 
-        topic = None
+        words_table = None
         words = list(self.selected_words)
         if words:
-            topic = Topic.from_numpy(
-                Domain([], metas=[StringVariable("Words")]),
-                X=np.empty((len(words), 0)),
-                metas=np.c_[words].astype(object),
-            )
-            topic.name = "Selected Words"
-        self.Outputs.selected_words.send(topic)
+            words_table = create_words_table(words)
+            words_table.name = "Selected Words"
+        self.Outputs.selected_words.send(words_table)
 
     def send_report(self):
         if self.webview:

--- a/orangecontrib/text/widgets/tests/test_owwordcloud.py
+++ b/orangecontrib/text/widgets/tests/test_owwordcloud.py
@@ -1,8 +1,7 @@
 import unittest
 
 import numpy as np
-import pkg_resources
-
+from AnyQt.QtCore import QItemSelectionModel
 from Orange.widgets.tests.base import WidgetTest
 from Orange.data import StringVariable, Domain
 from scipy.sparse import csr_matrix
@@ -154,6 +153,20 @@ class TestWordCloudWidget(WidgetTest):
             self.corpus.metas = np.array([[" "]] * len(self.corpus))
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.wait_until_finished()
+
+    def test_select_words_output(self):
+        self.send_signal(self.widget.Inputs.corpus, self.corpus)
+        self.assertIsNone(self.get_output(self.widget.Outputs.selected_words))
+
+        mode = QItemSelectionModel.Rows | QItemSelectionModel.Select
+        view = self.widget.tableview
+        view.clearSelection()
+        view.selectionModel().select(self.widget.tablemodel.index(2, 0), mode)
+        view.selectionModel().select(self.widget.tablemodel.index(3, 0), mode)
+
+        output = self.get_output(self.widget.Outputs.selected_words)
+        self.assertEqual(2, len(output))
+        self.assertEqual("words", output.domain["Words"].attributes["type"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description if the issue does not exist. -->
Word cloud's Selected Words output is missing a type in a word column, and it is not compatible with Semantic Viewer and some other Widgets.

##### Description of changes
Add type annotation and tests

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
