### PR TITLE
[ENH] Sentiment Analysis - Language from corpus

### DIFF
--- a/orangecontrib/text/language.py
+++ b/orangecontrib/text/language.py
@@ -97,6 +97,7 @@ ISO2LANG = {
     "ur": "Urdu",
     "vi": "Vietnamese",
     "zh": "Chinese",
+    "zh_char": "Chinese - Chinese Characters",
     None: None,
 }
 LANG2ISO = {lang: code for code, lang in ISO2LANG.items()}

--- a/orangecontrib/text/sentiment/__init__.py
+++ b/orangecontrib/text/sentiment/__init__.py
@@ -1,59 +1,66 @@
 import os
 import pickle
-import re
-
-import serverfiles
-from requests.exceptions import ConnectionError
+from typing import Callable, List, Optional, Set, Tuple
 
 import numpy as np
+import serverfiles
 from nltk.corpus import opinion_lexicon
 from nltk.sentiment import SentimentIntensityAnalyzer
-
 from Orange.misc.environ import data_dir
-from orangecontrib.text.misc import wait_nltk_data
+from Orange.util import dummy_callback, wrap_callback
+from requests.exceptions import ConnectionError
 
 from orangecontrib.text import Corpus
-from orangecontrib.text.vectorization.base import SharedTransform, \
-    VectorizationComputeValue
+from orangecontrib.text.misc import wait_nltk_data
+from orangecontrib.text.vectorization.base import (
+    SharedTransform,
+    VectorizationComputeValue,
+)
+
+ScoresType = List[List[float]]
 
 
-def read_file(file):
+def read_file(file: str) -> List[str]:
     with open(file, 'r', encoding='utf8') as f:
         return f.read().split('\n')
 
 
-def read_pickle(file):
+def read_pickle(file: str) -> List[str]:
     with open(file, 'rb') as f:
         return pickle.loads(f.read())
 
 
-def compute_from_dict(tokens, pos, neg):
+def compute_from_dict(
+    tokens: np.ndarray, pos: Set[str], neg: Set[str], callback: Callable
+) -> ScoresType:
     scores = []
-    for doc in tokens:
+    for i, doc in enumerate(tokens):
         pos_words = len(pos.intersection(doc)) if pos else 0
         neg_words = len(neg.intersection(doc)) if neg else 0
         scores.append([100 * (pos_words - neg_words) / max(len(doc), 1)])
+        callback((i + 1) / len(tokens))
     return scores
+
+
+class DictionaryNotFound(FileNotFoundError):
+    pass
 
 
 class Sentiment:
     sentiments = None
     name = None
 
-    def get_scores(self, corpus):
+    def get_scores(self, corpus: Corpus, callback: Callable) -> ScoresType:
         return NotImplemented
 
-    def transform(self, corpus):
-        scores = self.get_scores(corpus)
+    def transform(self, corpus: Corpus, callback: Callable = dummy_callback) -> Corpus:
+        scores = self.get_scores(corpus, wrap_callback(callback, end=0.9))
         X = np.array(scores).reshape((-1, len(self.sentiments)))
 
         # set compute values
         shared_cv = SharedTransform(self, corpus.used_preprocessor)
-        cv = [VectorizationComputeValue(shared_cv, col)
-              for col in self.sentiments]
-
-        corpus = corpus.extend_attributes(X, self.sentiments, compute_values=cv)
-        return corpus
+        cv = [VectorizationComputeValue(shared_cv, col) for col in self.sentiments]
+        return corpus.extend_attributes(X, self.sentiments, compute_values=cv)
 
 
 class LiuHuSentiment(Sentiment):
@@ -64,43 +71,53 @@ class LiuHuSentiment(Sentiment):
         resources_folder = os.path.dirname(__file__)
 
         @classmethod
-        def positive(cls):
-            f = os.path.join(cls.resources_folder,
-                             'resources/positive_words_Slolex.txt')
+        def positive(cls) -> List[str]:
+            f = os.path.join(
+                cls.resources_folder, "resources/positive_words_Slolex.txt"
+            )
             return read_file(f)
 
         @classmethod
-        def negative(cls):
-            f = os.path.join(cls.resources_folder,
-                             'resources/negative_words_Slolex.txt')
+        def negative(cls) -> List[str]:
+            f = os.path.join(
+                cls.resources_folder, "resources/negative_words_Slolex.txt"
+            )
             return read_file(f)
 
