### PR TITLE
[ENH] PubMed - add language to corpus

### DIFF
--- a/orangecontrib/text/pubmed.py
+++ b/orangecontrib/text/pubmed.py
@@ -6,11 +6,8 @@ from datetime import datetime
 import numpy as np
 from Bio import Entrez
 from Bio import Medline
+from Orange.misc import environ
 
-try:
-    from Orange.misc import environ
-except ImportError:
-    from Orange.canvas.utils import environ
 
 from Orange.data import StringVariable, DiscreteVariable, TimeVariable, Domain
 from orangecontrib.text.corpus import Corpus

--- a/orangecontrib/text/pubmed.py
+++ b/orangecontrib/text/pubmed.py
@@ -164,8 +164,10 @@ def _corpus_from_records(records, includes_metadata):
 
     Y = np.array([class_vars[0].to_val(cv) for cv in class_values])[:, None]
 
+    # as documented here https://www.nlm.nih.gov/bsd/mms/medlineelements.html#ab
+    # all abstracts are in English - setting language to English
     return Corpus.from_numpy(
-        domain=domain, X=np.empty((len(Y), 0)), Y=Y, metas=meta_values
+        domain=domain, X=np.empty((len(Y), 0)), Y=Y, metas=meta_values, language="en"
     )
 
 

--- a/orangecontrib/text/tests/test_pubmed.py
+++ b/orangecontrib/text/tests/test_pubmed.py
@@ -113,7 +113,6 @@ class PubmedTests(unittest.TestCase):
         )
         self.assertEqual(type(_date_to_iso(unexpected_input)), type(np.nan))
 
-
     def test_record_to_corpus(self):
         mock_records = [
             {
@@ -150,6 +149,7 @@ class PubmedTests(unittest.TestCase):
         self.assertCountEqual(meta_values[0], correct_metas[0])
         self.assertCountEqual(class_values, correct_classes)
         self.assertIsNotNone(corpus)
+        self.assertEqual(corpus.language, "en")
 
     @patch('Bio.Entrez.esearch', mock_entrez.esearch)
     @patch('Bio.Entrez.read', mock_entrez.read)


### PR DESCRIPTION
Derived from https://github.com/biolab/orange3-text/pull/874

##### Description of changes
Add language to the corpus. Always add English since PubMed only index the English version of articles.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
