### PR TITLE
Topic modelling - temporarily fix gensim to 4.1.2

### DIFF
--- a/orangecontrib/text/topics/lsi.py
+++ b/orangecontrib/text/topics/lsi.py
@@ -24,4 +24,4 @@ class LsiWrapper(GensimWrapper):
     has_negative_weights = True
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, dtype=float64, random_seed=0)
+        super().__init__(**kwargs, dtype=float64)

--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -181,8 +181,8 @@ class OWTopicModeling(OWWidget, ConcurrentWidgetMixin):
         # Commit button
         gui.auto_commit(self.buttonsArea, self, 'autocommit', 'Commit', box=False)
 
-        button_group = QButtonGroup(self, exclusive=True)
-        button_group.buttonClicked[int].connect(self.change_method)
+        self.button_group = QButtonGroup(self, exclusive=True)
+        self.button_group.buttonClicked.connect(self.change_method)
 
         self.widgets = []
         method_layout = QVBoxLayout()
@@ -195,11 +195,11 @@ class OWTopicModeling(OWWidget, ConcurrentWidgetMixin):
             setattr(self, attr_name, widget)
 
             rb = QRadioButton(text=widget.Model.name)
-            button_group.addButton(rb, i)
+            self.button_group.addButton(rb, i)
             method_layout.addWidget(rb)
             method_layout.addWidget(widget)
 
-        button_group.button(self.method_index).setChecked(True)
+        self.button_group.button(self.method_index).setChecked(True)
         self.toggle_widgets()
         method_layout.addStretch()
 
@@ -229,7 +229,8 @@ class OWTopicModeling(OWWidget, ConcurrentWidgetMixin):
     def model(self):
         return self.widgets[self.method_index].model
 
-    def change_method(self, new_index):
+    def change_method(self):
+        new_index = self.button_group.checkedId()
         if self.method_index != new_index:
             self.method_index = new_index
             self.toggle_widgets()

--- a/orangecontrib/text/widgets/tests/test_owtopicmodeling.py
+++ b/orangecontrib/text/widgets/tests/test_owtopicmodeling.py
@@ -22,6 +22,7 @@ class TestTopicModeling(WidgetTest):
         self.assertIsNone(output)
 
     def test_saved_selection(self):
+        self.widget.method_index = 1
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.wait_until_finished()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4
 biopython # Enables Pubmed widget.
 conllu
 docx2txt>=0.6
-gensim>=4.2.0
+gensim==4.1.2  # temporary fix - reset when gensim solves https://github.com/RaRe-Technologies/gensim/issues/3368
 httpx
 lemmagen3
 lxml


### PR DESCRIPTION
##### Issue
Temporarily fixes https://github.com/biolab/orange3-text/issues/820 until Gensim provides a solution

##### Description of changes
- Fix Gensim to version 4.1.2 - which is the last version where coherence still works
- Temporarily remove random seed for LSI since it is not compatible with 4.1.2
- Change the use of buttonClicked signal to be compatible with PyQt6

The first and second changes should be reverted when Gensim fixes CoherenceModel the last one should stay.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
