### PR TITLE
Adapt embedding tests to be compatible with changes in Orange

### DIFF
--- a/orangecontrib/text/tests/test_documentembedder.py
+++ b/orangecontrib/text/tests/test_documentembedder.py
@@ -17,7 +17,8 @@ class DummyResponse:
 
 def make_dummy_post(response, sleep=0):
     @staticmethod
-    async def dummy_post(url, headers, data):
+    async def dummy_post(url, headers, data=None, content=None):
+        assert data or content
         await asyncio.sleep(sleep)
         return DummyResponse(content=response)
     return dummy_post

--- a/orangecontrib/text/tests/test_ontology.py
+++ b/orangecontrib/text/tests/test_ontology.py
@@ -23,7 +23,8 @@ class DummyResponse:
 
 def make_dummy_post(response, sleep=0):
     @staticmethod
-    async def dummy_post(url, headers, data):
+    async def dummy_post(url, headers, data=None, content=None):
+        assert data or content
         await asyncio.sleep(sleep)
         return DummyResponse(
             content=next(response) if isinstance(response, Iterator) else response

--- a/orangecontrib/text/tests/test_sbert.py
+++ b/orangecontrib/text/tests/test_sbert.py
@@ -23,7 +23,8 @@ class DummyResponse:
 
 def make_dummy_post(response, sleep=0):
     @staticmethod
-    async def dummy_post(url, headers, data):
+    async def dummy_post(url, headers, data=None, content=None):
+        assert data or content
         await asyncio.sleep(sleep)
         return DummyResponse(
             content=next(response) if isinstance(response, Iterator) else response

--- a/orangecontrib/text/tests/test_semantic_search.py
+++ b/orangecontrib/text/tests/test_semantic_search.py
@@ -39,7 +39,8 @@ class DummyResponse:
 
 def make_dummy_post(response, sleep=0):
     @staticmethod
-    async def dummy_post(url, headers, data):
+    async def dummy_post(url, headers, data=None, content=None):
+        assert data or content
         await asyncio.sleep(sleep)
         return DummyResponse(
             content=next(response) if isinstance(response, Iterator) else response


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
ServerEmbedder module has some changes which don't affect embedding, but few changes are required in tests.

##### Description of changes
Adapt test to changes

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
