### PR TITLE
SBERT - consider 1D response when sending one text per request

### DIFF
--- a/orangecontrib/text/tests/test_ontology.py
+++ b/orangecontrib/text/tests/test_ontology.py
@@ -10,7 +10,7 @@ from orangecontrib.text.ontology import Tree, EmbeddingStorage, OntologyHandler,
 
 
 RESPONSE = [
-    f'{{ "embedding": [{[i] * EMB_DIM}] }}'.encode()
+    f'{{ "embedding": {[i] * EMB_DIM} }}'.encode()
     for i in range(4)
 ]
 

--- a/orangecontrib/text/tests/test_sbert.py
+++ b/orangecontrib/text/tests/test_sbert.py
@@ -8,7 +8,7 @@ from orangecontrib.text import Corpus
 
 PATCH_METHOD = 'httpx.AsyncClient.post'
 RESPONSE = [
-    f'{{ "embedding": [{[i] * EMB_DIM}] }}'.encode()
+    f'{{ "embedding": {[i] * EMB_DIM} }}'.encode()
     for i in range(9)
 ]
 

--- a/orangecontrib/text/vectorization/sbert.py
+++ b/orangecontrib/text/vectorization/sbert.py
@@ -56,7 +56,7 @@ class SBERT(BaseVectorizer):
         # embedd - send to server
         results = self._server_communicator.embedd_data(sorted_texts, callback=callback)
         # unsort and unpack
-        return [x[0] if x else None for _, x in sorted(zip(indices, results))]
+        return [x if x else None for _, x in sorted(zip(indices, results))]
 
     def _transform(
         self, corpus: Corpus, _, callback=dummy_callback

--- a/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
+++ b/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
@@ -17,7 +17,7 @@ async def none_method(_, __):
     return None
 
 _response_list = str(np.arange(0, EMB_DIM, dtype=float).tolist())
-SBERT_RESPONSE = f'{{"embedding": [{_response_list}]}}'.encode()
+SBERT_RESPONSE = f'{{"embedding": {_response_list}}}'.encode()
 
 
 class TestOWDocumentEmbedding(WidgetTest):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
SBERT was sending one text per request to the server but still received 2D results as a response.

##### Description of changes
Since from today on, the response is a 1D list when sending only one document, adapt the script to the latest canges

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
