### PR TITLE
[FIX] Ontology: Fix 'remove word' bug

### DIFF
--- a/orangecontrib/text/widgets/owontology.py
+++ b/orangecontrib/text/widgets/owontology.py
@@ -53,15 +53,17 @@ def _model_to_tree(
 ) -> Union[Dict, OntoType]:
     tree = {}
     for i in range(item.rowCount()):
-        tree[item.child(i).text()] = \
-            _model_to_tree(item.child(i), selection, with_selection)
+        if item.child(i) is not None:
+            tree[item.child(i).text()] = \
+                _model_to_tree(item.child(i), selection, with_selection)
     return (tree, item.index() in selection) if with_selection else tree
 
 
 def _model_to_words(item: QStandardItem) -> List:
     words = [item.text()] if item.text() else []
     for i in range(item.rowCount()):
-        words.extend(_model_to_words(item.child(i)))
+        if item.child(i) is not None:
+            words.extend(_model_to_words(item.child(i)))
     return words
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

<img width="567" alt="image" src="https://github.com/biolab/orange3-text/assets/11465003/6a8b8c43-49dc-415d-a182-9d12a17fb645">

Removing the `bar` word from the above ontology causes an error:

```
Traceback (most recent call last):
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owontology.py", line 803, in __on_ontology_data_changed
    self.__set_current_modified(self.CACHED)
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owontology.py", line 899, in __set_current_modified
    ontology = self.__ontology_view.get_data()
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owontology.py", line 324, in get_data
    return _model_to_tree(self.__root, selection, with_selection)
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owontology.py", line 57, in _model_to_tree
    _model_to_tree(item.child(i), selection, with_selection)
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owontology.py", line 57, in _model_to_tree
    _model_to_tree(item.child(i), selection, with_selection)
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owontology.py", line 57, in _model_to_tree
    _model_to_tree(item.child(i), selection, with_selection)
  File "/Users/vesna/orange3-text/orangecontrib/text/widgets/owontology.py", line 55, in _model_to_tree
    for i in range(item.rowCount()):
AttributeError: 'NoneType' object has no attribute 'rowCount'
```

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
