### PR TITLE
[ENH] Score Documents - enable matching n-grams

### DIFF
--- a/doc/widgets/score-documents.md
+++ b/doc/widgets/score-documents.md
@@ -29,6 +29,8 @@ Scores documents based on word appearance.
 4. If *Send Automatically*, changes are communicated automatically. Alternatively press *Send*.
 5. Filter documents based on the document title in the first column. Below is the table with the document titles in the first column and scores in other columns.
 
+**Note**: Score Documents will apply preprocessing from the input Corpus to words before scoring.
+
 Example
 -------
 

--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -55,6 +55,7 @@ def _check_arrays(*arrays):
 
 class Corpus(Table):
     """Internal class for storing a corpus."""
+    NGRAMS_SEPARATOR = " "
 
     def __new__(cls, *args, **kwargs):
         if args and isinstance(args[0], Domain) or "domain" in kwargs:
@@ -447,7 +448,7 @@ class Corpus(Table):
     def pos_tags(self, pos_tags):
         self._pos_tags = pos_tags
 
-    def ngrams_iterator(self, join_with=' ', include_postags=False):
+    def ngrams_iterator(self, join_with=NGRAMS_SEPARATOR, include_postags=False):
         if self.pos_tags is None:
             include_postags = False
 
@@ -471,7 +472,7 @@ class Corpus(Table):
     @property
     def ngrams(self):
         """generator: Ngram representations of documents."""
-        return self.ngrams_iterator(join_with=' ')
+        return self.ngrams_iterator(join_with=self.NGRAMS_SEPARATOR)
 
     def copy(self):
         """Return a copy of the table."""

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -19,6 +19,7 @@ from AnyQt.QtWidgets import (
     QRadioButton,
     QTableView,
 )
+
 from Orange.data import ContinuousVariable, Domain, StringVariable, Table
 from Orange.data.util import get_unique_names
 from Orange.util import wrap_callback
@@ -33,7 +34,7 @@ from pandas import isnull
 from sklearn.metrics.pairwise import cosine_similarity
 
 from orangecontrib.text import Corpus
-from orangecontrib.text.preprocess import BaseNormalizer, BaseTransformer
+from orangecontrib.text.preprocess import BaseNormalizer, NGrams, BaseTokenFilter
 from orangecontrib.text.vectorization.document_embedder import (
     LANGS_TO_ISO,
     DocumentEmbedder,
@@ -41,13 +42,14 @@ from orangecontrib.text.vectorization.document_embedder import (
 from orangecontrib.text.widgets.utils import enum2int
 from orangecontrib.text.widgets.utils.words import create_words_table
 
+
 def _word_frequency(corpus: Corpus, words: List[str], callback: Callable) -> np.ndarray:
     res = []
-    tokens = corpus.tokens
+    tokens = corpus.ngrams
     for i, t in enumerate(tokens):
         counts = Counter(t)
         res.append([counts.get(w, 0) for w in words])
-        callback((i + 1) / len(tokens))
+        callback((i + 1) / len(corpus))
     return np.array(res)
 
 
@@ -55,11 +57,11 @@ def _word_appearance(
     corpus: Corpus, words: List[str], callback: Callable
 ) -> np.ndarray:
     res = []
-    tokens = corpus.tokens
+    tokens = corpus.ngrams
     for i, t in enumerate(tokens):
         t = set(t)
         res.append([w in t for w in words])
-        callback((i + 1) / len(tokens))
+        callback((i + 1) / len(corpus))
     return np.array(res).astype(float)
 
 
@@ -123,10 +125,9 @@ def _preprocess_words(
 ) -> List[str]:
     """
     Corpus's tokens can be preprocessed. Since they will not match correctly
-    with words preprocessors that change words (e.g. normalization) must
-    be applied to words too.
+    with words, same preprocessors that preprocess words in corpus
+    (e.g. normalization) must be applied to words too.
     """
-    # workaround to preprocess words
     # TODO: currently preprocessors work only on corpus, when there will be more
     #  cases like this think about implementation of preprocessors for a list
     #  of strings
@@ -137,16 +138,16 @@ def _preprocess_words(
         metas=np.array([[w] for w in words]),
         text_features=[words_feature],
     )
-    # only transformers and normalizers preprocess on the word level
-    pps = [
-        pp
-        for pp in corpus.used_preprocessor.preprocessors
-        if isinstance(pp, (BaseTransformer, BaseNormalizer))
-    ]
+    # apply all corpus preprocessors except Filter and NGrams, which change terms
+    # filter removes words from the term, and NGrams split the term in grams.
+    # If a user decided to score with a particular term, he meant this term
+    # and not derivations of it
+    pps = corpus.used_preprocessor.preprocessors
     for i, pp in enumerate(pps):
-        words_c = pp(words_c)
-        callback((i + 1) / len(pps))
-    return [w[0] for w in words_c.tokens if len(w)]
+        if not isinstance(pp, (BaseTokenFilter, NGrams)):
+            words_c = pp(words_c)
+            callback((i + 1) / len(pps))
+    return [Corpus.NGRAMS_SEPARATOR.join(ngs) for ngs in words_c.tokens if len(ngs)]
 
 
 def _run(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Currently Score Document matches only words from the input. When more-term words are on input, it fails with scoring (only score with first word from the term).

##### Description of changes
- Apply same preprocessing on words that are used on corpus
- Match n-grams from the corpus

With this modifications Corpus's preprocessing defines how words are preprocessed and matched. E.g. if the user selects to use bi-grams (only) on the corpus, terms (from words input) are matched as bigrams. In this case terms that are words are ignored, and those that are longer than bigrams are transformed to bigrams.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