-    methods = {'English': opinion_lexicon,
-               'Slovenian': SloSentiment}
+    DEFAULT_LANG = "en"
+    LANGUAGES = {"en": opinion_lexicon, "sl": SloSentiment}
 
     @wait_nltk_data
-    def __init__(self, language):
+    def __init__(self, language: Optional[str] = None):
         self.language = language
-        self.positive = set(self.methods[self.language].positive())
-        self.negative = set(self.methods[self.language].negative())
 
-    def get_scores(self, corpus):
-        return compute_from_dict(corpus.tokens, self.positive, self.negative)
+    def get_scores(self, corpus: Corpus, callback: Callable) -> ScoresType:
+        language = self.language or corpus.language
+        try:
+            positive = set(self.LANGUAGES[language].positive())
+            negative = set(self.LANGUAGES[language].negative())
+        except LookupError:
+            raise DictionaryNotFound
+        return compute_from_dict(corpus.tokens, positive, negative, callback)
 
 
 class VaderSentiment(Sentiment):
-    sentiments = ('pos', 'neg', 'neu', 'compound') # output column names
-    name = 'Vader'
+    sentiments = ("pos", "neg", "neu", "compound")  # output column names
+    name = "Vader"
 
     @wait_nltk_data
     def __init__(self):
-        self.vader = SentimentIntensityAnalyzer()
+        try:
+            self.vader = SentimentIntensityAnalyzer()
+        except LookupError:
+            raise DictionaryNotFound
 
-    def get_scores(self, corpus):
+    def get_scores(self, corpus: Corpus, callback: Callable) -> ScoresType:
         scores = []
-        for text in corpus.documents:
+        for i, text in enumerate(corpus.documents):
             pol_sc = self.vader.polarity_scores(text)
             scores.append([pol_sc[x] for x in self.sentiments])
+            callback((i + 1) / len(corpus))
         return scores
 
 
@@ -114,11 +131,7 @@ class SentimentDictionaries:
                                                  serverfiles=self.serverfiles)
         self._supported_languages = []
 
-    def __getitem__(self, language):
-        return NotImplemented
-
-    @property
-    def supported_languages(self):
+    def __getitem__(self, language: str) -> List[str]:
         return NotImplemented
 
     @property
@@ -128,14 +141,6 @@ class SentimentDictionaries:
         except ConnectionError:
             return self.localfiles.listfiles()
 
-    @property
-    def online(self):
-        try:
-            self.serverfiles.listfiles()
-            return True
-        except ConnectionError:
-            return False
-
 
 class MultisentimentDictionaries(SentimentDictionaries):
     server_url = "http://file.biolab.si/files/sentiment/"
@@ -143,61 +148,38 @@ class MultisentimentDictionaries(SentimentDictionaries):
     def __init__(self):
         super().__init__()
 
-    def __getitem__(self, language):
-        pos = set(read_file(self.localfiles.localpath_download(
-            f"positive_words_{language}.txt")))
-        neg = set(read_file(self.localfiles.localpath_download(
-            f"negative_words_{language}.txt")))
+    def __getitem__(self, language: str) -> Tuple[Set[str], Set[str]]:
+        try:
+            pos = self.localfiles.localpath_download(f"positive_words_{language}.txt")
+            pos = set(read_file(pos))
+            neg = self.localfiles.localpath_download(f"negative_words_{language}.txt")
+            neg = set(read_file(neg))
+        except (FileNotFoundError, ConnectionError):
+            raise DictionaryNotFound
         return pos, neg
-
-    def supported_languages(self):
-        re_pos = r"positive_words_(.*)\.txt"
-        re_neg = r"negative_words_(.*)\.txt"
-        pos = neg = set()
-        for i in self.lang_files:
-            res_pos = re.fullmatch(re_pos, i[0])
-            res_neg = re.fullmatch(re_neg, i[0])
-            if res_pos:
-                pos.add(res_pos.group(1))
-            elif res_neg:
-                neg.add(res_neg.group(1))
-        return pos.intersection(neg)
 
 
 class MultiSentiment(Sentiment):
     sentiments = ('sentiment',)
     name = 'Multilingual Sentiment'
 
