### PR TITLE
[ENH] Ontology - Enable insert in ontology with multiple roots

### DIFF
--- a/orangecontrib/text/tests/test_ontology.py
+++ b/orangecontrib/text/tests/test_ontology.py
@@ -130,6 +130,18 @@ class TestOntologyHandler(unittest.TestCase):
         )
         self.assertEqual(skipped, 0)
 
+    @patch(
+        "httpx.AsyncClient.post",
+        make_dummy_post(arrays_to_response(RESPONSE2 + RESPONSE2)),
+    )
+    def test_insert_not_tree(self):
+        """Insert should also work when ontology has multiple roots"""
+        tree = {"1": {"2": {}}, "4": {}}
+        new_tree, skipped = self.handler.insert(tree, ["7"])
+        # 7 goes under number 1 since it has the same embedding as 1
+        self.assertDictEqual(new_tree, {"1": {"2": {}, "7": {}}, "4": {}})
+        self.assertEqual(skipped, 0)
+
     @patch('httpx.AsyncClient.post', make_dummy_post(array_to_response(np.zeros(384))))
     def test_score(self):
         tree, skipped = self.handler.generate(['1', '2', '3'])

--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -929,7 +929,7 @@ class OWOntology(OWWidget, ConcurrentWidgetMixin):
     def _enable_include_button(self):
         tree = self.__ontology_view.get_data()
         words = self.__get_selected_input_words()
-        enabled = len(tree) == 1 and len(words) > 0
+        enabled = len(tree) >= 1 and len(words) > 0
         self.__inc_button.setEnabled(enabled)
 
     def send_report(self):


### PR DESCRIPTION
##### Issue
When ontology have multiple root elements `Include` button is disabled

##### Description of changes
This PR enables inserting in the ontology with multiple root elements. Since the method require one root element, the temporary root is added and removed after insertion.

This PR additionally speeds up the test with mocking calls to the embedding server.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
