### PR TITLE
Remove corpus's __eq__

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -643,30 +643,6 @@ class Corpus(Table):
             new._set_unique_titles()
             new._infer_text_features()
 
-    def __eq__(self, other):
-        warnings.warn(
-            "Corpus's __eq__  is deprecated and will be removed in Orange3-text"
-            "1.11. Equality operator will return True only for the same objects.",
-            FutureWarning
-        )
-        def arrays_equal(a, b):
-            if sp.issparse(a) != sp.issparse(b):
-                return False
-            elif sp.issparse(a) and sp.issparse(b):
-                return (a != b).nnz == 0
-            else:
-                return np.array_equal(a, b)
-
-        return (self.text_features == other.text_features and
-                self._dictionary == other._dictionary and
-                np.array_equal(self._tokens, other._tokens) and
-                arrays_equal(self.X, other.X) and
-                arrays_equal(self.Y, other.Y) and
-                arrays_equal(self.metas, other.metas) and
-                np.array_equal(self.pos_tags, other.pos_tags) and
-                self.domain == other.domain and
-                self.ngram_range == other.ngram_range)
-
 
 if summarize:
     # summarize is not available in older versions of orange-widget-base

--- a/orangecontrib/text/tests/test_bowvectorizer.py
+++ b/orangecontrib/text/tests/test_bowvectorizer.py
@@ -117,7 +117,9 @@ class BowVectorizationTest(unittest.TestCase):
         corpus = Corpus.from_file("deerwester")[:0]
         vect = BowVectorizer(norm=BowVectorizer.L1)
         out = vect.transform(corpus)
-        self.assertEqual(out, corpus)
+        np.testing.assert_array_equal(corpus.X, out.X)
+        np.testing.assert_array_equal(corpus.Y, out.Y)
+        np.testing.assert_array_equal(corpus.metas, out.metas)
 
     def tests_duplicated_names(self):
         """

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -690,18 +690,6 @@ class TestCorpusSummaries(unittest.TestCase):
         self.assertEqual(140, summary.summary)
         self.assertEqual(details, summary.details)
 
-    def test_deprecated_eq(self):
-        """
-        Corpus's __eq__ is deprecated. When this test starts to fail:
-        - remove __eq__ in corpus
-        - remove this test
-        """
-        import pkg_resources
-
-        version = pkg_resources.get_distribution("orange3-text").version.split(".")
-        version = tuple(map(int, version[:3]))
-        self.assertLess(version, (1, 12, 0))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -443,7 +443,13 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(sel.attributes, c.attributes)
 
         sel = c[...]
-        self.assertEqual(sel, c)
+        self.assertEqual(len(sel), len(c))
+        self.assertEqual(len(sel._tokens), len(c))
+        np.testing.assert_equal(sel._tokens, c._tokens)
+        self.assertEqual(sel._dictionary, c._dictionary)
+        self.assertEqual(sel.text_features, c.text_features)
+        self.assertEqual(sel.ngram_range, c.ngram_range)
+        self.assertEqual(sel.attributes, c.attributes)
 
         sel = c[range(0, 5)]
         self.assertEqual(len(sel), 5)

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -134,7 +134,7 @@ class OWCorpusViewer(OWWidget):
             domain = self.corpus.domain
             # Enable/disable tokens checkbox
             if not self.corpus.has_tokens():
-                self.show_tokens_checkbox.setCheckState(False)
+                self.show_tokens_checkbox.setCheckState(Qt.Unchecked)
             self.show_tokens_checkbox.setEnabled(self.corpus.has_tokens())
 
             self.search_features = list(filter_visible(chain(domain.variables, domain.metas)))

--- a/orangecontrib/text/widgets/tests/test_owcorpustonetwork.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpustonetwork.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest.mock import Mock
 from unittest import skipIf
 
@@ -25,8 +26,9 @@ class TestOWCorpusToNetwork(WidgetTest):
         set_data = self.widget.set_data = Mock()
         self.send_signal("Corpus", None)
         set_data.assert_called_with(None)
-        self.send_signal("Corpus", self.corpus[:0])
-        set_data.assert_called_with(self.corpus[:0])
+        sampled = self.corpus[:0]
+        self.send_signal("Corpus", sampled)
+        set_data.assert_called_with(sampled)
         self.send_signal("Corpus", self.corpus)
         set_data.assert_called_with(self.corpus)
 
@@ -48,3 +50,7 @@ class TestOWCorpusToNetwork(WidgetTest):
         simulate.combobox_activate_index(cbox, 1)
         self.assertTrue(self.widget.controls.window_size.isEnabled())
         self.assertTrue(self.widget.controls.freq_threshold.isEnabled())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
@@ -1,4 +1,6 @@
 import unittest
+
+import numpy as np
 from AnyQt.QtTest import QSignalSpy
 from Orange.widgets.tests.base import WidgetTest
 from Orange.data import StringVariable
@@ -17,7 +19,10 @@ class TestCorpusViewerWidget(WidgetTest):
         self.assertEqual(len(self.widget.corpus), 9)
         self.widget.doc_list.selectAll()
         out_corpus = self.get_output(self.widget.Outputs.matching_docs)
-        self.assertEqual(out_corpus, self.corpus)
+        np.testing.assert_array_equal(out_corpus.X, self.corpus.X)
+        np.testing.assert_array_equal(out_corpus.Y, self.corpus.Y)
+        np.testing.assert_array_equal(out_corpus.metas, self.corpus.metas)
+        np.testing.assert_array_equal(out_corpus._tokens, self.corpus._tokens)
 
     def test_search(self):
         self.send_signal(self.widget.Inputs.corpus, self.corpus)

--- a/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
+++ b/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
@@ -2,11 +2,10 @@ import unittest
 from unittest.mock import Mock, patch
 
 import numpy as np
-from AnyQt.QtWidgets import QComboBox
+from AnyQt.QtWidgets import QComboBox, QRadioButton
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate
 from Orange.misc.utils.embedder_utils import EmbeddingConnectionError
-from PyQt5.QtWidgets import QRadioButton
 
 from orangecontrib.text.tests.test_documentembedder import PATCH_METHOD, make_dummy_post
 from orangecontrib.text.vectorization.sbert import EMB_DIM
@@ -38,8 +37,9 @@ class TestOWDocumentEmbedding(WidgetTest):
         set_data = self.widget.set_data = Mock()
         self.send_signal("Corpus", None)
         set_data.assert_called_with(None)
-        self.send_signal("Corpus", self.corpus[:0])
-        set_data.assert_called_with(self.corpus[:0])
+        sample = self.corpus[:0]
+        self.send_signal("Corpus", sample)
+        set_data.assert_called_with(sample)
         self.send_signal("Corpus", self.corpus)
         set_data.assert_called_with(self.corpus)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`__eq__` was deprecated and needs to be removed

##### Description of changes
- Remove corpus's `__eq__` method to be compatible with the table which does not have it.
- Adapt tests that started to fail because of removal
- Fix some PyQt6 incompatibilities

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