-    # mapping for nicer language labels
-    LANGS = {'Afrikaans': 'af', 'Arabic': 'ar', 'Azerbaijani': 'az',
-             'Belarusian': 'be', 'Bulgarian': 'bg',
-             'Bosnian': 'bs', 'Catalan': 'ca', 'Czech': 'cs',
-             'Danish': 'da', 'German': 'de', 'Greek': 'el',
-             'Spanish': 'es', 'Estonian': 'et', 'English': 'en',
-             'Farsi': 'fa', 'Finnish': 'fi', 'French': 'fr', 'Gaelic': 'ga',
-             'Hebrew': 'he', 'Hindi': 'hi', 'Croatian': 'hr', 'Hungarian': 'hu',
-             'Indonesian': 'id', 'Italian': 'it', 'Japanese': 'ja',
-             'Korean': 'ko', 'Latin': 'la', 'Lithuanian': 'lt', 'Latvian': 'lv',
-             'Macedonian': 'mk', 'Dutch': 'nl', 'Norwegian Nynorsk': 'nn',
-             'Norwegian': 'no', 'Polish': 'pl', 'Portuguese': 'pt',
-             'Romanian': 'ro', 'Russian': 'ru', 'Slovak': 'sk', 'Slovene': 'sl',
-             'Serbian': 'sr', 'Swedish': 'sv', 'Turkish': 'tr',
-             'Ukrainian': 'uk', 'Chinese': 'zh',
-             'Chinese Characters': 'zhw'}
+    # fmt: off
+    DEFAULT_LANG = "en"
+    LANGUAGES = [
+        'af', 'ar', 'az', 'be',  'bg', 'bs',  'ca',  'cs', 'da',  'de', 'el',
+        'es', 'et',  'en', 'fa',  'fi',  'fr', 'ga', 'he', 'hi',  'hr',  'hu',
+        'id', 'it', 'ja', 'ko', 'la',  'lt', 'lv', 'mk', 'nl',  'nn', 'no', 'pl',
+        'pt', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv', 'tr', 'uk', 'zh', 'zh_char'
+    ]
+    # fmt: on
 
-    def __init__(self, language='English'):
+    def __init__(self, language: Optional[str] = None):
         self.language = language
-        code = self.LANGS[self.language]
-        self.positive, self.negative = MultisentimentDictionaries()[code]
 
-    def get_scores(self, corpus):
-        return compute_from_dict(corpus.tokens, self.positive, self.negative)
-
-    def __getstate__(self):
-        return {'language': self.language}
-
-    def __setstate__(self, state):
-        self.__init__(state['language'])
+    def get_scores(self, corpus: Corpus, callback: Callable) -> ScoresType:
+        language = self.language or corpus.language
+        positive, negative = MultisentimentDictionaries()[language]
+        return compute_from_dict(corpus.tokens, positive, negative, callback)
 
 
 class SentiArtDictionaries(SentimentDictionaries):
@@ -206,19 +188,14 @@ class SentiArtDictionaries(SentimentDictionaries):
     def __init__(self):
         super().__init__()
 
-    def __getitem__(self, language):
-        filtering_dict = read_pickle(self.localfiles.localpath_download(
-                                     f"SentiArt_{language}.pickle"))
+    def __getitem__(self, language: str) -> List[str]:
+        try:
+            filtering_dict = read_pickle(
+                self.localfiles.localpath_download(f"SentiArt_{language}.pickle")
+            )
+        except (FileNotFoundError, ConnectionError):
+            raise DictionaryNotFound
         return filtering_dict
-
-    def supported_languages(self):
-        regex = r"SentiArt_(.*)\.pickle"
-        supported_languages = set()
-        for i in self.lang_files:
-            res = re.fullmatch(regex, i[0])
-            if res:
-                supported_languages.add(res.group(1))
-        return supported_languages
 
 
 class SentiArt(Sentiment):
@@ -226,19 +203,26 @@ class SentiArt(Sentiment):
                   'sadness', 'surprise')
     name = 'SentiArt'
 
-    LANGS = {'English': 'EN', 'German': 'DE'}
+    DEFAULT_LANG = "en"
+    LANGUAGES = ["en", "de"]
 
-    def __init__(self, language='English'):
+    def __init__(self, language: Optional[str] = None):
         self.language = language
-        self.dictionary = SentiArtDictionaries()[self.LANGS[self.language]]
 
-    def get_scores(self, corpus):
+    def get_scores(self, corpus: Corpus, callback: Callable) -> ScoresType:
+        language = self.language or corpus.language
+        dictionary = SentiArtDictionaries()[language.upper()]
         scores = []
