### PR TITLE
[ENH] New language detection

### DIFF
--- a/orangecontrib/text/annotate_documents.py
+++ b/orangecontrib/text/annotate_documents.py
@@ -289,7 +289,7 @@ if __name__ == "__main__":
 
     corpus_ = Corpus.from_file("book-excerpts")
     for pp in (LowercaseTransformer(), RegexpTokenizer(r"\w+"),
-               StopwordsFilter("English"), FrequencyFilter(0.1)):
+               StopwordsFilter(), FrequencyFilter(0.1)):
         corpus_ = pp(corpus_)
 
     transformed_corpus = BowVectorizer().transform(corpus_)

--- a/orangecontrib/text/tests/test_sentiment.py
+++ b/orangecontrib/text/tests/test_sentiment.py
@@ -10,7 +10,7 @@ from orangecontrib.text.sentiment import LiuHuSentiment, VaderSentiment, \
 class LiuHuTest(unittest.TestCase):
     def setUp(self):
         self.corpus = Corpus.from_file('deerwester')
-        self.method = LiuHuSentiment('English')
+        self.method = LiuHuSentiment('en')
         self.new_cols = 1
 
     def test_transform(self):
@@ -53,7 +53,7 @@ class LiuHuTest(unittest.TestCase):
 class LiuHuSlovenian(unittest.TestCase):
     def setUp(self):
         self.corpus = Corpus.from_file('slo-opinion-corpus')
-        self.method = LiuHuSentiment('Slovenian')
+        self.method = LiuHuSentiment('sl')
         self.new_cols = 1
 
     def test_transform(self):

--- a/orangecontrib/text/widgets/owannotator.py
+++ b/orangecontrib/text/widgets/owannotator.py
@@ -611,7 +611,7 @@ if __name__ == "__main__":
 
     corpus_ = Corpus.from_file("book-excerpts")
     for pp in (LowercaseTransformer(), RegexpTokenizer(r"\w+"),
-               StopwordsFilter("English"), FrequencyFilter(0.1)):
+               StopwordsFilter(), FrequencyFilter(0.1)):
         corpus_ = pp(corpus_)
 
     transformed_corpus = BowVectorizer().transform(corpus_)

--- a/orangecontrib/text/widgets/tests/test_owannotator.py
+++ b/orangecontrib/text/widgets/tests/test_owannotator.py
@@ -22,7 +22,7 @@ from orangecontrib.text.widgets.owannotator import OWAnnotator
 
 def preprocess(corpus: Corpus) -> Corpus:
     for pp in (LowercaseTransformer(), RegexpTokenizer(r"\w+"),
-               StopwordsFilter("English"), FrequencyFilter(0.25, 0.5)):
+               StopwordsFilter(), FrequencyFilter(0.25, 0.5)):
         corpus = pp(corpus)
 
     transformed_corpus = BowVectorizer().transform(corpus)

--- a/orangecontrib/text/widgets/tests/test_owkeywords.py
+++ b/orangecontrib/text/widgets/tests/test_owkeywords.py
@@ -188,22 +188,19 @@ class TestOWKeywords(WidgetTest):
             settings = {"selected_scoring_methods": scores}
             widget = self.create_widget(OWKeywords, stored_settings=settings)
 
-            cb = widget.controls.yake_lang_index
-            simulate.combobox_activate_item(cb, "Arabic")
-            cb = widget.controls.rake_lang_index
-            simulate.combobox_activate_item(cb, "Finnish")
+            for language in ("ar", "fi", "de"):
+                self.corpus.attributes["language"] = language
+                self.send_signal(widget.Inputs.corpus, self.corpus, widget=widget)
+                self.wait_until_finished(widget=widget, timeout=10000)
+                out = self.get_output(widget.Outputs.words, widget=widget)
+                self.assertEqual(scores, {a.name for a in out.domain.attributes})
 
-            self.send_signal(widget.Inputs.corpus, self.corpus, widget=widget)
-            self.wait_until_finished(widget=widget, timeout=10000)
-            out = self.get_output(widget.Outputs.words, widget=widget)
-            self.assertEqual(scores, {a.name for a in out.domain.attributes})
-
-            m[0][1].assert_called_once()
-            m[1][1].assert_called_once()
-            m[2][1].assert_called_once()
-            m[3][1].assert_called_once()
-            self.assertEqual(m[1][1].call_args[1]["language"], "Arabic")
-            self.assertEqual(m[2][1].call_args[1]["language"], "Finnish")
+                m[0][1].assert_called_once()
+                m[1][1].assert_called_once()
+                m[2][1].assert_called_once()
+                m[3][1].assert_called_once()
+                for mo in m:
+                    mo[1].reset_mock()
 
     def test_method_change(self):
         """Test method change by clicking"""

--- a/orangecontrib/text/widgets/tests/test_owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/tests/test_owsentimentanalysis.py
@@ -1,12 +1,11 @@
 import os
 import unittest
-from unittest import mock
+from unittest import mock, skip
 from unittest.mock import patch
 
 import numpy as np
-from numpy import array_equal
+from AnyQt.QtWidgets import QRadioButton
 from Orange.widgets.tests.base import WidgetTest
-from Orange.widgets.tests.utils import simulate
 
 from orangecontrib.text import preprocess
 from orangecontrib.text.corpus import Corpus
@@ -61,14 +60,14 @@ class TestSentimentWidget(WidgetTest):
         )
 
         # test multisentiment
