### PR TITLE
Speedup some of the slowest tests

### DIFF
--- a/orangecontrib/text/import_documents.py
+++ b/orangecontrib/text/import_documents.py
@@ -561,7 +561,7 @@ class ImportDocuments:
         if len(df.index.drop_duplicates()) != len(df.index):
             df = df[~df.index.duplicated(keep='first')]
         filtered = df.reindex(path_column)
-        for name, column in filtered.iteritems():
+        for name, column in filtered.items():
             data = column.astype(str).values
             val_map, vals, var_type = guess_data_type(data)
             values, variable = sanitize_variable(val_map, vals, data,

--- a/orangecontrib/text/tests/test_import_documents.py
+++ b/orangecontrib/text/tests/test_import_documents.py
@@ -1,10 +1,12 @@
 import asyncio
 import os
 import unittest
-from unittest.mock import patch, MagicMock
+from os.path import join, splitext
+from unittest.mock import patch, MagicMock, call
 
 import numpy as np
 import pandas as pd
+import yaml
 from httpx import URL, ConnectTimeout
 
 from orangecontrib.text.import_documents import (
@@ -16,6 +18,7 @@ from orangecontrib.text.import_documents import (
 
 
 PATCH_METHOD = "httpx.AsyncClient.get"
+SF_LIST = "orangecontrib.text.import_documents.serverfiles.ServerFiles.listfiles"
 
 
 async def dummy_post(_, url):
@@ -24,13 +27,40 @@ async def dummy_post(_, url):
 
 
 class DummyResponse:
-    content = b"lorem ipsum"
-
-    def __init__(self, url):
+    def __init__(self, url, content=b"lorem ipsum"):
         super().__init__()
         self.url = URL(url)
+        self.content = content
 
     raise_for_status = MagicMock()
+
+
+def dummy_yaml(file_name):
+    nn = splitext(file_name)[0] + ".txt"
+    return yaml.dump({"Title": "Test Doc", ImportDocuments.META_DATA_FILE_KEY: nn})
+
+
+TEXTS_URL = "http://dummyserver.com/special/"
+TEXTS_FILES = [
+    [f] for f in ("a.txt", "b.txt", "c.txt", "a.yaml", "b.yaml", "c.test", "meta.csv")
+]
+TEXTS_RESPONSES = [
+    DummyResponse(join(TEXTS_URL, f[0]), b"test")
+    for f in TEXTS_FILES
+    if f[0].endswith(".txt")
+]
+EXAMPLE_YAMLS = [
+    (f[0], dummy_yaml(f[0])) for f in TEXTS_FILES if f[0].endswith(".yaml")
+]
+TEXTS_YAML_RESPONSES = [
+    DummyResponse(join(TEXTS_URL, f), r.encode("utf-8")) for f, r in EXAMPLE_YAMLS
+]
+
+SPECIAL_CHAR_URL = "http://dummyserver.com/special/"
+SPECIAL_CHAR_FILES = [[f] for f in ("č.txt", "š.txt", "ž.txt")]
+SPECIAL_CHAR_RESPONSES = [
+    DummyResponse(join(SPECIAL_CHAR_URL, f[0]), b"test") for f in SPECIAL_CHAR_FILES
+]
 
 
 class TestUrlProxyReader(unittest.TestCase):
@@ -43,16 +73,19 @@ class TestUrlProxyReader(unittest.TestCase):
         self.assertEqual("", error)
         self.assertIsInstance(reader, TxtReader)
 
-    def test_read(self):
-        path = "http://file.biolab.si/text-semantics/data/semeval/C-1.txt"
+    resp = DummyResponse("http://dummyserver.com/semval/C-1.txt", b"Test 1")
+
+    @patch(PATCH_METHOD, return_value=resp)
+    def test_read(self, _):
+        path = "http://dummyserver.com/semval/C-1.txt"
         result = UrlProxyReader.read_files([path])
         reader, textdata, error = result[0]
         self.assertIsInstance(textdata, TextData)
         self.assertEqual(textdata.name, "C-1")
         self.assertEqual(textdata.path, path)
         self.assertEqual(textdata.ext, [".txt"])
-        self.assertEqual(textdata.category, "semeval")
-        self.assertTrue(textdata.content.startswith("On The Complexity of Co"))
+        self.assertEqual(textdata.category, "semval")
+        self.assertEqual("Test 1", textdata.content)
         self.assertEqual(error, "")
 
     @patch(PATCH_METHOD, dummy_post)
@@ -78,53 +111,76 @@ class TestUrlProxyReader(unittest.TestCase):
 
 
 class TestImportDocuments(unittest.TestCase):
-    def test_scan_url(self):
-        path = "http://file.biolab.si/text-semantics/data/semeval/"
-        importer = ImportDocuments(path, True)
-        paths = importer.scan_url(path)
-        self.assertGreater(len(paths), 0)
+    @patch(SF_LIST, return_value=TEXTS_FILES)
+    def test_scan_url(self, _):
+        importer = ImportDocuments(TEXTS_URL, True)
+        paths = importer.scan_url(TEXTS_URL)
+        self.assertEqual(7, len(paths))
+        self.assertListEqual([join(TEXTS_URL, f[0]) for f in TEXTS_FILES], paths)
 
-    def test_scan_url_txt(self):
-        path = "http://file.biolab.si/text-semantics/data/semeval/"
-        importer = ImportDocuments(path, True)
-        paths = importer.scan_url(path, include_patterns=["*.txt"])
-        self.assertGreater(len(paths), 0)
+    @patch(SF_LIST, return_value=TEXTS_FILES)
+    def test_scan_url_txt(self, _):
+        importer = ImportDocuments(TEXTS_URL, True)
+        paths = importer.scan_url(TEXTS_URL, include_patterns=["*.txt"])
+        self.assertEqual(3, len(paths))
+        self.assertListEqual(
+            [join(TEXTS_URL, f[0]) for f in TEXTS_FILES if f[0].endswith(".txt")], paths
+        )
 
-    def test_scan_url_csv(self):
-        path = "http://file.biolab.si/text-semantics/data/"
-        importer = ImportDocuments(path, True)
-        paths = importer.scan_url(path, include_patterns=["*.csv"])
-        self.assertGreater(len(paths), 0)
+    @patch(SF_LIST, return_value=TEXTS_FILES)
+    def test_scan_url_csv(self, _):
+        importer = ImportDocuments(TEXTS_URL, True)
+        paths = importer.scan_url(TEXTS_URL, include_patterns=["*.csv"])
+        self.assertEqual(1, len(paths))
+        self.assertListEqual(
+            [join(TEXTS_URL, f[0]) for f in TEXTS_FILES if f[0].endswith(".csv")], paths
+        )
 
-    def test_read_meta_data_url(self):
-        path = "http://file.biolab.si/text-semantics/data/semeval/"
-        importer = ImportDocuments(path, True)
+    @patch(SF_LIST, return_value=TEXTS_FILES)
+    @patch(PATCH_METHOD, side_effect=TEXTS_YAML_RESPONSES)
+    def test_read_meta_data_url(self, _, __):
+        importer = ImportDocuments(TEXTS_URL, True)
         _, meta_paths = importer._retrieve_paths()
+        self.assertListEqual(
+            [
+                join(TEXTS_URL, f[0])
+                for f in TEXTS_FILES
+                if f[0].endswith((".yaml", ".csv"))
+            ],
+            meta_paths,
+        )
+        meta_paths.remove(join(TEXTS_URL, "meta.csv"))
         callback = importer._shared_callback(len(meta_paths))
         data1, err = importer._read_meta_data(meta_paths, callback)
         self.assertIsInstance(data1, pd.DataFrame)
+        expected = pd.DataFrame(
+            {
+                "Text file": ["a.txt", "b.txt"],
+                "Title": ["Test Doc", "Test Doc"],
+            }
+        )
+        pd.testing.assert_frame_equal(data1.reset_index(drop=True), expected)
         self.assertEqual(len(err), 0)
 
-    # @patch("orangecontrib.text.import_documents.ImportDocuments."
-    #        "META_DATA_FILE_KEY", "File")
-    def test_merge_metadata_url(self):
-        path = "http://file.biolab.si/text-semantics/data/semeval/"
-        importer = ImportDocuments(path, True)
+    @patch(SF_LIST, return_value=TEXTS_FILES)
+    @patch(PATCH_METHOD, side_effect=TEXTS_RESPONSES + TEXTS_YAML_RESPONSES)
+    def test_merge_metadata_url(self, _, __):
+        importer = ImportDocuments(TEXTS_URL, True)
         file_paths, meta_paths = importer._retrieve_paths()
+        meta_paths.remove(join(TEXTS_URL, "meta.csv"))
         callback = importer._shared_callback(len(file_paths) + len(meta_paths))
         text_data, _, _, _, _, _ = importer._read_text_data(file_paths, callback)
         meta_data, _ = importer._read_meta_data(meta_paths, callback)
 
-        importer._text_data = text_data[:4]  # 'C-1', 'C-14', 'C-17', 'C-18'
-        importer._meta_data = meta_data[:50]
+        importer._text_data = text_data
+        importer._meta_data = meta_data
         corpus = importer._create_corpus()
         corpus = importer._add_metadata(corpus)
         self.assertGreater(len(corpus), 0)
-        columns = ["name", "path", "content", "Content",
-                   "Text file", "Keywords"]
+        columns = ["name", "path", "content", "Text file", "Title"]
         self.assertEqual([v.name for v in corpus.domain.metas], columns)
 
-        importer._text_data = text_data[:4]  # 'C-1', 'C-14', 'C-17', 'C-18'
+        importer._text_data = text_data
         importer._meta_data = None
         corpus = importer._create_corpus()
         corpus = importer._add_metadata(corpus)
@@ -132,35 +188,51 @@ class TestImportDocuments(unittest.TestCase):
         columns = ["name", "path", "content"]
         self.assertEqual([v.name for v in corpus.domain.metas], columns)
 
-    def test_run_url(self):
-        path = "http://file.biolab.si/text-semantics/data/predlogi-vladi-20/"
-        importer = ImportDocuments(path, True)
+    @patch(SF_LIST, side_effect=[TEXTS_FILES[:-1]] * 6)
+    @patch(PATCH_METHOD, side_effect=TEXTS_RESPONSES + TEXTS_YAML_RESPONSES)
+    def test_run_url(self, post_mock, sf_mock):
+        importer = ImportDocuments(TEXTS_URL, True)
         corpus1, _, _, _, _, _ = importer.run()
-        self.assertGreater(len(corpus1), 0)
+        self.assertEqual(3, len(corpus1))
+        post_mock.assert_has_calls(
+            [call(join(TEXTS_URL, f[0])) for f in TEXTS_FILES[:-2]]
+        )
 
         mask = np.ones_like(corpus1.metas, dtype=bool)
         mask[:, 1] = False
 
-        path = "http://file.biolab.si/text-semantics/data/predlogi-vladi-20////"
-        importer = ImportDocuments(path, True)
+        new_text_reponses = [
+            DummyResponse(join(TEXTS_URL + "///", f[0]), b"test")
+            for f in TEXTS_FILES
+            if f[0].endswith(".txt")
+        ]
+        post_mock.reset_mock()
+
+        post_mock.side_effect = new_text_reponses + TEXTS_YAML_RESPONSES
+        importer = ImportDocuments(TEXTS_URL + "///", True)
         corpus2, _, _, _, _, _ = importer.run()
-        self.assertGreater(len(corpus1), 0)
+        post_mock.assert_has_calls(
+            [call(join(TEXTS_URL + "///", f[0])) for f in TEXTS_FILES[:-2]]
+        )
+        self.assertEqual(3, len(corpus1))
         np.testing.assert_array_equal(corpus1.metas[mask].tolist(),
                                       corpus2.metas[mask].tolist())
 
-        path = "http://file.biolab.si/text-semantics/data/predlogi-vladi-20"
-        importer = ImportDocuments(path, True)
+        post_mock.side_effect = TEXTS_RESPONSES + TEXTS_YAML_RESPONSES
+        importer = ImportDocuments(TEXTS_URL[:-1], True)
         corpus3, _, _, _, _, _ = importer.run()
-        self.assertGreater(len(corpus2), 0)
-        np.testing.assert_array_equal(corpus1.metas[mask].tolist(),
-                                      corpus3.metas[mask].tolist())
+        post_mock.assert_has_calls(
+            [call(join(TEXTS_URL, f[0])) for f in TEXTS_FILES[:-2]]
+        )
+        self.assertEqual(3, len(corpus1))
+        np.testing.assert_array_equal(corpus1.metas.tolist(), corpus3.metas.tolist())
 
-    def test_run_url_special_characters(self):
-        path = "http://file.biolab.si/text-semantics/data/" \
-               "elektrotehniski-vestnik-clanki/"
-        importer = ImportDocuments(path, True)
+    @patch(SF_LIST, return_value=SPECIAL_CHAR_FILES)
+    @patch(PATCH_METHOD, side_effect=SPECIAL_CHAR_RESPONSES)
+    def test_run_url_special_characters(self, _, __):
+        importer = ImportDocuments(SPECIAL_CHAR_URL, True)
         corpus, errors, _, _, _, _ = importer.run()
-        self.assertGreater(len(corpus), 0)
+        self.assertEqual(3, len(corpus))
         self.assertEqual(0, len(errors))
 
     def test_conllu_reader(self):
@@ -173,10 +245,10 @@ class TestImportDocuments(unittest.TestCase):
         self.assertEqual(len(corpus), len(pos))
         self.assertEqual(len(corpus), len(ner))
 
+    @patch(SF_LIST, return_value=SPECIAL_CHAR_FILES)
     @patch(PATCH_METHOD, side_effect=ConnectTimeout("test message", request=""))
-    def test_url_errors(self, _):
-        path = "http://file.biolab.si/text-semantics/data/elektrotehniski-vestnik-clanki/"
-        importer = ImportDocuments(path, True)
+    def test_url_errors(self, _, __):
+        importer = ImportDocuments(TEXTS_URL, True)
         corpus, errors, _, _, _, _ = importer.run()
         self.assertIsNone(corpus)
         self.assertGreater(len(errors), 0)

--- a/orangecontrib/text/tests/test_wikipedia.py
+++ b/orangecontrib/text/tests/test_wikipedia.py
@@ -1,8 +1,12 @@
 import unittest
+from types import SimpleNamespace
 from unittest import mock
+from unittest.mock import call, patch
 
-from orangecontrib.text.wikipedia_api import WikipediaAPI, wikipedia
+from wikipedia import DisambiguationError
+
 from orangecontrib.text.corpus import Corpus
+from orangecontrib.text.wikipedia_api import WikipediaAPI, wikipedia
 
 
 class StoppingMock(mock.Mock):
@@ -19,17 +23,42 @@ class StoppingMock(mock.Mock):
             return False
 
 
+def create_page(title):
+    return SimpleNamespace(
+        title=title,
+        content=title + "text",
+        summary=title,
+        url=title,
+        pageid=int(title[-1]),
+        revision_id=1,
+    )
+
+
+ARTICLES = [f"Article {i}" for i in range(1, 11)]
+ARTICLE_TEXTS = [create_page(title) for title in ARTICLES]
+
+
 class WikipediaTests(unittest.TestCase):
-    def test_search(self):
+    @patch(
+        "orangecontrib.text.wikipedia_api.wikipedia.search", return_value=ARTICLES[:2]
+    )
+    @patch("orangecontrib.text.wikipedia_api.wikipedia.page", side_effect=ARTICLE_TEXTS)
+    def test_search(self, _, search_mock):
         on_progress = mock.MagicMock()
 
         api = WikipediaAPI()
 
-        result = api.search('en', ['Clinton'], articles_per_query=2, on_progress=on_progress)
+        result = api.search(
+            "en", ["Clinton"], articles_per_query=2, on_progress=on_progress
+        )
+        search_mock.assert_called_with("Clinton", results=2)
         self.assertIsInstance(result, Corpus)
         self.assertEqual(len(result.domain.attributes), 0)
         self.assertEqual(len(result.domain.metas), 7)
         self.assertEqual(len(result), 2)
+        self.assertListEqual(
+            [["Article 1"], ["Article 2"]], result[:, "Title"].metas.tolist()
+        )
 
         self.assertEqual(on_progress.call_count, 2)
         progress = 0
@@ -37,14 +66,39 @@ class WikipediaTests(unittest.TestCase):
             self.assertGreater(arg[0][0], progress)
             progress = arg[0][0]
 
-    def test_search_disambiguation(self):
+    @patch(
+        "orangecontrib.text.wikipedia_api.wikipedia.search",
+        side_effect=[ARTICLES[:3], [ARTICLES[4]]],
+    )
+    @patch(
+        "orangecontrib.text.wikipedia_api.wikipedia.page",
+        side_effect=[DisambiguationError("Article 0", "1")] + ARTICLE_TEXTS,
+    )
+    def test_search_disambiguation(self, _, search_mock):
         api = WikipediaAPI()
-        result = api.search('en', ['Scarf'], articles_per_query=3)
+        result = api.search("en", ["Scarf"], articles_per_query=3)
+        search_mock.assert_has_calls((call("Scarf", results=3), call("Article 1", 10)))
 
         self.assertIsInstance(result, Corpus)
         self.assertGreaterEqual(len(result), 3)
 
-    def test_search_break(self):
+    @patch(
+        "orangecontrib.text.wikipedia_api.wikipedia.search",
+        side_effect=[
+            ARTICLES[:2],  # clinton search
+            ARTICLES[2:5],  # first scarf
+            ARTICLES[2:3],  # firs scarf after DisambiguationError
+            ARTICLES[5:8],  # second scarf
+            ARTICLES[5:6],  # second scarf after DisambiguationError
+        ],
+    )
+    @patch(
+        "orangecontrib.text.wikipedia_api.wikipedia.page",
+        side_effect=[DisambiguationError("Article 2", "1")]  # firs scarf
+        + ARTICLE_TEXTS[2:5]  # firs scarf - successes
+        + [DisambiguationError("Article 2", "1")],  # second scarf
+    )
+    def test_search_break(self, _, search_mock):
         api = WikipediaAPI()
 
         # stop immediately
@@ -53,16 +107,27 @@ class WikipediaTests(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
         # stop inside recursion
-        result_all = api.search('en', ['Scarf'], articles_per_query=3)
-        result_stopped = api.search('en', ['Scarf'], articles_per_query=3,
-                                    should_break=StoppingMock(allow_calls=1))
-        self.assertLess(len(result_stopped), len(result_all))
+        r = api.search("en", ["Scarf"], articles_per_query=3)
+        self.assertListEqual(
+            [["Article 3"], ["Article 4"], ["Article 5"]], r[:, "Title"].metas.tolist()
+        )
+        result = api.search(
+            "en",
+            ["Scarf"],
+            articles_per_query=3,
+            should_break=StoppingMock(allow_calls=1),
+        )
+        self.assertEqual(len(result), 0)
 
     def page(*args, **kwargs):
         raise wikipedia.exceptions.PageError('1')
 
     @mock.patch('wikipedia.page', page)
-    def test_page_error(self):
+    @patch(
+        "orangecontrib.text.wikipedia_api.wikipedia.search",
+        return_values=ARTICLES[:3],
+    )
+    def test_page_error(self, _):
         on_error = mock.MagicMock()
         api = WikipediaAPI(on_error=on_error)
         api.search('en', ['Barack Obama'])
@@ -77,3 +142,7 @@ class WikipediaTests(unittest.TestCase):
         api = WikipediaAPI(on_error=on_error)
         api.search('en', ['Barack Obama'])
         self.assertEqual(on_error.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Many tests are slow - especially those who are making request online

##### Description of changes
This PR speeds up following tests:
- orangecontrib/text/tests/test_import_documents.py
- orangecontrib/text/tests/test_ontology.py
- orangecontrib/text/tests/test_wikipedia.py

Locally speedup is about 1 minute (speedup on Ubuntu GH runner is more than 2 minutes):
before: 3m30s
now: 2m10s

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
