### PR TITLE
[FIX] Replace exec_ with exec and fix deprecations

### DIFF
--- a/orangecontrib/text/widgets/owguardian.py
+++ b/orangecontrib/text/widgets/owguardian.py
@@ -100,11 +100,11 @@ class OWGuardian(OWWidget):
         self.api_dlg = self.CredentialsDialog(self)
         self.api_dlg.accept(silent=True)
         gui.button(self.controlArea, self, 'The Guardian API Key',
-                   callback=self.api_dlg.exec_,
+                   callback=self.api_dlg.exec,
                    focusPolicy=Qt.NoFocus)
 
         # Query
-        query_box = gui.widgetBox(self.controlArea, 'Query', addSpace=True)
+        query_box = gui.widgetBox(self.controlArea, 'Query')
         self.query_box = QueryBox(query_box, self, self.recent_queries,
                                   callback=self.new_query_input)
 

--- a/orangecontrib/text/widgets/owimportdocuments.py
+++ b/orangecontrib/text/widgets/owimportdocuments.py
@@ -766,7 +766,7 @@ def main(argv=sys.argv):
     if path is not None:
         w.setCurrentPath(path)
 
-    app.exec_()
+    app.exec()
     w.saveSettings()
     w.onDeleteWidget()
     return 0

--- a/orangecontrib/text/widgets/ownyt.py
+++ b/orangecontrib/text/widgets/ownyt.py
@@ -106,11 +106,11 @@ class OWNYT(OWWidget):
         # API key
         self.api_dlg = self.APICredentialsDialog(self)
         self.api_dlg.accept(silent=True)
-        gui.button(self.controlArea, self, 'Article API Key', callback=self.api_dlg.exec_,
+        gui.button(self.controlArea, self, 'Article API Key', callback=self.api_dlg.exec,
                    focusPolicy=Qt.NoFocus)
 
         # Query
-        query_box = gui.widgetBox(self.controlArea, 'Query', addSpace=True)
+        query_box = gui.widgetBox(self.controlArea, 'Query')
         self.query_box = QueryBox(query_box, self, self.recent_queries,
                                   callback=self.new_query_input)
 

--- a/orangecontrib/text/widgets/owpubmed.py
+++ b/orangecontrib/text/widgets/owpubmed.py
@@ -136,7 +136,7 @@ class OWPubmed(OWWidget):
         # API key
         self.email_dlg = self.EmailCredentialsDialog(self)
         gui.button(self.controlArea, self, 'Email',
-                   callback=self.email_dlg.exec_,
+                   callback=self.email_dlg.exec,
                    focusPolicy=Qt.NoFocus)
         gui.separator(self.controlArea)
 
@@ -146,7 +146,7 @@ class OWPubmed(OWWidget):
         # RECORD SEARCH
         self.search_tabs = gui.tabWidget(self.controlArea)
         # --- Regular search ---
-        regular_search_box = gui.widgetBox(self.controlArea, addSpace=True)
+        regular_search_box = gui.widgetBox(self.controlArea)
 
         # Author
         self.author_input = gui.lineEdit(regular_search_box, self, 'author',
@@ -207,7 +207,7 @@ class OWPubmed(OWWidget):
         regular_search_box.setMaximumSize(tab_height)
 
         # --- Advanced search ---
-        advanced_search_box = gui.widgetBox(self.controlArea, addSpace=True)
+        advanced_search_box = gui.widgetBox(self.controlArea)
         # Advanced search query.
         h_box = gui.hBox(advanced_search_box)
         self.advanced_query_input = QTextEdit(h_box)
@@ -243,7 +243,7 @@ class OWPubmed(OWWidget):
         # RECORD RETRIEVAL
         # Text includes box.
         text_includes_box = gui.widgetBox(
-            self.controlArea, 'Text includes', addSpace=True)
+            self.controlArea, 'Text includes')
         self.authors_checkbox = gui.checkBox(
             text_includes_box, self, 'includes_authors', 'Authors')
         self.title_checkbox = gui.checkBox(
@@ -468,7 +468,7 @@ class OWPubmed(OWWidget):
 
     def open_calendar(self, widget):
         cal_dlg = CalendarDialog(self, 'Date picker')
-        if cal_dlg.exec_():
+        if cal_dlg.exec():
             widget.setText(cal_dlg.picked_date)
 
     def send_report(self):

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -212,7 +212,7 @@ class OWTwitter(OWWidget, ConcurrentWidgetMixin):
         self.setFocus()  # to widget itself to show placeholder for query_edit
 
     def open_key_dialog(self):
-        self.api_dlg.exec_()
+        self.api_dlg.exec()
 
     def mode_toggle(self):
         if self.mode == self.AUTHOR:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description if the issue does not exist. -->
- In PyQt6, they completely removed `exec_` for opening dialogues as of PyQt5 already, `exec` is available.
- `addSpace` keyword is deprecated and, in my opinion, not needed (the user interface already looks good with normal spacing)

##### Description of changes
- replacing `exec_` with `exec`.
- removing `addSpace` in several widgets. It can be replaced by a separator, but in my opinion, it is not necessary.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
