### PR TITLE
[FIX] Corpus - remove dictionary and fix wrong types count on subsampled corpus

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -26,8 +26,7 @@ class BaseTokenFilter(TokenizedPreprocessor):
         corpus = super().__call__(corpus, wrap_callback(callback, end=0.2))
         return self._filter_tokens(corpus, wrap_callback(callback, start=0.2))
 
-    def _filter_tokens(self, corpus: Corpus, callback: Callable,
-                       dictionary=None) -> Corpus:
+    def _filter_tokens(self, corpus: Corpus, callback: Callable) -> Corpus:
         callback(0, "Filtering...")
         filtered_tokens = []
         filtered_tags = []
@@ -37,10 +36,7 @@ class BaseTokenFilter(TokenizedPreprocessor):
             if corpus.pos_tags is not None:
                 filtered_tags.append(list(compress(corpus.pos_tags[i],
                                                    filter_map)))
-        if dictionary is None:
-            corpus.store_tokens(filtered_tokens)
-        else:
-            corpus.store_tokens(filtered_tokens, dictionary)
+        corpus.store_tokens(filtered_tokens)
         if filtered_tags:
             corpus.pos_tags = np.array(filtered_tags, dtype=object)
         return corpus
@@ -178,11 +174,8 @@ class FitDictionaryFilter(BaseTokenFilter):
     def _fit(self, corpus: Corpus):
         raise NotImplemented
 
-    def _filter_tokens(self, corpus: Corpus, callback: Callable,
-                       dictionary=None) -> Corpus:
-        corpus = super()._filter_tokens(corpus, callback,
-                                        dictionary=self._dictionary)
-        return corpus
+    def _filter_tokens(self, corpus: Corpus, callback: Callable) -> Corpus:
+        return super()._filter_tokens(corpus, callback)
 
     def _check(self, token):
         assert self._lexicon is not None

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -2,37 +2,28 @@ import os
 import pickle
 import unittest
 from datetime import datetime
-from unittest import skipIf
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from orangecontrib.text.preprocess import (
-    RegexpTokenizer,
-    LowercaseTransformer,
-    StopwordsFilter,
-)
-from scipy.sparse import csr_matrix, issparse
-
 from Orange.data import (
-    Table,
-    DiscreteVariable,
-    StringVariable,
-    Domain,
     ContinuousVariable,
+    DiscreteVariable,
+    Domain,
+    StringVariable,
+    Table,
     dataset_dirs,
 )
+from orangewidget.utils.signals import summarize
+from scipy.sparse import csr_matrix, issparse
 
 from orangecontrib.text import preprocess
 from orangecontrib.text.corpus import Corpus
+from orangecontrib.text.preprocess import (
+    LowercaseTransformer,
+    RegexpTokenizer,
+    StopwordsFilter,
+)
 from orangecontrib.text.tag import AveragedPerceptronTagger
-
-try:
-    from orangewidget.utils.signals import summarize
-    # import to check if Table summary is available - if summarize_by_name does
-    # not exist Orange (3.28) does not support automated summaries
-    from Orange.widgets.utils.state_summary import summarize_by_name
-except ImportError:
-    summarize = None
 
 
 class CorpusTests(unittest.TestCase):
@@ -707,8 +698,39 @@ class CorpusTests(unittest.TestCase):
         corpus = Corpus.from_file(file)
         self.assertIsNone(corpus.attributes["language"])
 
+    def test_count_tokens(self):
+        domain = Domain([], metas=[StringVariable("Text")])
+        texts = np.array([["Test text"], ["This is another test text"], ["Text 3"]])
+        corpus = Corpus.from_numpy(
+            domain,
+            np.empty((3, 0)),
+            metas=texts,
+            text_features=domain.metas,
+            language="en",
+        )
+        corpus = RegexpTokenizer()(corpus)
+        self.assertEqual(9, corpus.count_tokens())
+        # test on Corpus subset
+        self.assertEqual(7, corpus[:2].count_tokens())
+        self.assertEqual(2, corpus[:1].count_tokens())
 
