### PR TITLE
CI - Raise error for Orange deprecation warning only in oldest test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,10 @@ changedir =
     {envsitepackagesdir}
 setenv =
     # Raise deprecations as errors in our tests
-    ORANGE_DEPRECATIONS_ERROR=y
+    oldest: ORANGE_DEPRECATIONS_ERROR=y
     # Need this otherwise unittest installs a warning filter that overrides
     # our desire to have OrangeDeprecationWarnings raised
-    PYTHONWARNINGS=module
+    oldest: PYTHONWARNINGS=module
     # set coverage output and project config
     COVERAGE_FILE = {toxinidir}/.coverage
     COVERAGE_RCFILE = {toxinidir}/.coveragerc


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Error is raised, and tests fail every time Orange deprecate the function that the text is using. Sometimes it is not possible to replace deprecation since we must also support the oldest Oranges versions.

##### Description of changes
Raise error for Orange deprecations only in the oldest test.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
