### PR TITLE
[ENH] Remove elements with delete/backspace key

### DIFF
--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -10,7 +10,7 @@ import requests
 from AnyQt.QtCore import Qt, QModelIndex, QItemSelection, Signal, \
     QItemSelectionModel
 from AnyQt.QtGui import QDropEvent, QStandardItemModel, QStandardItem, \
-    QPainter, QColor, QPalette, QDragEnterEvent, QDragLeaveEvent
+    QPainter, QColor, QPalette, QDragEnterEvent, QDragLeaveEvent, QKeyEvent
 from AnyQt.QtWidgets import QWidget, QAction, QVBoxLayout, QTreeView, QMenu, \
     QToolButton, QGroupBox, QListView, QSizePolicy, QStyledItemDelegate, \
     QStyleOptionViewItem, QLineEdit, QFileDialog, QApplication, QDialog, \
@@ -355,6 +355,13 @@ class EditableTreeView(QWidget):
         self._set_data(self.__stack[self.__stack_index])
         self._enable_undo_redo()
         self.dataChanged.emit()
+
+    def keyPressEvent(self, event: QKeyEvent):
+        """Delete element with delete or backspace key"""
+        if event.key() == Qt.Key_Delete or event.key() == Qt.Key_Backspace:
+            self.__on_remove_recursive()
+        else:
+            super().keyPressEvent(event)
 
 
 class Ontology:

--- a/orangecontrib/text/widgets/owwordlist.py
+++ b/orangecontrib/text/widgets/owwordlist.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from AnyQt.QtCore import Qt, QModelIndex, QItemSelectionModel, \
     QItemSelection, QItemSelectionRange, Signal
-from AnyQt.QtGui import QKeySequence, QPalette, QColor, QPainter
+from AnyQt.QtGui import QKeySequence, QPalette, QColor, QPainter, QKeyEvent
 from AnyQt.QtWidgets import QListView, QSizePolicy, QGridLayout, QLineEdit, \
     QRadioButton, QGroupBox, QToolButton, QMenu, QAction, QFileDialog, \
     QStyledItemDelegate, QStyleOptionViewItem, QWidget
@@ -572,6 +572,13 @@ class OWWordList(OWWidget):
     def _save_state(self):
         self.word_list_library = [s.as_dict() for s in self.library_model]
         self.words = self.words_model[:]
+
+    def keyPressEvent(self, event: QKeyEvent):
+        """Delete word with delete or backspace key"""
+        if event.key() == Qt.Key_Delete or event.key() == Qt.Key_Backspace:
+            self.__on_remove_word()
+        else:
+            super().keyPressEvent(event)
 
     def send_report(self):
         library = self.library_model[self.word_list_index].name \

--- a/orangecontrib/text/widgets/tests/test_owontology.py
+++ b/orangecontrib/text/widgets/tests/test_owontology.py
@@ -8,7 +8,8 @@ from unittest.mock import Mock, patch
 import numpy as np
 from AnyQt.QtCore import Qt, QItemSelectionModel, QItemSelection, \
     QItemSelectionRange
-from AnyQt.QtWidgets import QFileDialog, QPushButton
+from AnyQt.QtWidgets import QFileDialog
+from AnyQt.QtTest import QTest
 
 from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest
@@ -98,6 +99,27 @@ class TestEditableTreeView(WidgetTest):
         self.assertEqual(self.view.get_data(), {"foo": {"bar": {}, "baz": {}}})
         self.view._EditableTreeView__on_remove_recursive()
         self.assertEqual(self.view.get_data(), {})
+
+    def test_on_remove_with_delete_key(self):
+        # test with delete button
+        self.view.set_data(self.data)
+        model = self.view._EditableTreeView__model
+        sel_model = self.view._EditableTreeView__tree.selectionModel()
+        sel_model.select(model.index(0, 0), QItemSelectionModel.ClearAndSelect)
+
+        self.assertEqual(self.view.get_data(), {"foo": {"bar": {}, "baz": {}}})
+        QTest.keyClick(self.view, Qt.Key_Delete)
+        self.assertDictEqual({}, self.view.get_data())
+
+    def test_on_remove_with_backspace_key(self):
+        self.view.set_data(self.data)
+        model = self.view._EditableTreeView__model
+        sel_model = self.view._EditableTreeView__tree.selectionModel()
+        sel_model.select(model.index(0, 0), QItemSelectionModel.ClearAndSelect)
+
+        self.assertEqual(self.view.get_data(), {"foo": {"bar": {}, "baz": {}}})
+        QTest.keyClick(self.view, Qt.Key_Backspace)
+        self.assertDictEqual({}, self.view.get_data())
 
     def test_get_words(self):
         self.view.set_data(self.data)

--- a/orangecontrib/text/widgets/tests/test_owwordlist.py
+++ b/orangecontrib/text/widgets/tests/test_owwordlist.py
@@ -6,6 +6,7 @@ import os
 
 from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QGroupBox, QFileDialog
+from AnyQt.QtTest import QTest
 
 from Orange.data import Table, StringVariable, Domain
 from Orange.widgets.tests.base import WidgetTest
@@ -237,6 +238,26 @@ class TestOWWordList(WidgetTest):
 
         self.widget._OWWordList__on_remove_word()
         self.widget._OWWordList__on_remove_word()
+        self.assertIsNone(self.get_output(self.widget.Outputs.words))
+
+    def test_remove_word_del_key(self):
+        self.widget._set_selected_words([0])
+        QTest.keyClick(self.widget, Qt.Key_Delete)
+        output = self.get_output(self.widget.Outputs.words)
+        self.assertListEqual(list(output.metas[:, 0]), ["bar", "baz"])
+
+        QTest.keyClick(self.widget, Qt.Key_Delete)
+        QTest.keyClick(self.widget, Qt.Key_Delete)
+        self.assertIsNone(self.get_output(self.widget.Outputs.words))
+
+    def test_remove_word_backspace_key(self):
+        self.widget._set_selected_words([0])
+        QTest.keyClick(self.widget, Qt.Key_Backspace)
+        output = self.get_output(self.widget.Outputs.words)
+        self.assertListEqual(list(output.metas[:, 0]), ["bar", "baz"])
+
+        QTest.keyClick(self.widget, Qt.Key_Backspace)
+        QTest.keyClick(self.widget, Qt.Key_Backspace)
         self.assertIsNone(self.get_output(self.widget.Outputs.words))
 
     def test_remove_word_commit_invoked_once(self):


### PR DESCRIPTION
##### Issue

We discussed that it would be excellent for elements in the Ontology and List View widget can be removed with delete key

##### Description of changes
Delete elements/words with delete/backspace key.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
