### PR TITLE
[FIX] Keywords: Fix selection and use idClicked instead of buttonClicked

### DIFF
--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -263,7 +263,7 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
             button.setChecked(method == self.sel_method)
             grid.addWidget(button, method, 0)
             self.__sel_method_buttons.addButton(button, method)
-        self.__sel_method_buttons.buttonClicked.connect(self._set_selection_method)
+        self.__sel_method_buttons.idClicked.connect(self._set_selection_method)
 
         spin = gui.spin(
             box, self, "n_selected", 1, 999, addToLayout=False,
@@ -389,9 +389,9 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
         self.start(run, self.corpus, self.words, self.__cached_keywords,
                    self.selected_scoring_methods, kwargs, self.agg_method)
 
-    def _set_selection_method(self):
-        self.sel_method = self.__sel_method_buttons.checkedId()
-        self.__sel_method_buttons.button(self.sel_method).setChecked(True)
+    def _set_selection_method(self, method: int):
+        self.sel_method = method
+        self.__sel_method_buttons.button(method).setChecked(True)
         self._select_rows()
 
     def _select_rows(self):


### PR DESCRIPTION
##### Issue
```
Traceback (most recent call last):
...
  File "../orange3-text/orangecontrib/text/widgets/owkeywords.py", line 270, in <lambda>
    callback=lambda: self._set_selection_method(
TypeError: OWKeywords._set_selection_method() takes 1 positional argument but 2 were given
```
When making a widget PyQt6 compatible in https://github.com/biolab/orange3-text/pull/929, I missed a callback causing the issue.

##### Description of changes
Also at that time, I didn't know that `buttonClicked[int]` was removed on behalf of `idClicked`. So instead of changing the callback I am reverting the `_set_selection_method` to the previous state and using `idClicked` callback instead.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
