### PR TITLE
[ENH] Preprocess - Use language from Corpus

### DIFF
--- a/orangecontrib/text/keywords/__init__.py
+++ b/orangecontrib/text/keywords/__init__.py
@@ -20,7 +20,7 @@ from orangecontrib.text.preprocess import StopwordsFilter
 from orangecontrib.text.vectorization import BowVectorizer
 
 # all available languages for RAKE
-RAKE_LANGUAGES = StopwordsFilter.supported_languages()
+RAKE_LANGUAGES = StopwordsFilter.supported_languages
 # all available languages for YAKE!
 # fmt: off
 YAKE_LANGUAGES = [

--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -117,9 +117,10 @@ class StopwordsFilter(BaseTokenFilter, FileWordListMixin):
         """
         return LANG2ISO[StopwordsFilter.NLTK2LANG.get(language, language)]
 
-    @staticmethod
+    @classmethod
+    @property
     @wait_nltk_data
-    def supported_languages() -> Set[str]:
+    def supported_languages(_) -> Set[str]:
         """
         List all languages supported by NLTK
 

--- a/orangecontrib/text/preprocess/normalize.py
+++ b/orangecontrib/text/preprocess/normalize.py
@@ -123,6 +123,10 @@ class UDPipeModels:
         return [(name, iso) for iso, (name, _) in self.model_files.items()]
 
     @property
+    def supported_languages_iso(self) -> List[Tuple[str, str]]:
+        return {iso for _, iso in self.supported_languages}
+
+    @property
     def online(self) -> bool:
         try:
             self.serverfiles.listfiles()

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -486,7 +486,7 @@ class FilteringTests(unittest.TestCase):
         self.assertEqual(len(corpus.used_preprocessor.preprocessors), 2)
 
     def test_supported_languages(self):
-        langs = preprocess.StopwordsFilter.supported_languages()
+        langs = preprocess.StopwordsFilter.supported_languages
         self.assertIsInstance(langs, set)
         # just testing few of most important languages since I want for test to be
         # resistant for any potentially newly introduced languages by NLTK


### PR DESCRIPTION
##### Description of changes
Set language combo boxes for the language from the corpus. 

Additionally, this PR changes the UDPIPE combo box to keep the same language when one wants to set language to language unavailable in UDPIPE. Previously, it was always reset to English.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
