### PR TITLE
[ENH] Document Embedding - set SBERT as default

### DIFF
--- a/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
+++ b/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
@@ -27,6 +27,13 @@ class TestOWDocumentEmbedding(WidgetTest):
         self.corpus = Corpus.from_file('deerwester')
         self.larger_corpus = Corpus.from_file('book-excerpts')
 
+        # test on fastText, except for tests that change the setting
+        self.widget.findChildren(QRadioButton)[1].click()
+        self.widget.vectorizer.method.clear_cache()
+
+    def tearDown(self):
+        self.widget.vectorizer.method.clear_cache()
+
     def test_input(self):
         set_data = self.widget.set_data = Mock()
         self.send_signal("Corpus", None)
@@ -42,7 +49,6 @@ class TestOWDocumentEmbedding(WidgetTest):
         self.assertIsNone(self.get_output(self.widget.Outputs.corpus))
 
         self.send_signal("Corpus", self.corpus)
-        self.wait_until_finished()
         result = self.get_output(self.widget.Outputs.corpus)
         self.assertIsNotNone(result)
         self.assertIsInstance(result, Corpus)
@@ -113,7 +119,7 @@ class TestOWDocumentEmbedding(WidgetTest):
 
     @patch(PATCH_METHOD, make_dummy_post(SBERT_RESPONSE))
     def test_sbert(self):
-        self.widget.findChildren(QRadioButton)[1].click()
+        self.widget.findChildren(QRadioButton)[0].click()
         self.widget.vectorizer.method.clear_cache()
 
         self.send_signal("Corpus", self.corpus)

--- a/orangecontrib/text/widgets/utils/owbasevectorizer.py
+++ b/orangecontrib/text/widgets/utils/owbasevectorizer.py
@@ -70,6 +70,7 @@ class OWBaseVectorizer(OWWidget, ConcurrentWidgetMixin, openclass=True):
 
         box = QGroupBox(title="Options")
         box.setLayout(self.create_configuration_layout())
+        box.layout().setContentsMargins(4, 4, 4, 4)  # same than other widgets
         self.controlArea.layout().addWidget(box)
 
         output_layout = gui.hBox(self.controlArea)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Currently fasttext is default embedder

##### Description of changes
Set SBERT as default

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
