### PR TITLE
[FIX] Corpus - preserve name in extend_attributes

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -107,7 +107,7 @@ class Corpus(Table):
 
     @property
     def used_preprocessor(self):
-        return self.__used_preprocessor  # type: PreprocessorList
+        return self.__used_preprocessor
 
     @used_preprocessor.setter
     def used_preprocessor(self, pp):
@@ -261,7 +261,7 @@ class Corpus(Table):
     def extend_attributes(
             self, X, feature_names, feature_values=None, compute_values=None,
             var_attrs=None, sparse=False, rename_existing=False
-        ):
+    ):
         """
         Append features to corpus. If `feature_values` argument is present,
         features will be Discrete else Continuous.
@@ -308,9 +308,7 @@ class Corpus(Table):
             feature_values = [None] * X.shape[1]
 
         # rename existing variables if required
-        curr_attributes, curr_class_var, curr_metas = _rename_features(
-            feature_names
-        )
+        curr_attributes, curr_class_var, curr_metas = _rename_features(feature_names)
         if not rename_existing:
             # rename new feature names if required
             feature_names = get_unique_names(
@@ -341,6 +339,7 @@ class Corpus(Table):
             self.W.copy(),
             text_features=copy(self.text_features),
         )
+        c.name = self.name  # keep corpus's name
         Corpus.retain_preprocessing(self, c)
         return c
 

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -203,6 +203,16 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(new_c.ngram_range, c.ngram_range)
         self.assertEqual(new_c.attributes, c.attributes)
 
+    def test_extend_attributes_keep_name(self):
+        """
+        Test if corpus's name is kept after corpus's extension
+        """
+        c = Corpus.from_file('book-excerpts')
+        self.assertEqual("book-excerpts", c.name)
+        x = np.random.random((len(c), 3))
+        new_c = c.extend_attributes(x, ['1', '2', '3'])
+        self.assertEqual("book-excerpts", new_c.name)
+
     def test_from_table(self):
         t = Table.from_file('brown-selected')
         self.assertIsInstance(t, Table)

--- a/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
+++ b/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
@@ -129,6 +129,22 @@ class TestOWDocumentEmbedding(WidgetTest):
         self.assertTupleEqual(self.corpus.domain.metas, result.domain.metas)
         self.assertEqual(384, len(result.domain.attributes))
 
+    @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [1.3, 1]}'))
+    def test_corpus_name_preserved(self):
+        # test on fasttext
+        self.send_signal("Corpus", self.corpus)
+        # just to make sure corpus already has a name
+        self.assertEqual("deerwester", self.corpus.name)
+        result = self.get_output(self.widget.Outputs.corpus)
+        self.assertIsNotNone(result)
+        self.assertEqual("deerwester", result.name)
+
+        # test on sbert
+        self.widget.findChildren(QRadioButton)[0].click()
+        result = self.get_output(self.widget.Outputs.corpus)
+        self.assertIsNotNone(result)
+        self.assertEqual("deerwester", result.name)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Corpus's method `extend_attributes` does not preserve the Corpus name

##### Description of changes
Preserve Corpus name in `extend_attributes`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
