### PR TITLE
Document Embedding tests - do requests server when testing report

### DIFF
--- a/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
+++ b/orangecontrib/text/widgets/tests/test_owdocumentembedding.py
@@ -215,6 +215,7 @@ class TestOWDocumentEmbedding(WidgetTest):
         self.send_signal(widget.Inputs.corpus, self.corpus, widget=widget)
         self.assertEqual("French", widget.language)
 
+    @patch(PATCH_METHOD, make_dummy_post(b'{"embedding": [1.3, 1]}'))
     @patch("orangecontrib.text.widgets.owdocumentembedding.OWDocumentEmbedding.report_items")
     def test_report(self, mocked_items: Mock):
         self.widget.findChildren(QRadioButton)[0].click()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
test_report in OWDocumentEmbeddings tests is calling server which makes test fail sometimes

##### Description of changes
Mock server call for this test

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
