### PR TITLE
Score Documents: Assign input corpus ids to output corpus

### DIFF
--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -565,6 +565,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
                 self.corpus.X,
                 self.corpus.Y,
                 np.hstack([self.corpus.metas, scores]),
+                ids=self.corpus.ids,
             )
             Corpus.retain_preprocessing(self.corpus, out_corpus)
         else:

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -23,7 +23,7 @@ from Orange.data import ContinuousVariable, Domain, StringVariable, Table
 from Orange.data.util import get_unique_names
 from Orange.util import wrap_callback
 from Orange.widgets.settings import ContextSetting, PerfectDomainContextHandler, Setting
-from Orange.widgets.utils.annotated_data import create_annotated_table
+from Orange.widgets.utils.annotated_data import create_annotated_table, add_columns
 from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 from Orange.widgets.utils.itemmodels import PyTableModel, TableModel
 from Orange.widgets.widget import Input, Msg, Output, OWWidget
@@ -291,7 +291,7 @@ class ScoreDocumentsTableModel(PyTableModel):
                 # in document title column remove newline characters from titles
                 dat = self.simplify(dat)
             return dat
-        if role == Qt.BackgroundColorRole and index.column() == 0:
+        if role == Qt.BackgroundRole and index.column() == 0:
             return TableModel.ColorForRole[TableModel.Meta]
         return super().data(index, role)
 
@@ -401,7 +401,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
             button.setChecked(method == self.sel_method)
             grid.addWidget(button, method, 0)
             self._sel_method_buttons.addButton(button, method)
-        self._sel_method_buttons.buttonClicked[int].connect(self.__set_selection_method)
+        self._sel_method_buttons.buttonClicked.connect(self.__on_method_change)
 
         spin = gui.spin(
             box,
@@ -440,7 +440,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
 
         proxy_model = ScoreDocumentsProxyModel()
         proxy_model.setFilterKeyColumn(0)
-        proxy_model.setFilterCaseSensitivity(False)
+        proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
         view.setModel(proxy_model)
         view.model().setSourceModel(self.model)
         self.view.selectionModel().selectionChanged.connect(self.__on_selection_change)
@@ -467,6 +467,9 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
     def __on_selection_change(self):
         self.selected_rows = self.get_selected_indices()
         self._send_output()
+
+    def __on_method_change(self):
+        self.__set_selection_method(self._sel_method_buttons.checkedId())
 
     def __set_selection_method(self, method: int):
         self.sel_method = method
@@ -554,20 +557,11 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
         scores, labels = self._gather_scores()
         if labels:
             d = self.corpus.domain
-            domain = Domain(
-                d.attributes,
-                d.class_var,
-                metas=d.metas + tuple(ContinuousVariable(get_unique_names(d, l))
-                                      for l in labels),
-            )
-            out_corpus = Corpus.from_numpy(
-                domain,
-                self.corpus.X,
-                self.corpus.Y,
-                np.hstack([self.corpus.metas, scores]),
-                ids=self.corpus.ids,
-            )
-            Corpus.retain_preprocessing(self.corpus, out_corpus)
+            new_vars = tuple(ContinuousVariable(get_unique_names(d, l)) for l in labels)
+            new_domain = add_columns(d, metas=new_vars)
+            out_corpus = Corpus.from_table(new_domain, self.corpus)
+            with out_corpus.unlocked(out_corpus.metas):
+                out_corpus[:, new_vars] = scores
         else:
             out_corpus = self.corpus
 

--- a/orangecontrib/text/widgets/tests/test_owscoredocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owscoredocuments.py
@@ -416,6 +416,18 @@ class TestOWScoreDocuments(WidgetTest):
         output = self.get_output(self.widget.Outputs.selected_documents)
         self.assertTrue("Word count (1)" in output.domain)
 
+    def test_output_ids(self):
+        corpus = Corpus.from_file("book-excerpts")
+        var = ContinuousVariable("Word count")
+        corpus = corpus.add_column(var, np.array([1 for _ in range(len(
+            corpus))]))
+        words = create_words_table(["doctor", "rum", "house"])
+        self.send_signal(self.widget.Inputs.corpus, corpus)
+        self.send_signal(self.widget.Inputs.words, words)
+        self.wait_until_finished()
+        output = self.get_output(self.widget.Outputs.selected_documents)
+        self.assertTrue(all([i in corpus.ids for i in output.ids]))
+
     def test_titles_no_newline(self):
         corpus = Corpus.from_file("andersen")
         with corpus.unlocked():


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Output corpus cannot be feed as in input subset to a projection widget.

##### Description of changes
- assign output corpus input's ids

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
