### PR TITLE
SBERT - send single text to embedder instead of list with one text

### DIFF
--- a/orangecontrib/text/vectorization/sbert.py
+++ b/orangecontrib/text/vectorization/sbert.py
@@ -172,4 +172,4 @@ class _ServerCommunicator(ServerEmbedderCommunicator):
             # Document in corpus is too large. Size limit is 500 KB
             # (after compression). - document skipped
             return None
-        return json.dumps([data]).encode("utf-8", "replace")
+        return json.dumps(data).encode("utf-8", "replace")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Now SBERT embedded support single text (not only list of texts)

##### Description of changes
Send a text without packing it to list

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
