### PR TITLE
[FIX] Annotator: Invalidate clusters on setting change

### DIFF
--- a/orangecontrib/text/widgets/owannotator.py
+++ b/orangecontrib/text/widgets/owannotator.py
@@ -324,6 +324,7 @@ class OWAnnotator(OWDataProjectionWidget, ConcurrentWidgetMixin):
 
     def __on_clustering_type_changed(self):
         self._enable_clustering_controls()
+        self._invalidate_clusters()
         self._run()
 
     def __on_epsilon_check_changed(self):
@@ -343,6 +344,7 @@ class OWAnnotator(OWDataProjectionWidget, ConcurrentWidgetMixin):
         self._run()
 
     def __on_cluster_var_changed(self):
+        self._invalidate_clusters()
         self._run()
 
     def __on_fdr_threshold_changed(self):

--- a/orangecontrib/text/widgets/tests/test_owannotator.py
+++ b/orangecontrib/text/widgets/tests/test_owannotator.py
@@ -254,6 +254,25 @@ class TestOWAnnotator(WidgetTest):
         self.widget.controls.clustering_type.buttons[2].click()
         self.assertIsNotNone(self.widget.cluster_var)
 
+    def test_invalidate(self):
+        self.send_signal(self.widget.Inputs.corpus, self.corpus)
+
+        self.wait_until_finished()
+        self.assertEqual(len(self.widget.clusters.groups), 1)
+
+        self.widget.controls.clustering_type.buttons[1].click()
+        self.wait_until_finished()
+        self.assertEqual(len(self.widget.clusters.groups), 3)
+
+        self.widget.controls.use_n_components.setChecked(True)
+        self.widget.controls.n_components.setValue(4)
+        self.wait_until_finished()
+        self.assertEqual(len(self.widget.clusters.groups), 4)
+
+        self.widget.controls.clustering_type.buttons[2].click()
+        self.wait_until_finished()
+        self.assertEqual(len(self.widget.clusters.groups), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget crashes with
```
Traceback (most recent call last):
  File "/Users/vesna/orange-widget-base/orangewidget/gui.py", line 2258, in __call__
    self.func(**kwds)
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owannotator.py", line 327, in __on_clustering_type_changed
    self._run()
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owannotator.py", line 379, in _run
    self.graph.update_clusters()  # Remove cluster hulls and labels
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owannotator.py", line 154, in update_clusters
    self._update_cluster_hull()
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owannotator.py", line 162, in _update_cluster_hull
    hulls = self.master.get_cluster_hulls()
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owannotator.py", line 525, in get_cluster_hulls
    return [(hull, colors[key])
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owannotator.py", line 525, in <listcomp>
    return [(hull, colors[key])
IndexError: index 3 is out of bounds for axis 0 with size 3
```

To reproduce:
Corpus (book-excerpts) -> tSNE -> Annotated Corpus Maps (1. select `Gaussian mixture models` with `4` clusters, 2. select `From variable`)

##### Description of changes
- invalidate clusters if settings change

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
