### PR TITLE
All widgets: keywords from list to string

### DIFF
--- a/orangecontrib/text/widgets/owannotator.py
+++ b/orangecontrib/text/widgets/owannotator.py
@@ -202,7 +202,7 @@ class OWAnnotator(OWDataProjectionWidget, ConcurrentWidgetMixin):
     description = "Annotates projection clusters."
     icon = "icons/Annotator.svg"
     priority = 1110
-    keywords = ["annotator"]
+    keywords = "annotated corpus map, annotator"
 
     settingsHandler = AnnotatorContextHandler()
     GRAPH_CLASS = OWAnnotatorGraph

--- a/orangecontrib/text/widgets/owbagofwords.py
+++ b/orangecontrib/text/widgets/owbagofwords.py
@@ -7,11 +7,11 @@ from orangecontrib.text.widgets.utils import owbasevectorizer, widgets
 
 
 class OWTBagOfWords(owbasevectorizer.OWBaseVectorizer):
-    name = 'Bag of Words'
+    name = "Bag of Words"
     description = 'Generates a bag of words from the input corpus.'
     icon = 'icons/BagOfWords.svg'
     priority = 300
-    keywords = ["BOW"]
+    keywords = "bag of words, bow"
 
     Method = BowVectorizer
 

--- a/orangecontrib/text/widgets/owcollocations.py
+++ b/orangecontrib/text/widgets/owcollocations.py
@@ -75,7 +75,7 @@ class TableView(QTableView):
 class OWCollocations(OWWidget):
     name = "Collocations"
     description = "Compute significant bigrams and trigrams."
-    keywords = ["PMI"]
+    keywords = "collocations, pmi"
     icon = "icons/Collocations.svg"
 
     class Inputs:

--- a/orangecontrib/text/widgets/owconcordance.py
+++ b/orangecontrib/text/widgets/owconcordance.py
@@ -191,6 +191,7 @@ class OWConcordance(OWWidget, ConcurrentWidgetMixin):
     description = "Display the context of the word."
     icon = "icons/Concordance.svg"
     priority = 520
+    keywords = "concordance, context"
 
     class Inputs:
         corpus = Input("Corpus", Corpus)

--- a/orangecontrib/text/widgets/owcorpus.py
+++ b/orangecontrib/text/widgets/owcorpus.py
@@ -79,6 +79,7 @@ class OWCorpus(OWWidget, ConcurrentWidgetMixin):
     description = "Load a corpus of text documents."
     icon = "icons/TextFile.svg"
     priority = 100
+    keywords = "corpus, text"
     replaces = ["orangecontrib.text.widgets.owloadcorpus.OWLoadCorpus"]
 
     class Inputs:

