### PR TITLE
CorpusToNetwork: Output Corpus when type=Document

### DIFF
--- a/orangecontrib/text/corpus_to_network.py
+++ b/orangecontrib/text/corpus_to_network.py
@@ -32,10 +32,7 @@ class CorpusToNetwork:
         self.document_network = None
         self.word2ind = None
         self.word_freqs = None
-        self.document_items = Table(corpus.domain,
-                                    corpus.X,
-                                    corpus.Y,
-                                    corpus.metas)
+        self.document_items = corpus.copy()
         self.word_items = None
         self.num_ngrams = 0
         self.last_called_nodes = True


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
It would be useful to enable further examination of documents, selected in the Network Exporler, when the selected NodeType (Corpus to Network) is `Documents`. Currently this is not possible, because the Node Data's type (output of Corpus to Network) is always a `Table`.

![image](https://user-images.githubusercontent.com/11465003/224270689-90bb48a3-d0b9-4da3-abe0-d1791687933f.png)


##### Description of changes
Change the Node Data type to Corpus when the Node type == Documents.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
