### PR TITLE
Omit Gensim version 4.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4
 biopython  # Enables Pubmed widget.
 conllu
 docx2txt>=0.6
-gensim>=4.3.0
+gensim>=4.3.0,!=4.3.1  # gensim 4.3.1 is build on numpy 1.24, causing error on older numpys
 httpx!=0.23.1  # temporary fix - semantic search fail (but only in tests)
 langdetect
 lemmagen3


### PR DESCRIPTION
##### Issue
Gensim made changes in wheel building and accidentally started to build the package with the newest version
https://github.com/RaRe-Technologies/gensim/pull/3467.

##### Description of changes
Skip 4.3.1, which is built with the newest Numpy. 4.3.0 is fine.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
