### PR TITLE
[ENH] Guardian - infer language and add to corpus

### DIFF
--- a/orangecontrib/text/util.py
+++ b/orangecontrib/text/util.py
@@ -1,10 +1,14 @@
 from functools import wraps
 from math import ceil
-from typing import Union, List
+from typing import Union, List, Callable, Any, Tuple
 
 import numpy as np
 import scipy.sparse as sp
+from Orange.data import Domain, DiscreteVariable
 from gensim.matutils import Sparse2Corpus
+
+from orangecontrib.text import Corpus
+from orangecontrib.text.language import infer_language_from_variable
 
 
 def chunks(iterable, chunk_size):
@@ -88,3 +92,82 @@ class Sparse2CorpusSliceable(Sparse2Corpus):
         """
         sparse = self.sparse.__getitem__((slice(None, None, None), key))
         return Sparse2CorpusSliceable(sparse)
+
+
+def create_corpus(
+    documents: List[Any],
+    attributes: List[Tuple[Callable, Callable]],
+    class_vars: List[Tuple[Callable, Callable]],
+    metas: List[Tuple[Callable, Callable]],
+    title_indices: List[int],
+    text_features: List[str],
+    name: str,
+    language_attribute: str,
+):
+    """
+    Create a corpus from list of features/documents produced by modelu such as
+    Guardian/NYT
+
+    Parameters
+    ----------
+    documents
+        List with values downloaded from API
+    attributes
+        List of attributes and recipes on how to extract values from documents.
+    class_vars
+        List of class attributes and recipes on how to extract values from documents.
+    metas
+        List of meta and recipes on how to extract values from documents.
+    title_indices
+        The index of the title attribute.
+    text_features
+        Names of text features
+    name
+        The name of the Corpus
+    language_attribute
+        The attribute to infer the language from.
+
+    Returns
+    -------
+    Corpus with documents.
+    """
+    domain = Domain(
+        attributes=[attr() for attr, _ in attributes],
+        class_vars=[attr() for attr, _ in class_vars],
+        metas=[attr() for attr, _ in metas],
+    )
+    for ind in title_indices:
+        domain[ind].attributes["title"] = True
+
+    def to_val(attr, val):
+        if isinstance(attr, DiscreteVariable):
+            attr.val_from_str_add(val)
+        return attr.to_val(val)
+
+    X = [
+        [to_val(a, f(doc)) for a, (_, f) in zip(domain.class_vars, attributes)]
+        for doc in documents
+    ]
+    Y = [
+        [to_val(a, f(doc)) for a, (_, f) in zip(domain.class_vars, class_vars)]
+        for doc in documents
+    ]
+    metas = [
+        [to_val(a, f(doc)) for a, (_, f) in zip(domain.metas, metas)]
+        for doc in documents
+    ]
+    X = np.array(X, dtype=np.float64)
+    Y = np.array(Y, dtype=np.float64)
+    metas = np.array(metas, dtype=object)
+
+    language = infer_language_from_variable(domain[language_attribute])
+    corpus = Corpus.from_numpy(
+        domain=domain,
+        X=X,
+        Y=Y,
+        metas=metas,
+        text_features=[domain[f] for f in text_features],
+        language=language,
+    )
+    corpus.name = name
+    return corpus

--- a/orangecontrib/text/widgets/owguardian.py
+++ b/orangecontrib/text/widgets/owguardian.py
@@ -78,9 +78,10 @@ class OWGuardian(OWWidget):
     recent_queries = Setting([])
     date_from = Setting((datetime.now().date() - timedelta(365)))
     date_to = Setting(datetime.now().date())
-    attributes = [feat.name for feat, _ in TheGuardianAPI.metas if
-                  isinstance(feat, StringVariable)]
-    text_includes = Setting([feat.name for feat in TheGuardianAPI.text_features])
+    attributes = [
+        part.args[0] for part, _ in TheGuardianAPI.metas if part.func is StringVariable
+    ]
+    text_includes = Setting([feat for feat in TheGuardianAPI.text_features])
 
     class Warning(OWWidget.Warning):
         no_text_fields = Msg('Text features are inferred when none are selected.')


### PR DESCRIPTION
Derived from https://github.com/biolab/orange3-text/pull/874

##### Description of changes
Infer language from articles and add it to the corpus

In the current implementation, Corpus variables are created when GuardianAPI is initialized, so they are shared between multiple corpora. The problem appears when different values are added to DiscreteVariable by different calls, so values accumulate. This PR changes that variables are defined in each call separately. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
