### PR TITLE
Time bomb for removing enum2int

### DIFF
--- a/orangecontrib/text/widgets/utils/tests/test_utils.py
+++ b/orangecontrib/text/widgets/utils/tests/test_utils.py
@@ -1,0 +1,18 @@
+import unittest
+from datetime import datetime
+
+
+class TestEnum2Int(unittest.TestCase):
+    def test_remove_enum2int(self):
+        """
+        Happy new year 2024. When this test start to fail:
+        - remove enum2int from orangecontrib.text.widgets.utils.__init__
+        - change imports to Orange's enum2int in widget that use it
+        - remove this test
+        - depend orange3-text on orange 3.35
+        """
+        self.assertLess(datetime.today(), datetime(2024, 1, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
enum2int is now available from Orange3.

##### Description of changes
Remove it when Orange3-text can depend on Orange 3.35

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