-        for doc in corpus.tokens:
-            score = np.array([list(self.dictionary[word].values()) for word in
-                              doc if word in self.dictionary])
-            scores.append(score.mean(axis=0) if score.shape[0] > 0
-                          else np.zeros(len(self.sentiments)))
+        for i, doc in enumerate(corpus.tokens):
+            score = np.array(
+                [list(dictionary[word].values()) for word in doc if word in dictionary]
+            )
+            scores.append(
+                score.mean(axis=0)
+                if score.shape[0] > 0
+                else np.zeros(len(self.sentiments))
+            )
+            callback((i + 1) / len(corpus))
         return scores
 
 
@@ -248,19 +232,14 @@ class LilahDictionaries(SentimentDictionaries):
     def __init__(self):
         super().__init__()
 
-    def __getitem__(self, language):
-        filtering_dict = read_pickle(self.localfiles.localpath_download(
-                                     f"LiLaH-{language}.pickle"))
+    def __getitem__(self, language: str) -> List[str]:
+        try:
+            filtering_dict = read_pickle(
+                self.localfiles.localpath_download(f"LiLaH-{language}.pickle")
+            )
+        except (FileNotFoundError, ConnectionError):
+            raise DictionaryNotFound
         return filtering_dict
-
-    def supported_languages(self):
-        regex = r"LiLaH-(.*)\.pickle"
-        supported_languages = set()
-        for i in self.lang_files:
-            res = re.fullmatch(regex, i[0])
-            if res:
-                supported_languages.add(res.group(1))
-        return supported_languages
 
 
 class LilahSentiment(Sentiment):
@@ -268,19 +247,26 @@ class LilahSentiment(Sentiment):
                   'Fear', 'Joy', 'Sadness', 'Surprise', 'Trust')
     name = 'LiLaH Sentiment'
 
-    LANGS = {'Slovenian': 'SL', 'Croatian': 'HR', 'Dutch': 'NL'}
+    DEFAULT_LANG = "sl"
+    LANGUAGES = ["hr", "nl", "sl"]
 
-    def __init__(self, language='Slovenian'):
+    def __init__(self, language: Optional[str] = None):
         self.language = language
-        self.dictionary = LilahDictionaries()[self.LANGS[self.language]]
 
-    def get_scores(self, corpus):
+    def get_scores(self, corpus: Corpus, callback: Callable) -> ScoresType:
+        language = self.language or corpus.language
+        dictionary = LilahDictionaries()[language.upper()]
         scores = []
-        for doc in corpus.tokens:
-            score = np.array([list(self.dictionary[word].values()) for word in
-                              doc if word in self.dictionary])
-            scores.append(score.mean(axis=0) if score.shape[0] > 0
-                          else np.zeros(len(self.sentiments)))
+        for i, doc in enumerate(corpus.tokens):
+            score = np.array(
+                [list(dictionary[word].values()) for word in doc if word in dictionary]
+            )
+            scores.append(
+                score.mean(axis=0)
+                if score.shape[0] > 0
+                else np.zeros(len(self.sentiments))
+            )
+            callback((i + 1) / len(corpus))
         return scores
 
 
@@ -288,16 +274,15 @@ class CustomDictionaries(Sentiment):
     sentiments = ('sentiment',)
     name = 'Custom Dictionaries'
 
-    @wait_nltk_data
-    def __init__(self, pos, neg):
+    def __init__(self, pos: Optional[str], neg: Optional[str]):
         self.positive = set(read_file(pos)) if pos else None
         self.negative = set(read_file(neg)) if neg else None
 
-    def get_scores(self, corpus):
-        return compute_from_dict(corpus.tokens, self.positive, self.negative)
+    def get_scores(self, corpus: Corpus, callback: Callable) -> ScoresType:
+        return compute_from_dict(corpus.tokens, self.positive, self.negative, callback)
 
 
 if __name__ == "__main__":
-    c = Corpus.from_file('deerwester')
-    liu = LiuHuSentiment('Slovenian')
+    c = Corpus.from_file("deerwester")
+    liu = LiuHuSentiment()
     c2 = liu.transform(c[:5])

--- a/orangecontrib/text/tests/test_sentiment.py
+++ b/orangecontrib/text/tests/test_sentiment.py
@@ -3,116 +3,123 @@ import unittest
 from numpy.testing import assert_allclose
 
 from orangecontrib.text.corpus import Corpus