-@skipIf(summarize is None, "summarize is not available for orange3<=3.28")
+    def test_count_unique_tokens(self):
+        domain = Domain([], metas=[StringVariable("Text")])
+        texts = np.array([["Test text"], ["This is another test text"], ["Text 3"]])
+        corpus = Corpus.from_numpy(
+            domain,
+            np.empty((3, 0)),
+            metas=texts,
+            text_features=domain.metas,
+            language="en",
+        )
+        corpus = RegexpTokenizer()(LowercaseTransformer()(corpus))
+        self.assertEqual(6, corpus.count_unique_tokens())
+        # test on Corpus subset
+        self.assertEqual(5, corpus[:2].count_unique_tokens())
+        self.assertEqual(2, corpus[:1].count_unique_tokens())
+
+
 class TestCorpusSummaries(unittest.TestCase):
     def test_corpus_not_preprocessed(self):
         """Check if details part of the summary is formatted correctly"""
@@ -745,6 +767,40 @@ class TestCorpusSummaries(unittest.TestCase):
         )
         summary = summarize.dispatch(Corpus)(corpus)
         self.assertEqual(140, summary.summary)
+        self.assertEqual(details, summary.details)
+
+    def test_corpus_subset(self):
+        """Test numbers are correct on corpus subset"""
+        # use custom set to have more control
+        domain = Domain([], metas=[StringVariable("Text")])
+        corpus = Corpus.from_numpy(
+            domain,
+            np.empty((2, 0)),
+            metas=np.array([["This is test text 1"], ["This is test another text"]]),
+            text_features=domain.metas,
+            language="en",
+        )
+        corpus = RegexpTokenizer()(corpus)
+
+        details = (
+            f"<nobr>{len(corpus)} instances, 1 variable</nobr><br/>"
+            f"<nobr>Metas: string</nobr><br/>"
+            f"<nobr>Tokens: 10, Types: 6</nobr><br/>"
+            f"<nobr>Language: English</nobr>"
+        )
+        summary = summarize.dispatch(Corpus)(corpus)
+        self.assertEqual(2, summary.summary)
+        self.assertEqual(details, summary.details)
+
+        corpus = corpus[:1]
+        details = (
+            f"<nobr>{len(corpus)} instance, 1 variable</nobr><br/>"
+            f"<nobr>Metas: string</nobr><br/>"
+            f"<nobr>Tokens: 5, Types: 5</nobr><br/>"
+            f"<nobr>Language: English</nobr>"
+        )
+        summary = summarize.dispatch(Corpus)(corpus)
+        self.assertEqual(1, summary.summary)
         self.assertEqual(details, summary.details)
 
     def test_language(self):

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -16,6 +16,7 @@ from Orange.data import (
 from orangewidget.utils.signals import summarize
 from scipy.sparse import csr_matrix, issparse
 
+import orangecontrib
 from orangecontrib.text import preprocess
 from orangecontrib.text.corpus import Corpus
 from orangecontrib.text.preprocess import (
@@ -189,7 +190,6 @@ class CorpusTests(unittest.TestCase):
 
         self.assertEqual(len(new_c._tokens), len(c))
         np.testing.assert_equal(new_c._tokens, new_c._tokens)
-        self.assertEqual(new_c._dictionary, c._dictionary)
         self.assertEqual(new_c.text_features, c.text_features)
         self.assertEqual(new_c.ngram_range, c.ngram_range)
         self.assertEqual(new_c.attributes, c.attributes)
@@ -406,20 +406,17 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(sel), 1)
         self.assertEqual(len(sel._tokens), 1)
         np.testing.assert_equal(sel._tokens, np.array([c._tokens[0]]))
-        self.assertEqual(sel._dictionary, c._dictionary)
 
         sel = c[0:5]
         self.assertEqual(len(sel), 5)
         self.assertEqual(len(sel._tokens), 5)
         np.testing.assert_equal(sel._tokens, c._tokens[0:5])
-        self.assertEqual(sel._dictionary, c._dictionary)
 
         ind = [3, 4, 5, 6]
         sel = c[ind]
         self.assertEqual(len(sel), len(ind))
         self.assertEqual(len(sel._tokens), len(ind))
         np.testing.assert_equal(sel._tokens, c._tokens[ind])
-        self.assertEqual(sel._dictionary, c._dictionary)
         self.assertEqual(sel.text_features, c.text_features)
         self.assertEqual(sel.ngram_range, c.ngram_range)
         self.assertEqual(sel.attributes, c.attributes)
@@ -429,7 +426,6 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(sel), len(ind))
         self.assertEqual(len(sel._tokens), len(ind))
         np.testing.assert_equal(sel._tokens, c._tokens[ind])