--- a/orangecontrib/text/widgets/owcorpustonetwork.py
+++ b/orangecontrib/text/widgets/owcorpustonetwork.py
@@ -45,7 +45,7 @@ def run(
 class OWCorpusToNetwork(OWWidget, ConcurrentWidgetMixin):
     name = "Corpus to Network"
     description = "Constructs network from given corpus."
-    keywords = ["text, network"]
+    keywords = "corpus to network, network"
     icon = "icons/CorpusToNetwork.svg"
     priority = 250
 

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -290,6 +290,7 @@ class OWCorpusViewer(OWWidget, ConcurrentWidgetMixin):
     description = "Display corpus contents."
     icon = "icons/CorpusViewer.svg"
     priority = 500
+    keywords = "corpus viewer, display"
 
     class Inputs:
         corpus = Input("Corpus", Corpus, replaces=["Data"])

--- a/orangecontrib/text/widgets/owcreatecorpus.py
+++ b/orangecontrib/text/widgets/owcreatecorpus.py
@@ -71,6 +71,7 @@ class OWCreateCorpus(OWWidget):
     description = "Write/paste documents to create a corpus"
     icon = "icons/CreateCorpus.svg"
     priority = 120
+    keywords = "create corpus, write"
 
     class Outputs:
         corpus = Output("Corpus", Corpus)

--- a/orangecontrib/text/widgets/owdocmap.py
+++ b/orangecontrib/text/widgets/owdocmap.py
@@ -37,7 +37,7 @@ class OWDocMap(widget.OWWidget):
     priority = 530
     icon = "icons/DocMap.svg"
     replaces = ["orangecontrib.text.widgets.owgeomap.OWGeoMap"]
-    keywords = ["GeoMap"]
+    keywords = "document map, geomap"
 
     class Inputs:
         data = Input("Data", Table)

--- a/orangecontrib/text/widgets/owdocumentembedding.py
+++ b/orangecontrib/text/widgets/owdocumentembedding.py
@@ -34,7 +34,7 @@ class EmbeddingVectorizer(Vectorizer):
 class OWDocumentEmbedding(OWBaseVectorizer):
     name = "Document Embedding"
     description = "Document embedding using pretrained models."
-    keywords = ["embedding", "document embedding", "text", "fasttext", "bert", "sbert"]
+    keywords = "embedding, document embedding, fasttext, bert, sbert"
     icon = "icons/TextEmbedding.svg"
     priority = 300
 

--- a/orangecontrib/text/widgets/owduplicates.py
+++ b/orangecontrib/text/widgets/owduplicates.py
@@ -19,6 +19,7 @@ class OWDuplicates(widget.OWWidget):
     description = 'Detect & remove duplicates from a corpus.'
     icon = 'icons/Duplicates.svg'
     priority = 700
+    keywords = "duplicate detection, detect, remove"
 
     class Inputs:
         distances = Input("Distances", DistMatrix)

--- a/orangecontrib/text/widgets/owguardian.py
+++ b/orangecontrib/text/widgets/owguardian.py
@@ -68,6 +68,7 @@ class OWGuardian(OWWidget):
     description = 'Fetch articles from The Guardian API.'
     icon = 'icons/TheGuardian.svg'
     priority = 120
+    keywords = "the guardian, articles"
 
     class Outputs:
         corpus = Output("Corpus", Corpus)

--- a/orangecontrib/text/widgets/owimportdocuments.py
+++ b/orangecontrib/text/widgets/owimportdocuments.py
@@ -26,6 +26,7 @@ from AnyQt.QtWidgets import (
     QVBoxLayout, QLabel, QGridLayout, QSizePolicy, QCompleter
 )
 from numpy import array
+
 from orangewidget.settings import ContextHandler, Context
 
 from orangewidget.utils.itemmodels import PyListModel
@@ -113,6 +114,7 @@ class OWImportDocuments(widget.OWWidget):
     description = "Import text documents from folders."
     icon = "icons/ImportDocuments.svg"
     priority = 110
+    keywords = "import documents"
 
     class Outputs:
         data = Output("Corpus", Corpus, default=True)

--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -182,7 +182,7 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
     description = "Infers characteristic words from the input corpus."
     icon = "icons/Keywords.svg"
     priority = 1100
-    keywords = ["characteristic", "term"]
+    keywords = "extract keywords, characteristic, term"
 
     buttons_area_orientation = Qt.Vertical
 

--- a/orangecontrib/text/widgets/owldavis.py
+++ b/orangecontrib/text/widgets/owldavis.py
@@ -229,6 +229,7 @@ class OWLDAvis(OWWidget):
     description = "Interactive exploration of LDA topics."
     priority = 410
     icon = "icons/LDAvis.svg"
+    keywords = "ldavis"
 
     selected_topic = Setting(0, schema_only=True)
     relevance = Setting(0.5)

--- a/orangecontrib/text/widgets/ownyt.py
+++ b/orangecontrib/text/widgets/ownyt.py
@@ -67,6 +67,7 @@ class OWNYT(OWWidget):
     description = "Fetch articles from the New York Times search API."
     icon = "icons/NYTimes.svg"
     priority = 130
+    keywords = "new york times, ny times, articles"
 
     class Outputs:
         corpus = Output("Corpus", Corpus)

--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -584,7 +584,7 @@ class OWOntology(OWWidget, ConcurrentWidgetMixin):
     description = ""
     icon = "icons/Ontology.svg"
     priority = 1110
-    keywords = []
+    keywords = "ontology"
 
     CACHED, LIBRARY = range(2)  # library list modification types
     RUN_BUTTON, INC_BUTTON = "Generate", "Include"

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -1025,7 +1025,7 @@ class OWPreprocess(Orange.widgets.data.owpreprocess.OWPreprocess,
     category=None
     icon = "icons/TextPreprocess.svg"
     priority = 200
-    keywords = []
+    keywords = "preprocess text, text"
 
     settings_version = 3
 

--- a/orangecontrib/text/widgets/owpubmed.py
+++ b/orangecontrib/text/widgets/owpubmed.py
@@ -93,6 +93,7 @@ class OWPubmed(OWWidget):
     description = 'Fetch data from Pubmed.'
     icon = 'icons/Pubmed.svg'
     priority = 140
+    keywords = "pubmed"
 
     want_main_area = False
     resizing_enabled = False

--- a/orangecontrib/text/widgets/owscoredocuments.py
+++ b/orangecontrib/text/widgets/owscoredocuments.py
@@ -321,6 +321,7 @@ class OWScoreDocuments(OWWidget, ConcurrentWidgetMixin):
     description = ""
     icon = "icons/ScoreDocuments.svg"
     priority = 500
+    keywords = "score documents"
 
     buttons_area_orientation = Qt.Vertical
 

--- a/orangecontrib/text/widgets/owsemanticviewer.py
+++ b/orangecontrib/text/widgets/owsemanticviewer.py
@@ -206,7 +206,7 @@ class OWSemanticViewer(OWWidget, ConcurrentWidgetMixin):
     description = "Infers characteristic words from the input corpus."
     icon = "icons/SemanticViewer.svg"
     priority = 1120
-    keywords = ["search"]
+    keywords = "semantic viewer, search"
 
     class Inputs:
         corpus = Input("Corpus", Corpus, default=True)

--- a/orangecontrib/text/widgets/owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/owsentimentanalysis.py
@@ -20,7 +20,7 @@ class OWSentimentAnalysis(OWWidget):
     description = "Compute sentiment from text."
     icon = "icons/SentimentAnalysis.svg"
     priority = 320
-    keywords = ["emotion"]
+    keywords = "sentiment analysis, emotion"
 
     class Inputs:
         corpus = Input("Corpus", Corpus)

--- a/orangecontrib/text/widgets/owsimhash.py
+++ b/orangecontrib/text/widgets/owsimhash.py
@@ -8,11 +8,11 @@ from orangecontrib.text.widgets.utils import owbasevectorizer
 
 
 class OWSimhash(owbasevectorizer.OWBaseVectorizer):
-    name = 'Similarity Hashing'
+    name = "Similarity Hashing"
     description = 'Computes documents hashes.'
     icon = 'icons/Simhash.svg'
     priority = 310
-    keywords = ["SimHash"]
+    keywords = "similarity hashing, simhash"
 
     Method = SimhashVectorizer
 

--- a/orangecontrib/text/widgets/owstatistics.py
+++ b/orangecontrib/text/widgets/owstatistics.py
@@ -475,7 +475,7 @@ def run(corpus: Corpus, statistics: Tuple[int, str], state: TaskState) -> None:
 class OWStatistics(OWWidget, ConcurrentWidgetMixin):
     name = "Statistics"
     description = "Create new statistic variables for documents."
-    keywords = []
+    keywords = "statistics"
     icon = "icons/Statistics.svg"
 
     class Inputs:

--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -127,7 +127,7 @@ class OWTopicModeling(OWWidget, ConcurrentWidgetMixin):
     description = "Uncover the hidden thematic structure in a corpus."
     icon = "icons/TopicModeling.svg"
     priority = 400
-    keywords = ["LDA"]
+    keywords = "topic modelling, lda"
 
     settingsHandler = DomainContextHandler()
 

--- a/orangecontrib/text/widgets/owtweetprofiler.py
+++ b/orangecontrib/text/widgets/owtweetprofiler.py
@@ -34,7 +34,7 @@ class OWTweetProfiler(OWWidget, ConcurrentWidgetMixin):
                   "emotions in tweets."
     icon = "icons/TweetProfiler.svg"
     priority = 330
-    keywords = ["Twitter"]
+    keywords = "tweet profiler, twitter"
 
     class Inputs:
         corpus = Input("Corpus", Corpus)

--- a/orangecontrib/text/widgets/owtwitter.py
+++ b/orangecontrib/text/widgets/owtwitter.py
@@ -54,7 +54,7 @@ class OWTwitter(OWWidget, ConcurrentWidgetMixin):
     name = "Twitter"
     description = "Load tweets from the Twitter API."
     icon = "icons/Twitter.svg"
-    keywords = ["twitter", "tweet"]
+    keywords = "twitter, tweet"
     priority = 150
 
     class Outputs:

--- a/orangecontrib/text/widgets/owwikipedia.py
+++ b/orangecontrib/text/widgets/owwikipedia.py
@@ -15,6 +15,7 @@ class OWWikipedia(OWWidget):
     name = 'Wikipedia'
     priority = 160
     icon = 'icons/Wikipedia.svg'
+    keywords = "wikipedia"
 
     class Outputs:
         corpus = Output("Corpus", Corpus)

--- a/orangecontrib/text/widgets/owwordcloud.py
+++ b/orangecontrib/text/widgets/owwordcloud.py
@@ -106,6 +106,7 @@ class OWWordCloud(OWWidget, ConcurrentWidgetMixin):
     name = "Word Cloud"
     priority = 510
     icon = "icons/WordCloud.svg"
+    keywords = "word cloud"
 
     class Inputs:
         corpus = Input("Corpus", Corpus, default=True)

--- a/orangecontrib/text/widgets/owwordenrichment.py
+++ b/orangecontrib/text/widgets/owwordenrichment.py
@@ -50,6 +50,7 @@ class OWWordEnrichment(OWWidget, ConcurrentWidgetMixin):
     description = "Word enrichment analysis for selected documents."
     icon = "icons/SetEnrichment.svg"
     priority = 600
+    keywords = "word enrichment"
 
     # Input/output
     class Inputs:

--- a/orangecontrib/text/widgets/owwordlist.py
+++ b/orangecontrib/text/widgets/owwordlist.py
@@ -149,6 +149,7 @@ class OWWordList(OWWidget):
     description = "Create a list of words."
     icon = "icons/WordList.svg"
     priority = 1000
+    keywords = "word list"
 
     class Inputs:
         words = Input("Words", Table)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
 numpy
 odfpy>=1.3.5
 Orange3 >=3.34.0
-orange-widget-base >=4.14.0
+orange-widget-base >=4.20.0
 orange-canvas-core
 owlready2
 pandas

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     oldest: scikit-learn==1.0.1
     oldest: orange3==3.34.0
     oldest: orange-canvas-core==0.1.28
-    oldest: orange-widget-base==4.19.0
+    oldest: orange-widget-base==4.20.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange3-network/archive/refs/heads/master.zip#egg=orange3-network
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
     oldest: scikit-learn==1.0.1
     oldest: orange3==3.34.0
-    oldest: orange-canvas-core==0.1.28
+    oldest: orange-canvas-core==0.1.30
     oldest: orange-widget-base==4.20.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange3-network/archive/refs/heads/master.zip#egg=orange3-network


### PR DESCRIPTION
##### Issue
All widgets have keywords for easier search. This keywords were written in list, which caused translation complications.

##### Description of changes
We changed them to string, so now instead of ["first", "second"], we have "first, second". And now we can translate this efficiently.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