-from orangecontrib.text.sentiment import LiuHuSentiment, VaderSentiment, \
-    MultiSentiment, SentiArt, LilahSentiment
+from orangecontrib.text.sentiment import (
+    LiuHuSentiment,
+    VaderSentiment,
+    MultiSentiment,
+    SentiArt,
+    LilahSentiment,
+)
 
 
-class LiuHuTest(unittest.TestCase):
+class BaseTest:
+    # base test use to avoid SentimentTests being called by unittest.main
+    class SentimentTests(unittest.TestCase):
+        METHOD = None
+        LANGUAGE = None
+        NEW_COLS = 1
+
+        def setUp(self):
+            self.corpus = Corpus.from_file("deerwester")
+            args = (self.LANGUAGE,) if self.LANGUAGE is not None else ()
+            self.method = self.METHOD(*args)
+
+        def test_transform(self):
+            sentiment = self.method.transform(self.corpus)
+            self.assertIsInstance(sentiment, Corpus)
+            self.assertEqual(
+                len(sentiment.domain.variables),
+                len(self.corpus.domain.variables) + self.NEW_COLS,
+            )
+
+        def test_copy(self):
+            sentiment_t = self.method.transform(self.corpus)
+            self.assertIsNot(self.corpus, sentiment_t)
+
+        def test_compute_values(self):
+            sentiment = self.method.transform(self.corpus)
+            computed = Corpus.from_table(sentiment.domain, self.corpus)
+
+            self.assertEqual(sentiment.domain, computed.domain)
+            self.assertTrue((sentiment.X == computed.X).all())
+
+        def test_compute_values_to_different_domain(self):
+            destination = Corpus.from_file("andersen")
+
+            self.assertFalse(self.corpus.domain.attributes)
+            self.assertFalse(destination.domain.attributes)
+
+            sentiment = self.method.transform(self.corpus)
+            computed = destination.transform(sentiment.domain)
+
+            self.assertTrue(sentiment.domain.attributes)
+            self.assertEqual(sentiment.domain.attributes, computed.domain.attributes)
+
+        def test_empty_corpus(self):
+            sentiment = self.method.transform(self.corpus[:0])
+            self.assertEqual(
+                len(sentiment.domain.variables),
+                len(self.corpus.domain.variables) + self.NEW_COLS,
+            )
+            self.assertEqual(len(sentiment), 0)
+
+        def test_language_from_corpus(self):
+            """Init method without language, it should be provided by corpus"""
+            method = self.METHOD()
+            # Lilah does not support english - change language to one supported
+            self.corpus.attributes["language"] = self.LANGUAGE
+            sentiment = method.transform(self.corpus)
+            self.assertIsInstance(sentiment, Corpus)
+            self.assertEqual(
+                len(sentiment.domain.variables),
+                len(self.corpus.domain.variables) + self.NEW_COLS,
+            )
+
+
+class LiuHuTest(BaseTest.SentimentTests):
+    METHOD = LiuHuSentiment
+    LANGUAGE = "en"
+
+
+class LiuHuSlovenian(BaseTest.SentimentTests):
+    METHOD = LiuHuSentiment
+    LANGUAGE = "sl"
+
     def setUp(self):
-        self.corpus = Corpus.from_file('deerwester')
-        self.method = LiuHuSentiment('English')
-        self.new_cols = 1
-
-    def test_transform(self):
-        sentiment = self.method.transform(self.corpus)
-        self.assertIsInstance(sentiment, Corpus)
-        self.assertEqual(len(sentiment.domain.variables),
-                         len(self.corpus.domain.variables) + self.new_cols)
-
-    def test_copy(self):
-        sentiment_t = self.method.transform(self.corpus)
-        self.assertIsNot(self.corpus, sentiment_t)
-
-    def test_compute_values(self):
-        sentiment = self.method.transform(self.corpus)
-        computed = Corpus.from_table(sentiment.domain, self.corpus)
-
-        self.assertEqual(sentiment.domain, computed.domain)
-        self.assertTrue((sentiment.X == computed.X).all())
+        super().setUp()
+        self.corpus = Corpus.from_file("slo-opinion-corpus")
 
     def test_compute_values_to_different_domain(self):