-        self.assertEqual(sel._dictionary, c._dictionary)
         self.assertEqual(sel.text_features, c.text_features)
         self.assertEqual(sel.ngram_range, c.ngram_range)
         self.assertEqual(sel.attributes, c.attributes)
@@ -439,7 +435,6 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(sel), len(ind))
         self.assertEqual(len(sel._tokens), len(ind))
         np.testing.assert_equal(sel._tokens, c._tokens[list(ind)])
-        self.assertEqual(sel._dictionary, c._dictionary)
         self.assertEqual(sel.text_features, c.text_features)
         self.assertEqual(sel.ngram_range, c.ngram_range)
         self.assertEqual(sel.attributes, c.attributes)
@@ -448,7 +443,6 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(sel), len(c))
         self.assertEqual(len(sel._tokens), len(c))
         np.testing.assert_equal(sel._tokens, c._tokens)
-        self.assertEqual(sel._dictionary, c._dictionary)
         self.assertEqual(sel.text_features, c.text_features)
         self.assertEqual(sel.ngram_range, c.ngram_range)
         self.assertEqual(sel.attributes, c.attributes)
@@ -457,7 +451,6 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(len(sel), 5)
         self.assertEqual(len(sel._tokens), 5)
         np.testing.assert_equal(sel._tokens, c._tokens[0:5])
-        self.assertEqual(sel._dictionary, c._dictionary)
 
     def test_set_text_features(self):
         c = Corpus.from_file('friends-transcripts')[:100]
@@ -729,6 +722,15 @@ class CorpusTests(unittest.TestCase):
         # test on Corpus subset
         self.assertEqual(5, corpus[:2].count_unique_tokens())
         self.assertEqual(2, corpus[:1].count_unique_tokens())
+
+    def test_remove_dictionary(self):
+        """
+        When this test starts to fail remove:
+        - this test
+        - dictionary property from Corpus
+        - dictionary argument from Corpus.store_tokens
+        """
+        self.assertFalse(orangecontrib.text.__version__.startswith("1.15"))
 
 
 class TestCorpusSummaries(unittest.TestCase):

--- a/orangecontrib/text/tests/test_topic_modeling.py
+++ b/orangecontrib/text/tests/test_topic_modeling.py
@@ -18,8 +18,8 @@ class BaseTests:
     def test_get_topic_table_by_id(self):
         self.model.fit(self.corpus)
         topic1 = self.model.get_topics_table_by_id(1)
-        self.assertEqual(len(topic1), len(self.corpus.dictionary))
-        self.assertEqual(topic1.metas.shape, (len(self.corpus.dictionary), 2))
+        self.assertEqual(len(topic1), self.corpus.count_unique_tokens())
+        self.assertEqual(topic1.metas.shape, (self.corpus.count_unique_tokens(), 2))
         # self.assertAlmostEqual(topic1.W.sum(), 1.)
         self.assertFalse(any(topic1.W == np.nan))
 

--- a/orangecontrib/text/topics/topics.py
+++ b/orangecontrib/text/topics/topics.py
@@ -77,7 +77,9 @@ def infer_ngrams_corpus(corpus, return_dict=False):
     dictionary = Dictionary(corpus.ngrams_iterator(include_postags=True), prune_at=None)
     idx_of_keep = np.argsort([dictionary.token2id[a] for _, a in keep])
     keep = [keep[i][0] for i in idx_of_keep]
-    result = Sparse2Corpus(corpus.X[:, keep].T)
+    result = []
+    if len(dictionary) > 0:
+        result = Sparse2Corpus(corpus.X[:, keep].T)
 
     return (result, dictionary) if return_dict else result
 