-        self.widget.multi_sent.click()
+        self.widget.findChildren(QRadioButton)[2].click()  # multi senti
         out_corpus = self.get_output(self.widget.Outputs.corpus)
         self.assertEqual(
             len(out_corpus.domain.variables), len(self.corpus.domain.variables) + 1
         )
 
         # test SentiArt
-        self.widget.senti_art.click()
+        self.widget.findChildren(QRadioButton)[3].click()  # senti art
         out_corpus = self.get_output(self.widget.Outputs.corpus)
         self.assertEqual(
             len(out_corpus.domain.variables), len(self.corpus.domain.variables) + 7
@@ -82,7 +81,7 @@ class TestSentimentWidget(WidgetTest):
         )
 
         # test liu hu
-        self.widget.liu_hu.click()
+        self.widget.findChildren(QRadioButton)[0].click()  # liu hu
         out_corpus = self.get_output(self.widget.Outputs.corpus)
         self.assertEqual(
             len(out_corpus.domain.variables), len(self.corpus.domain.variables) + 1
@@ -95,7 +94,7 @@ class TestSentimentWidget(WidgetTest):
         self.widget.neg_file = os.path.join(
             os.path.dirname(__file__), "data/sentiment/neg.txt"
         )
-        self.widget.custom_list.click()
+        self.widget.findChildren(QRadioButton)[5].click()  # custom dictionary
         out_corpus = self.get_output(self.widget.Outputs.corpus)
         self.assertEqual(
             len(out_corpus.domain.variables), len(self.corpus.domain.variables) + 1
@@ -115,19 +114,14 @@ class TestSentimentWidget(WidgetTest):
         )
         np.testing.assert_array_almost_equal(out_corpus.X, res, decimal=8)
 
-    def test_language_changed(self):
-        """Test if output changes on language change"""
+        # test Lilah sentiment
+        self.corpus.attributes["language"] = "sl"
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
-        self.assertEqual(self.widget.multi_box.count(), 5)
-
-        # default for Liu Hu should be English
-        self.widget.liu_hu.click()
-        simulate.combobox_activate_item(self.widget.liu_lang, "English")
-        output_eng = self.get_output(self.widget.Outputs.corpus)
-
-        simulate.combobox_activate_item(self.widget.liu_lang, "Slovenian")
-        output_slo = self.get_output(self.widget.Outputs.corpus)
-        self.assertFalse(array_equal(output_eng.X, output_slo.X))
+        self.widget.findChildren(QRadioButton)[4].click()  # Lilah
+        out_corpus = self.get_output(self.widget.Outputs.corpus)
+        self.assertEqual(
+            len(out_corpus.domain.variables), len(self.corpus.domain.variables) + 10
+        )
 
     def test_sentiment_offline(self):
         """Test if sentiment works with offline lexicons"""
@@ -145,7 +139,7 @@ class TestSentimentWidget(WidgetTest):
         widget = self.create_widget(OWSentimentAnalysis)
         self.send_signal(widget.Inputs.corpus, self.corpus)
         self.assertFalse(widget.Warning.no_dicts_loaded.is_shown())
-        widget.custom_list.click()
+        widget.findChildren(QRadioButton)[5].click()  # custom dictionary
         self.assertTrue(widget.Warning.no_dicts_loaded.is_shown())
         widget.pos_file = os.path.join(
             os.path.dirname(__file__), "data/sentiment/pos.txt"
@@ -159,7 +153,7 @@ class TestSentimentWidget(WidgetTest):
         widget.commit.now()
         self.assertFalse(widget.Warning.one_dict_only.is_shown())
         self.assertFalse(widget.Warning.no_dicts_loaded.is_shown())
-        widget.vader.click()
+        widget.findChildren(QRadioButton)[1].click()  # vader
         self.assertFalse(widget.Warning.one_dict_only.is_shown())
         self.assertFalse(widget.Warning.no_dicts_loaded.is_shown())
 
@@ -180,8 +174,7 @@ class TestSentimentWidget(WidgetTest):
             corpus = pp(corpus)
         self.send_signal(widget.Inputs.corpus, corpus)
         self.assertTrue(widget.pp_corpus)
-        widget.liu_hu.click()
-        simulate.combobox_activate_item(widget.liu_lang, "English")
+        widget.findChildren(QRadioButton)[0].click()  # vader
         self.assertTrue(widget.pp_corpus)
         self.send_signal(widget.Inputs.corpus, None)
         self.assertIsNone(widget.pp_corpus)


### PR DESCRIPTION
##### Issue
Implements the new approach to language detection in the add-on.
Fixes https://github.com/biolab/orange3-text/issues/583

##### Description of changes
- The function for language detection and dict of supported languages (all languages supported by any method in Addon)
- Adoption of corpus to store language setting. Corpus can have the language set to the iso code of the language or None (for languages that are not in the list of supported languages - language-dependent methods do not work, but all other methods work)
- Adopting "input" widgets to set the language of the Corpus
- Adopting widgets which uses language setting (removing language controls, handling not supported languages)
- Removed Stafornford POS-tagging method since we do not use it and it is deprecated in NLTK

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation

##### Comments to the reviewer

- In the Create Corpus widget user must select a language manually
- Twitter widget use language set by the user; if language is not set and all tweets have the same language, it is set as Corpus'es language. When tweets are in different languages, language is set to None. I also changed the Twitter widget that variables are initialized when Corpus is built. Before, the same variable instance was used multiple times, and those settings were shared (values, ....).
- UDPipe offers various variants of models for the same language. Should we still support those variants or use the basic one for each language? Are they used in practice? 
