### PR TITLE
Corpus - postphone removing eq deprecation

### DIFF
--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -700,7 +700,7 @@ class TestCorpusSummaries(unittest.TestCase):
 
         version = pkg_resources.get_distribution("orange3-text").version.split(".")
         version = tuple(map(int, version[:3]))
-        self.assertLess(version, (1, 11, 0))
+        self.assertLess(version, (1, 12, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`__eq__` deprecation was merged after the last release, so we cannot remove it now. 

##### Description of changes
This PR moves the deletion of `__eq__` into the next release.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
