### PR TITLE
[FIX] Statistics - Fix layout (hidden + button on Windows)

### DIFF
--- a/orangecontrib/text/widgets/owstatistics.py
+++ b/orangecontrib/text/widgets/owstatistics.py
@@ -6,9 +6,7 @@ from string import punctuation
 from typing import Callable, List, Optional, Tuple
 
 import numpy as np
-from AnyQt.QtCore import QSize
-from AnyQt.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, \
-    QSizePolicy
+from AnyQt.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QSizePolicy
 
 from Orange.widgets import gui
 from Orange.widgets.settings import ContextSetting
@@ -25,9 +23,7 @@ from orangecontrib.text.preprocess import (
     LowercaseTransformer,
     RegexpTokenizer,
     PreprocessorList)
-from orangecontrib.text.widgets.utils.context import (
-    AlmostPerfectContextHandler,
-)
+from orangecontrib.text.widgets.utils.context import AlmostPerfectContextHandler
 
 
 def num_words(document: str, callback: Callable) -> int:
@@ -410,6 +406,12 @@ class ComputeValue:
         # lambda is added as a placeholder for a callback.
         return self.function(data, self.pattern, lambda: True)[0]
 
+    def __eq__(self, other):
+        return self.function == other.function and self.pattern == other.pattern
+
+    def __hash__(self):
+        return hash((self.function, self.pattern))
+
 
 # the definition of all statistics used in this widget, if new statistic
 # is required ad it to this list
@@ -518,11 +520,8 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
     def _init_controls(self) -> None:
         """ Init all controls of the widget """
         self._init_statistics_box()
-        box = gui.hBox(self.controlArea)
-        gui.rubber(box)
 
-        gui.button(self.buttonsArea, self, "Apply",
-                   callback=self.apply)
+        gui.button(self.buttonsArea, self, "Apply", callback=self.apply)
 
     def get_button(self, label, callback):
         return
@@ -532,22 +531,30 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
         Init the statistics box in control area - place where used statistics
         are listed, remove, and added.
         """
-        patternbox = gui.vBox(self.controlArea, box=True)
-        self.rules_box = rules_box = QGridLayout()
-        patternbox.layout().addLayout(self.rules_box)
-        box = gui.hBox(patternbox)
+        box = gui.vBox(self.controlArea, box=True)
+
+        rules_box = gui.vBox(box)
+        self.rules_grid = grid = QGridLayout()
+        rules_box.layout().addLayout(self.rules_grid)
+        grid.setColumnMinimumWidth(1, 100)
+        grid.setColumnMinimumWidth(0, 25)
+        grid.setColumnStretch(0, 1)
+        grid.setColumnStretch(1, 1)
+        grid.setColumnStretch(2, 100)
+        grid.addWidget(QLabel("Feature"), 0, 1)
+        grid.addWidget(QLabel("Pattern"), 0, 2)
+
         gui.button(
-            box, self, "+", callback=self._add_row,
-            addToLayout=False, autoDefault=False, width=34,
-            sizePolicy=(QSizePolicy.Maximum, QSizePolicy.Maximum))
+            box,
+            self,
+            "+",
+            callback=self._add_row,
+            autoDefault=False,
+            width=34,
+            sizePolicy=(QSizePolicy.Maximum, QSizePolicy.Maximum),
+        )
         gui.rubber(box)
-        self.rules_box.setColumnMinimumWidth(1, 70)
-        self.rules_box.setColumnMinimumWidth(0, 10)
-        self.rules_box.setColumnStretch(0, 1)
-        self.rules_box.setColumnStretch(1, 1)
-        self.rules_box.setColumnStretch(2, 100)
-        rules_box.addWidget(QLabel("Feature"), 0, 1)
-        rules_box.addWidget(QLabel("Pattern"), 0, 2)
+
         self.adjust_n_rule_rows()
 
     def adjust_n_rule_rows(self) -> None:
@@ -563,19 +570,19 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
                 None, self, "×", callback=self._remove_row,
                 addToLayout=False, autoDefault=False, width=34,
                 sizePolicy=(QSizePolicy.Maximum, QSizePolicy.Maximum))
-            self.rules_box.addWidget(button, n_lines, 0)
+            self.rules_grid.addWidget(button, n_lines, 0)
             self.remove_buttons.append(button)
 
             # add statistics type dropdown
             combo = QComboBox()
             combo.addItems(STATISTICS_NAMES)
             combo.currentIndexChanged.connect(self._sync_edit_combo)
-            self.rules_box.addWidget(combo, n_lines, 1)
+            self.rules_grid.addWidget(combo, n_lines, 1)
             self.combos.append(combo)
 
             # add line edit for patern
             line_edit = QLineEdit()
-            self.rules_box.addWidget(line_edit, n_lines, 2)
+            self.rules_grid.addWidget(line_edit, n_lines, 2)
             line_edit.textChanged.connect(self._sync_edit_line)
             self.line_edits.append(line_edit)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
On Windows + button is hidden when the user opens the widget. Also, stretching is not optimal: empty space between the box and Apply button, and the whole box stretches instead of adding space at the bottom.

##### Description of changes
Update layout according to issue description.

Additionally, added missing `__eq__` and `__hash__` to ComputeValue.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
