### PR TITLE
Ci - quick fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
-        python-version: [3.7, 3.8]
+        os: [ubuntu-18.04, macos-11.0, windows-2019]
+        python-version: [3.8, 3.9, "3.10"]
         tox_env: [py-orange-released]
         experimental: [false]
         name: [Released]
@@ -28,40 +28,35 @@ jobs:
             tox_env: py-orange-released
             experimental: true
             name: Windows10
+
+          - os: windows-2019
+            python-version: 3.8
+            tox_env: py-orange-oldest
+            experimental: false
+            name: Oldest
           - os: macos-11.0
             python-version: 3.8
-            tox_env: py-orange-released
-            experimental: true
-            name: Big Sur
-
-          - os: windows-2019
-            python-version: 3.7
-            tox_env: py-orange-oldest
-            experimental: false
-            name: Oldest
-          - os: macos-10.15
-            python-version: 3.7
             tox_env: py-orange-oldest
             name: Oldest
             experimental: false
           - os: ubuntu-18.04
-            python-version: 3.7
+            python-version: 3.8
             tox_env: py-orange-oldest
             name: Oldest
             experimental: false
 
           - os: windows-2019
-            python-version: 3.8
+            python-version: "3.10"
             tox_env: py-orange-latest
             experimental: false
             name: Latest
-          - os: macos-10.15
-            python-version: 3.8
+          - os: macos-11.0
+            python-version: "3.10"
             tox_env: py-orange-latest
             experimental: false
             name: Latest
           - os: ubuntu-18.04
-            python-version: 3.8
+            python-version: "3.10"
             tox_env: py-orange-latest
             experimental: false
             name: Latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ biopython  # Enables Pubmed widget.
 conllu
 docx2txt>=0.6
 gensim==4.1.2  # temporary fix - reset when gensim solves https://github.com/RaRe-Technologies/gensim/issues/3368
-httpx
+httpx!=0.23.1  # temporary fix - semantic search fail (but only in tests)
 langdetect
 lemmagen3
 lxml


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Mac0s 10.15 workers are deprecated and we do not test py 3.9 and 3.10. 

##### Description of changes
Since it seems that it will take some time to adopt https://github.com/biolab/orange3-text/pull/917 I propose quick version fix here


##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
