### PR TITLE
[FIX] import_documents - replace lxml xml parser with ElementTree

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ gensim>=4.3.0,!=4.3.1  # gensim 4.3.1 is build on numpy 1.24, causing error on o
 httpx!=0.23.1  # temporary fix - semantic search fail (but only in tests)
 langdetect
 lemmagen3
-lxml
 nltk>=3.0.5     # TweetTokenizer introduced in 3.0.5
 numpy
 odfpy>=1.3.5


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-text/issues/974
`lxml` library is used only in importing documents to read XML files. They still didn't provide MacOS ARM wheels (Apple silicon), so installing text add-ons for users with Apple Silicon without certain compilers fails.

##### Description of changes
Since there exists an [ElemntTree](https://docs.python.org/3.9/library/xml.etree.elementtree.html#module-xml.etree.ElementTree) alternative to read XML, I propose replacing lxml. ElementTree is considered fast since it uses fast c implementation and it comes with python. I see a situation as a good way to eliminate one dependency.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
