### PR TITLE
[ENH] Wikipedia - add language to corpus

### DIFF
--- a/orangecontrib/text/tests/test_wikipedia.py
+++ b/orangecontrib/text/tests/test_wikipedia.py
@@ -59,12 +59,19 @@ class WikipediaTests(unittest.TestCase):
         self.assertListEqual(
             [["Article 1"], ["Article 2"]], result[:, "Title"].metas.tolist()
         )
+        self.assertEqual("en", result.language)
 
         self.assertEqual(on_progress.call_count, 2)
         progress = 0
         for arg in on_progress.call_args_list:
             self.assertGreater(arg[0][0], progress)
             progress = arg[0][0]
+
+        # if searched in it language Corpus's language should be it
+        result = api.search(
+            "it", ["Clinton"], articles_per_query=2, on_progress=on_progress
+        )
+        self.assertEqual("it", result.language)
 
     @patch(
         "orangecontrib.text.wikipedia_api.wikipedia.search",

--- a/orangecontrib/text/widgets/owwikipedia.py
+++ b/orangecontrib/text/widgets/owwikipedia.py
@@ -61,7 +61,7 @@ class OWWikipedia(OWWidget):
 
         # Language
         row += 1
-        languages = tuple(sorted(set(LANG2ISO.items()) - {(None, None)}))
+        languages = sorted(set(LANG2ISO.items()) - {(None, None)})
         language_edit = ComboBox(self, 'language', languages)
         layout.addWidget(QLabel('Language:'), row, 0, 1, self.label_width)
         layout.addWidget(language_edit, row, self.label_width, 1, self.widgets_width)

--- a/orangecontrib/text/widgets/utils/widgets.py
+++ b/orangecontrib/text/widgets/utils/widgets.py
@@ -18,7 +18,6 @@ from orangecontrib.text.corpus import get_sample_corpora_dir
 
 class ListEdit(QTextEdit):
     PLACEHOLDER_COLOR = QColor(128, 128, 128)
-    USER_TEXT_COLOR = QColor(0, 0, 0)
 
     def __init__(self, master=None, attr=None, placeholder_text=None,
                  fixed_height=None, *args):
@@ -55,7 +54,6 @@ class ListEdit(QTextEdit):
         if self.toPlainText() == '':
             self.clear()
             self.setFontItalic(False)
-            self.setTextColor(self.USER_TEXT_COLOR)
 
     def focusOutEvent(self, event):
         self.set_placeholder()

--- a/orangecontrib/text/wikipedia_api.py
+++ b/orangecontrib/text/wikipedia_api.py
@@ -69,8 +69,15 @@ class WikipediaAPI:
             if callable(should_break) and should_break():
                 break
 
-        return Corpus.from_documents(results, 'Wikipedia', self.attributes,
-                                     self.class_vars, self.metas, title_indices=[-1])
+        return Corpus.from_documents(
+            results,
+            "Wikipedia",
+            self.attributes,
+            self.class_vars,
+            self.metas,
+            title_indices=[-1],
+            language=lang,
+        )
 
     def _get(self, article, query, should_break, recursive=True):
         try:


### PR DESCRIPTION
Derived from https://github.com/biolab/orange3-text/pull/874

##### Description of changes

Add language to the corpus. Always add search language since all results will be in this language.

I also removed setting text colour in the ListEdit, since it causes the colour is also black in dark mode. Now, the default colour is used (white for dark mode and black for bright mode).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
