### PR TITLE
Corpus dictionary - Postpone its removal 

### DIFF
--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -730,7 +730,7 @@ class CorpusTests(unittest.TestCase):
         - dictionary property from Corpus
         - dictionary argument from Corpus.store_tokens
         """
-        self.assertFalse(orangecontrib.text.__version__.startswith("1.15"))
+        self.assertFalse(orangecontrib.text.__version__.startswith("1.16"))
 
 
 class TestCorpusSummaries(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Dictionary deprecation was planned in version 1.15, and total removal was planned for version 1.16. Since #990  was merged after 1.15, it is not valid anymore.

##### Description of changes
Since deprecation will be introduced in 1.16, the dictionary removal is postponed to version 1.17

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
