### PR TITLE
[FIX] Keywords/Score Documents - fix ctrl/cmd selection

### DIFF
--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -286,7 +286,8 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
         self.mainArea.layout().addWidget(self.__filter_line_edit)
 
         def select_manual():
-            self._set_selection_method(SelectionMethods.MANUAL)
+            self.sel_method = SelectionMethods.MANUAL
+            self.__sel_method_buttons.button(SelectionMethods.MANUAL).setChecked(True)
 
         self.view = KeywordsTableView()
         self.view.pressedAny.connect(select_manual)

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -428,7 +428,8 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         model.setHorizontalHeaderLabels(["Document"])
 
         def select_manual():
-            self.__set_selection_method(SelectionMethods.MANUAL)
+            self.sel_method = SelectionMethods.MANUAL
+            self._sel_method_buttons.button(SelectionMethods.MANUAL).setChecked(True)
 
         self.view = view = ScoreDocumentsTableView()
         view.pressedAny.connect(select_manual)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
Fixes https://github.com/biolab/orange3-text/issues/811
Selecting with mouse and programmatically selecting by `_select_rows` on every click causes clearing the selection and re-emitting the `selectionChanged` signal, which clears the selection.

##### Description of changes
Only switch to manual selection without reselecting items programmatically when selection is made in the table/listview.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
