### PR TITLE
[FIX] Ontology - Show labels instead of names for imported ontolgies

### DIFF
--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -104,7 +104,8 @@ def _tree_to_html(tree: Dict) -> str:
 def _onto_to_tree(thing: Thing, world: World) -> Dict:
     tree = {}
     for cl in list(thing.subclasses(world=world)):
-        tree[cl.name] = _onto_to_tree(cl, world)
+        label = (cl.label.first() or cl.name).replace("\n", " ").strip()
+        tree[label] = _onto_to_tree(cl, world)
     return tree
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description if the issue does not exist. -->
When ontologies are imported, the tree shows node name instead of node label. 

##### Description of changes
Name is not necessarily in human-readable format (can be codes), but the label attribute usually shows name in a human-readable format. Show label if exists and name if label not assigned.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