@@ -106,7 +108,8 @@ class GensimWrapper:
         Args:
             corpus (Corpus): A corpus to learn topics from.
         """
-        if not len(corpus.dictionary):
+        ngrams_corpus, dictionary = infer_ngrams_corpus(corpus, return_dict=True)
+        if len(dictionary) == 0:
             return None
         model_kwars = self.kwargs
         if "callbacks" in inspect.getfullargspec(self.Model).args:
@@ -116,7 +119,6 @@ class GensimWrapper:
                 model_kwars, callbacks=[GensimProgressCallback(on_progress)]
             )
 
-        ngrams_corpus, dictionary = infer_ngrams_corpus(corpus, return_dict=True)
         self.model = self.Model(
             corpus=ngrams_corpus, id2word=dictionary, **model_kwars
         )

--- a/orangecontrib/text/vectorization/bagofwords.py
+++ b/orangecontrib/text/vectorization/bagofwords.py
@@ -70,10 +70,12 @@ class BowVectorizer(BaseVectorizer):
         self.wglobal = wglobal
 
     def _transform(self, corpus, source_dict=None, callback=dummy_callback):
-        if not (len(corpus.dictionary) or source_dict) or not len(corpus):
+        if len(corpus) == 0:
             return corpus
         temp_corpus = list(corpus.ngrams_iterator(' ', include_postags=True))
         dic = corpora.Dictionary(temp_corpus, prune_at=None) if not source_dict else source_dict
+        if len(dic) == 0:
+            return corpus
         callback(0.3)
         temp_corpus = [dic.doc2bow(doc) for doc in temp_corpus]
         model = models.TfidfModel(dictionary=dic, normalize=False,

--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -613,8 +613,8 @@ class OWCorpusViewer(OWWidget, ConcurrentWidgetMixin):
         if self.corpus is not None:
             has_tokens = self.corpus.has_tokens()
             self.n_matching = f"{self.doc_list.model().rowCount()}/{len(self.corpus)}"
-            self.n_tokens = sum(map(len, self.corpus.tokens)) if has_tokens else "n/a"
-            self.n_types = len(self.corpus.dictionary) if has_tokens else "n/a"
+            self.n_tokens = self.corpus.count_tokens() if has_tokens else "n/a"
+            self.n_types = self.corpus.count_unique_tokens() if has_tokens else "n/a"
         else:
             self.n_matching = "n/a"
             self.n_matches = "n/a"

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -1186,7 +1186,7 @@ class OWPreprocess(Orange.widgets.data.owpreprocess.OWPreprocess,
             if not pp_data.has_tokens():
                 pp_data = BASE_TOKENIZER(
                     pp_data, wrap_callback(callback, start=0.9))
-            if pp_data is not None and len(pp_data.dictionary) == 0:
+            if pp_data is not None and pp_data.count_tokens() == 0:
                 msgs.append(self.Warning.no_token_left)
                 pp_data = None
         return Result(corpus=pp_data, msgs=msgs)
@@ -1212,9 +1212,8 @@ class OWPreprocess(Orange.widgets.data.owpreprocess.OWPreprocess,
             try:
                 tokens = next(data.ngrams_iterator(include_postags=True))
                 self.preview = ", ".join(tokens[:5])
-                n_tokens = sum(
-                    map(len, data.tokens)) if data.has_tokens() else ''
-                n_types = len(data.dictionary) if data.has_tokens() else ''
+                n_tokens = data.count_tokens() if data.has_tokens() else ''
+                n_types = data.count_unique_tokens() if data.has_tokens() else ''
                 self.output_info = f"Tokens: {n_tokens}\nTypes: {n_types}"
             except StopIteration:
                 self.preview = ""


### PR DESCRIPTION
##### Issue
Fixes https://github.com/biolab/orange3-text/issues/920
Corpus saves a dictionary (Gensim Dictionary) which is created on first need and cached. The problem with the dictionary is that it stays the same after subsampling Corpus (creating a corpus with the subset of documents) even though the number of unique tokens changes. The most problematic is that it was used to access a number of unique tokens in Corpus at different locations in the addon. The information was incorrect after the corpus was subsampled (issue in #920).

##### Description of changes
Since the dictionary was primarily introduced for Topic modelling purposes and topic modelling does not use it anymore, I decided to remove it from Corpus. All pieces of code that use a dictionary can be written differently. 

This PR so removes the dictionary and updates all the code that uses it.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
