### PR TITLE
TopicModeling: HDP model settings change

### DIFF
--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -88,7 +88,7 @@ class HdpWidget(TopicWidget):
     gamma = settings.Setting(1)
     alpha = settings.Setting(1)
     eta = settings.Setting(.01)
-    T = settings.Setting(150)
+    T = settings.Setting(20)
     K = settings.Setting(15)
     kappa = settings.Setting(1)
     tau = settings.Setting(64)


### PR DESCRIPTION
##### Issue
It took too long to load HDP model when default setting for `Top level truncation level (Τ)` was set on 150.


##### Description of changes
Decreased it from 150 to 20.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
