### PR TITLE
Statistics: default value for feature pattern

### DIFF
--- a/orangecontrib/text/widgets/owstatistics.py
+++ b/orangecontrib/text/widgets/owstatistics.py
@@ -620,10 +620,7 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
         edit_index = self.combos.index(combo)
         selected_i = combo.currentIndex()
         default_value = STATISTICS_DEFAULT_VALUE[selected_i]
-        self.active_rules[edit_index] = (
-            selected_i,
-            default_value or self.active_rules[edit_index][1],
-        )
+        self.active_rules[edit_index] = (selected_i, default_value)
         self.adjust_n_rule_rows()
 
     def _sync_edit_line(self) -> None:

--- a/orangecontrib/text/widgets/tests/test_owstatistics.py
+++ b/orangecontrib/text/widgets/tests/test_owstatistics.py
@@ -340,7 +340,7 @@ class TestStatisticsWidget(WidgetTest):
         self.widget.apply()
         self.wait_until_finished()
 
-        self.assertListEqual([(1, "")], list(self.widget.result_dict.keys()))
+        self.assertListEqual([(1, None)], list(self.widget.result_dict.keys()))
 
         self.widget.active_rules = [(1, ""), (2, "")]
         self.widget.adjust_n_rule_rows()
@@ -348,7 +348,7 @@ class TestStatisticsWidget(WidgetTest):
         self.wait_until_finished()
 
         self.assertListEqual(
-            [(1, ""), (2, "")], list(self.widget.result_dict.keys())
+            [(1, ""), (2, None)], list(self.widget.result_dict.keys())
         )
 
         self.widget.active_rules = [(2, "")]
@@ -356,7 +356,7 @@ class TestStatisticsWidget(WidgetTest):
         self.widget.apply()
         self.wait_until_finished()
 
-        self.assertListEqual([(2, "")], list(self.widget.result_dict.keys()))
+        self.assertListEqual([(2, None)], list(self.widget.result_dict.keys()))
 
         # dict should empty on new data
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
@@ -364,7 +364,7 @@ class TestStatisticsWidget(WidgetTest):
 
     def test_context(self):
         """ Test whether context correctly restore rules """
-        rules = [(0, ""), (1, ""), (2, "")]
+        rules = [(0, ""), (1, ""), (2, None)]
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         self.widget.active_rules = rules[:]
 


### PR DESCRIPTION
##### Issue
When I changed `Vowel count` to `Starts with`, the pattern stayed `a,e,i,o,u` instead of going blank (` `).

##### Description of changes
It goes to default value now.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
