### PR TITLE
[FIX] Ontology - remove cache and other fixes

### DIFF
--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -598,6 +598,7 @@ class OWOntology(OWWidget, ConcurrentWidgetMixin):
 
     class Warning(OWWidget.Warning):
         no_words_column = Msg("Input is missing 'Words' column.")
+        skipped_words = Msg("{} terms are skipped due to server connection error.")
 
     class Error(OWWidget.Error):
         load_error = Msg("{}")
@@ -830,23 +831,28 @@ class OWOntology(OWWidget, ConcurrentWidgetMixin):
 
     def _run(self):
         self.__run_button.setText("Stop")
+        self.Warning.skipped_words.clear()
         words = self.__ontology_view.get_words()
         handler = self.__onto_handler.generate
         self.start(_run, handler, (words,))
 
     def _run_insert(self):
         self.__inc_button.setText("Stop")
+        self.Warning.skipped_words.clear()
         tree = self.__ontology_view.get_data()
         words = self.__get_selected_input_words()
         handler = self.__onto_handler.insert
         self.start(_run, handler, (tree, words))
 
-    def on_done(self, data: Dict):
+    def on_done(self, result: Tuple[Dict, int]):
+        data, num_skipped = result
         self.__inc_button.setText(self.INC_BUTTON)
         self.__run_button.setText(self.RUN_BUTTON)
         self.__ontology_view.set_data(data, keep_history=True)
         self.__set_current_modified(self.CACHED)
         self.__update_score()
+        if num_skipped > 0:
+            self.Warning.skipped_words(num_skipped)
 
     def __update_score(self):
         tree = self.__ontology_view.get_data()

--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -153,7 +153,7 @@ class TreeView(QTreeView):
 
         edit_triggers = QTreeView.DoubleClicked | QTreeView.EditKeyPressed
         super().__init__(
-            editTriggers=int(edit_triggers),
+            editTriggers=edit_triggers,
             selectionMode=QTreeView.ExtendedSelection,
             dragEnabled=True,
             acceptDrops=True,
@@ -165,7 +165,7 @@ class TreeView(QTreeView):
 
         self.__disconnected = False
 
-    def startDrag(self, actions: Qt.DropActions):
+    def startDrag(self, actions: Qt.DropAction):
         with disconnected(self.model().dataChanged, self.__data_changed_cb):
             super().startDrag(actions)
         self.drop_finished.emit()
@@ -626,7 +626,7 @@ class OWOntology(OWWidget, ConcurrentWidgetMixin):
 
         edit_triggers = QListView.DoubleClicked | QListView.EditKeyPressed
         self.__library_view = QListView(
-            editTriggers=int(edit_triggers),
+            editTriggers=edit_triggers,
             minimumWidth=200,
             sizePolicy=QSizePolicy(QSizePolicy.Ignored, QSizePolicy.Expanding),
         )


### PR DESCRIPTION
##### Issue
- Fixes https://github.com/biolab/orange3-text/issues/824
- Ontology fails when embedding cannot be computed for some terms.
- OWOntology is not compatible with PyQt6

##### Description of changes
- Since now SBERT sends single documents (words in the case of ontology) to the server, and SBERT embedded already uses an embedding cache, a separate ontology cache is no longer required. **This PR removes the ontology embedding cache.** Anyway, sending single words to the embedded is not optimal and is slow in the case of terms, so in the future, I will change the SBERT embedded to have the option to send more words in the single request (and the cache will be handled there).
- **This PR also removes the similarity cache**. It is not required since I found out that it is faster to compute pairwise cosine similarity (for the whole matrix at the time) than looping over the cache to find cached results.
- **Handle cases when some embedding cannot be retrieved** (most likely due to connection error). When generating, non-embedded words will be excluded, and the user will get a warning in the widget. **To discuss:** is that a suitable solution, or should computation fail?
- **Fixes incompatibilities with PyQt6 in the Ontology widget**


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