-        destination = Corpus.from_file('andersen')
-
-        self.assertFalse(self.corpus.domain.attributes)
-        self.assertFalse(destination.domain.attributes)
-
-        sentiment = self.method.transform(self.corpus)
-        computed = destination.transform(sentiment.domain)
-
-        self.assertTrue(sentiment.domain.attributes)
-        self.assertEqual(sentiment.domain.attributes, computed.domain.attributes)
-
-    def test_empty_corpus(self):
-        corpus = Corpus.from_file('deerwester')[:0]
-        sentiment = self.method.transform(corpus)
-        self.assertEqual(len(sentiment.domain.variables),
-                         len(self.corpus.domain.variables) + self.new_cols)
-        self.assertEqual(len(sentiment), 0)
+        """Skip test_compute_values_to_different_domain for Slovenian"""
+        pass
 
 
-class LiuHuSlovenian(unittest.TestCase):
-    def setUp(self):
-        self.corpus = Corpus.from_file('slo-opinion-corpus')
-        self.method = LiuHuSentiment('Slovenian')
-        self.new_cols = 1
-
-    def test_transform(self):
-        sentiment = self.method.transform(self.corpus)
-        self.assertIsInstance(sentiment, Corpus)
-        self.assertEqual(len(sentiment.domain.variables),
-                         len(self.corpus.domain.variables) + self.new_cols)
-
-    def test_copy(self):
-        sentiment_t = self.method.transform(self.corpus)
-        self.assertIsNot(self.corpus, sentiment_t)
-
-    def test_compute_values(self):
-        sentiment = self.method.transform(self.corpus)
-        computed = Corpus.from_table(sentiment.domain, self.corpus)
-
-        self.assertEqual(sentiment.domain, computed.domain)
-        self.assertTrue((sentiment.X == computed.X).all())
-
-    def test_empty_corpus(self):
-        corpus = self.corpus[:0]
-        sentiment = self.method.transform(corpus)
-        self.assertEqual(len(sentiment.domain.variables),
-                         len(self.corpus.domain.variables) + self.new_cols)
-        self.assertEqual(len(sentiment), 0)
+class VaderTest(BaseTest.SentimentTests):
+    METHOD = VaderSentiment
+    NEW_COLS = 4
 
 
-class VaderTest(LiuHuTest):
-    def setUp(self):
-        self.corpus = Corpus.from_file('deerwester')
-        self.method = VaderSentiment()
-        self.new_cols = 4
+class MultiSentimentTest(BaseTest.SentimentTests):
+    METHOD = MultiSentiment
+    LANGUAGE = "en"
 
 
-class MultiSentimentTest(LiuHuTest):
-    def setUp(self):
-        self.corpus = Corpus.from_file('deerwester')
-        self.method = MultiSentiment()
-        self.new_cols = 1
-
-
-class SentiArtTest(LiuHuTest):
-    def setUp(self):
-        self.corpus = Corpus.from_file('deerwester')
-        self.slo_corpus = Corpus.from_file('slo-opinion-corpus')[83:85]
-        self.method = SentiArt()
-        self.new_cols = 7
+class SentiArtTest(BaseTest.SentimentTests):
+    METHOD = SentiArt
+    LANGUAGE = "en"
+    NEW_COLS = 7
 
     def test_empty_slice_mean(self):
         # this should execute without raising an exception
-        result = self.method.transform(self.slo_corpus)
-        assert_allclose(result.X[0, -self.new_cols:], 0)
+        slo_corpus = Corpus.from_file("slo-opinion-corpus")[83:85]
+        result = self.method.transform(slo_corpus)
+        assert_allclose(result.X[0, -self.NEW_COLS :], 0)
 
 
-class LilahTest(LiuHuTest):
-    def setUp(self):
-        self.corpus = Corpus.from_file('deerwester')
-        self.method = LilahSentiment()
-        self.new_cols = 10
+class LilahTest(BaseTest.SentimentTests):
+    METHOD = LilahSentiment
+    LANGUAGE = "sl"
+    NEW_COLS = 10
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Derived from #874 

##### Description of changes
Use language from the corpus for Sentiment analysis

This PR also fix some other problems:
- Widget run computation in a separate thread to prevent blocking of widget
- Offline errors had to be re-implemented (widget does not check available languages on start anymore) since it can trigger the download of models which block the widget. Now models are downloaded before sentiment is computed in the separate thread.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
