### PR TITLE
[FIX] VectorizationComputeValue - remove wrongly set "original" variable

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -320,8 +320,6 @@ class Corpus(Table):
             else:
                 var = ContinuousVariable(f, compute_value=cv)
             var.sparse = sparse     # don't pass this to constructor so this works with Orange < 3.8.0
-            if cv is not None:      # set original variable for cv
-                cv.variable = var
             if isinstance(var_attrs, dict):
                 var.attributes.update(var_attrs)
             additional_attributes.append(var)

--- a/orangecontrib/text/vectorization/bagofwords.py
+++ b/orangecontrib/text/vectorization/bagofwords.py
@@ -88,10 +88,8 @@ class BowVectorizer(BaseVectorizer):
         callback(0.9)
 
         # set compute values
-        shared_cv = SharedTransform(self, corpus.used_preprocessor,
-                                    source_dict=dic)
-        cv = [VectorizationComputeValue(shared_cv, dic[i])
-              for i in range(len(dic))]
+        shared_cv = SharedTransform(self, corpus.used_preprocessor, source_dict=dic)
+        cv = [VectorizationComputeValue(shared_cv, dic[i]) for i in range(len(dic))]
 
         corpus = self.add_features(corpus, X, dic, cv, var_attrs={'bow-feature': True})
         callback(1)


### PR DESCRIPTION
##### Issue
`extend_attributes` wrongly adds the original variable to the compute_value. It actually adds a current variable. This causes infinite recursion when computing the hash value of the variable/SharedComputeVariable.

##### Description of changes
Since the wrong variable is added and it is actually never used, I am removing it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
