### PR TITLE
[FIX] NY Times: missing attributes in Text includes & fixed report crashes

### DIFF
--- a/orangecontrib/text/widgets/ownyt.py
+++ b/orangecontrib/text/widgets/ownyt.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, date
 
 from AnyQt.QtCore import Qt
-from AnyQt.QtWidgets import QApplication, QFormLayout
+from AnyQt.QtWidgets import QFormLayout
 
 from Orange.data import StringVariable
 from Orange.widgets import gui
@@ -79,7 +79,7 @@ class OWNYT(OWWidget):
     date_from = Setting((datetime.now().date() - timedelta(365)))
     date_to = Setting(datetime.now().date())
 
-    attributes = [feat.name for feat, _ in NYT.metas if isinstance(feat, StringVariable)]
+    attributes = [feat.args[0] for feat, _ in NYT.metas if feat.func is StringVariable]
     text_includes = Setting([NYT.text_features])
 
     class Warning(OWWidget.Warning):
@@ -200,15 +200,17 @@ class OWNYT(OWWidget):
         self.nyt_api.on_no_connection = self.Error.offline
 
     def send_report(self):
-        self.report_items([
-            ('Query', self.recent_queries[0] if self.recent_queries else ''),
-            ('Date from', self.date_from),
-            ('Date to', self.date_to),
-            ('Text includes', ', '.join(self.text_includes)),
-            ('Output', self.output_info or 'Nothing'),
-        ])
+        if self.corpus:
+            self.report_items((
+                ('Query', self.recent_queries[0] if self.recent_queries else ''),
+                ('Date from', self.date_from),
+                ('Date to', self.date_to),
+                ('Text includes', ', '.join(self.text_includes)),
+                ('Output', self.output_info or 'Nothing'),
+            ))
 
 
 if __name__ == '__main__':
     from orangewidget.utils.widgetpreview import WidgetPreview
+
     WidgetPreview(OWNYT).run()

--- a/orangecontrib/text/widgets/tests/test_ownyt.py
+++ b/orangecontrib/text/widgets/tests/test_ownyt.py
@@ -1,0 +1,27 @@
+import unittest
+
+from orangecontrib.text.widgets.ownyt import OWNYT
+from orangecontrib.text.widgets.utils import CheckListLayout
+from orangewidget.tests.base import WidgetTest
+
+
+class TestOWNYT(WidgetTest):
+    def setUp(self) -> None:
+        self.widget = self.create_widget(OWNYT)
+
+    def test_text_includes_gui(self):
+        """Check that Text includes section has all controls"""
+        # fmt: off
+        exp_controls = [
+            "Headline", "Abstract", "Snippet", "Lead Paragraph", "Subject Keywords",
+            "URL", "Locations", "Persons", "Organizations", "Creative Works"
+        ]
+        # fmt: on
+        self.assertListEqual(exp_controls, self.widget.attributes)
+        self.assertListEqual(
+            exp_controls, self.widget.controlArea.findChild(CheckListLayout).items
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

- In the NY Times widget - section `Text includes` is missing its attributes.
![nyt-text-includes-missing](https://github.com/biolab/orange3-text/assets/49983458/30318850-e19a-464b-8a5d-c6e8793964c5)
- Fixes #972  

##### Description of changes

- Change in line 82, so that attributes are now shown.
- Added if sentence to show report if there is any data. Otherwise is just blank report.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
