### PR TITLE
Ontology: added new keyword

### DIFF
--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -584,7 +584,7 @@ class OWOntology(OWWidget, ConcurrentWidgetMixin):
     description = ""
     icon = "icons/Ontology.svg"
     priority = 1110
-    keywords = "ontology"
+    keywords = "ontology, hierarchy"
 
     CACHED, LIBRARY = range(2)  # library list modification types
     RUN_BUTTON, INC_BUTTON = "Generate", "Include"


### PR DESCRIPTION
##### Issue
Because ontology keyword was only "ontology", it did not get a separated translation string (because a few rows down, there is another "ontology" and it would be better if they are somehow separated).

##### Description of changes
I added a new keyword.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
