### PR TITLE
[FIX] Corpus: Unpickle corpus without language

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -4,7 +4,7 @@ from collections import Counter, defaultdict
 from copy import copy, deepcopy
 from numbers import Integral
 from itertools import chain
-from typing import Union, Optional, List, Tuple
+from typing import Union, Optional, List, Tuple, Dict
 from warnings import warn
 
 import nltk
@@ -367,6 +367,11 @@ class Corpus(Table):
     @property
     def language(self):
         return self.attributes["language"]
+
+    def __setstate__(self, state: Dict):
+        super().__setstate__(state)
+        if "language" not in self.attributes:
+            self.attributes["language"] = None
 
     def documents_from_features(self, feats):
         """

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -691,6 +691,12 @@ class CorpusTests(unittest.TestCase):
         """
         self.assertLess(datetime.today(), datetime(2024, 1, 1))
 
+    def test_language_unpickle(self):
+        path = os.path.dirname(__file__)
+        file = os.path.abspath(os.path.join(path, "data", "book-excerpts.pkl"))
+        corpus = Corpus.from_file(file)
+        self.assertIsNone(corpus.attributes["language"])
+
 
 @skipIf(summarize is None, "summarize is not available for orange3<=3.28")
 class TestCorpusSummaries(unittest.TestCase):

--- a/orangecontrib/text/widgets/tests/test_owcorpus.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpus.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import numpy as np
@@ -324,6 +325,15 @@ class TestOWCorpus(WidgetTest):
         self.wait_until_finished()
         self.assertEqual("English", self.widget.language)
         self.assertEqual("en", self.get_output(self.widget.Outputs.corpus).language)
+
+    def test_language_unpickle(self):
+        path = os.path.dirname(__file__)
+        file = os.path.abspath(os.path.join(path, "..", "..", "tests",
+                                            "data", "book-excerpts.pkl"))
+        corpus = Corpus.from_file(file)
+        self.send_signal(self.widget.Inputs.data, corpus)
+        self.wait_until_finished()
+        self.assertEqual(self.widget.language, "English")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Corpuses, pickled before #916, cannot be used in Corpus widget, because they are missing a `language` property.

##### Description of changes
- reimplement Corpus.__setstate__ to add the `language` property


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
