### PR TITLE
[FIX] Score Documents - cast bool scores to float

### DIFF
--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -59,7 +59,7 @@ def _word_appearance(
         t = set(t)
         res.append([w in t for w in words])
         callback((i + 1) / len(tokens))
-    return np.array(res)
+    return np.array(res).astype(float)
 
 
 def _embedding_similarity(

--- a/orangecontrib/text/widgets/tests/test_owscoredocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owscoredocuments.py
@@ -215,6 +215,20 @@ class TestOWScoreDocuments(WidgetTest):
         self.wait_until_finished()
         self.assertListEqual([x[1] for x in self.widget.model], [1, 1, 1])
 
+        # test case where all values are 0
+        corpus = self.create_corpus(
+            [
+                "Lorem ipsum dolor sit ipsum, consectetur adipiscing elit.",
+                "Sed eu sollicitudin velit lorem.",
+            ]
+        )
+        self.send_signal(self.widget.Inputs.corpus, corpus)
+        simulate.combobox_activate_item(cb_aggregation, "Min")
+        self.wait_until_finished()
+        scores = [x[1] for x in self.widget.model]
+        self.assertTrue(all(isinstance(s, float) for s in scores))
+        self.assertListEqual(scores, [0, 0])
+
     @patch.object(_ServerEmbedder, "embedd_data", new=embedding_mock)
     def test_embedding_similarity(self):
         corpus = self.create_corpus(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In some rare cases in cases of words appearance, scores were boolean instead of numeric values (when aggregation result was inside the bool range -- for example, when using min aggregation). It caused the widget to crash when plotting range bars. 

##### Description of changes
Cast word appearance scores to float before aggregating.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
