### PR TITLE
[FIX] Statistics - Regex count in whole document to only token

### DIFF
--- a/orangecontrib/text/widgets/owstatistics.py
+++ b/orangecontrib/text/widgets/owstatistics.py
@@ -3,7 +3,7 @@ from collections import Counter
 from copy import copy
 from itertools import groupby
 from string import punctuation
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union, Iterator, Dict
 
 import numpy as np
 from AnyQt.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QSizePolicy
@@ -14,32 +14,35 @@ from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input, Output, OWWidget
 from nltk import tokenize
+from orangecanvas.gui.utils import disconnected
 from orangewidget.widget import Msg
 
 from orangecontrib.text import Corpus
 
-# those functions are implemented here since they are used in more statistics
-from orangecontrib.text.preprocess import (
-    LowercaseTransformer,
-    RegexpTokenizer,
-    PreprocessorList
-)
+
+class Sources:
+    DOCUMENTS = "Documents"
+    TOKENS = "Tokens"  # tokens or ngrams - depending on statistic
 
 
-def num_words(document: str, callback: Callable) -> int:
+def num_words(document: Union[str, List], callback: Callable) -> int:
     """
     Return number of words in document-string. Word is every entity divided by
     space, tab, newline.
     """
     callback()
-    return len(document.split())
+    if isinstance(document, str):
+        document = document.split()
+    return len(document)
 
 
-def char_count(document: str, callback: Callable) -> int:
+def char_count(document: Union[str, List], callback: Callable) -> int:
     """
     Count number of alpha-numerical in document/string.
     """
     callback()
+    if isinstance(document, List):
+        document = "".join(document)
     return sum(c.isalnum() for c in document)
 
 
@@ -52,37 +55,32 @@ def digit_count(document: str, callback: Callable) -> int:
 
 
 def count_appearances(
-    document: str, characters: List[str], callback: Callable
+    document: Union[str, List], characters: List[str], callback: Callable
 ) -> int:
     """
     Count number of appearances of chars from `characters` list.
     """
     callback()
     # I think it supports the majority of main languages
-    # Y can be vowel too sometimes - it is not possible to distinguish
-    return sum(document.lower().count(c) for c in characters)
+    # Y can be vo wel too sometimes - it is not possible to distinguish
+    if isinstance(document, str):
+        return sum(document.lower().count(c) for c in characters)
+    else:
+        return sum(d.lower().count(c) for c in characters for d in document)
 
 
-def preprocess_only_words(corpus: Corpus) -> Corpus:
+def get_source(corpus: Corpus, source: str) -> Union[List[str], Iterator[List[str]]]:
     """
-    Apply the preprocessor that splits words, transforms them to lower case
-    (and removes punctuations).
-
-    Parameters
-    ----------
-    corpus
-        Corpus on which the preprocessor will be applied.
-
-    Returns
-    -------
-    Preprocessed corpus. Result of pre-processing is saved in tokens/ngrams.
+    Extract source from corpus according to source variable:
+    - if source == Sources.DOCUMENTS return documents
+    - if source == Sources.TOKENS return ngrams
     """
-    p = PreprocessorList(
-        [LowercaseTransformer(),
-         # by default regexp keeps only words (no punctuations, no spaces)
-         RegexpTokenizer()]
-    )
-    return p(corpus)
+    if source == Sources.DOCUMENTS:
+        return corpus.documents
+    elif source == Sources.TOKENS:
+        return corpus.ngrams
+    else:
+        raise ValueError(f"Wrong source {source}")
 
 
 # every statistic returns a np.ndarray with statistics
@@ -91,38 +89,34 @@ def preprocess_only_words(corpus: Corpus) -> Corpus:
 
 
 def words_count(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Count number of words in each document.
     """
-    corpus = preprocess_only_words(corpus)
+    assert source == Sources.DOCUMENTS
     # np.c_ makes column vector (ndarray) out of the list
     # [1, 2, 3] -> [[1], [2], [3]]
-    return (
-        np.c_[[num_words(d, callback) for d in corpus.documents]],
-        ["Word count"],
-    )
+    return np.c_[[num_words(d, callback) for d in corpus.documents]], ["Word count"]
 
 
 def characters_count(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Count number of characters without spaces, newlines, tabs, ...
     """
-    return (
-        np.c_[[char_count(d, callback) for d in corpus.documents]],
-        ["Character count"],
-    )
+    source = get_source(corpus, source)
+    return np.c_[[char_count(d, callback) for d in source]], ["Character count"]
 
 
 def n_gram_count(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Count number of n-grams in every document
     """
+    assert source == Sources.TOKENS
 
     def ng_count(n_gram: List[str]):
         callback()
@@ -132,28 +126,25 @@ def n_gram_count(
 
 
 def average_word_len(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Computes word density as: word count / character count + 1
     """
+    source = get_source(corpus, source)
     return (
-        np.c_[
-            [
-                char_count(d, lambda: True) / num_words(d, callback)
-                for d in corpus.documents
-            ]
-        ],
+        np.c_[[char_count(d, lambda: True) / num_words(d, callback) for d in source]],
         ["Average word length"],
     )
 
 
 def punctuation_count(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Count number of punctuation signs
     """
+    assert source == Sources.DOCUMENTS
 
     def num_punctuation(document: str):
         callback()
@@ -166,11 +157,12 @@ def punctuation_count(
 
 
 def capital_count(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Count number of capital letters in documents
     """
+    assert source == Sources.DOCUMENTS
 
     def num_capitals(document: str):
         callback()
@@ -183,11 +175,13 @@ def capital_count(
 
 
 def vowel_count(
-    corpus: Corpus, vowels: str, callback: Callable
+    corpus: Corpus, vowels: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Count number of vowels in documents
     """
+    assert source == Sources.DOCUMENTS
+
     # comma separated string of vowels to list
     vowels = [v.strip() for v in vowels.split(",")]
     return (
@@ -199,12 +193,14 @@ def vowel_count(
 
 
 def consonant_count(
-    corpus: Corpus, consonants: str, callback: Callable
+    corpus: Corpus, consonants: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Count number of consonants in documents. Consonants are all alnum
     characters except vowels and numbers
     """
+    assert source == Sources.DOCUMENTS
+
     # comma separated string of consonants to list
     consonants = [v.strip() for v in consonants.split(",")]
     return (
@@ -219,12 +215,12 @@ def consonant_count(
 
 
 def per_cent_unique_words(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Ratio between unique words count and all words count
     """
-    corpus = preprocess_only_words(corpus)
+    assert source == Sources.TOKENS
 
     def perc_unique(tokens: str):
         callback()
@@ -232,83 +228,84 @@ def per_cent_unique_words(
             return np.nan
         return len(set(tokens)) / len(tokens)
 
-    return np.c_[list(map(perc_unique, corpus.tokens))], ["% unique words"]
+    return np.c_[list(map(perc_unique, corpus.ngrams))], ["% unique words"]
 
 
 def starts_with(
-    corpus: Corpus, prefix: str, callback: Callable
+    corpus: Corpus, prefix: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Number of words that starts with the string in `prefix`.
     """
-    corpus = preprocess_only_words(corpus)
+    assert source == Sources.TOKENS
 
     def number_starts_with(tokens: List[str]):
         callback()
         return sum(t.startswith(prefix) for t in tokens)
 
     return (
-        np.c_[list(map(number_starts_with, corpus.tokens))],
+        np.c_[list(map(number_starts_with, corpus.ngrams))],
         [f"Starts with {prefix}"],
     )
 
 
 def ends_with(
-    corpus: Corpus, postfix: str, callback: Callable
+    corpus: Corpus, postfix: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Number of words that ends with the string in `postfix`.
     """
-    corpus = preprocess_only_words(corpus)
+    assert source == Sources.TOKENS
 
     def number_ends_with(tokens: List[str]):
         callback()
         return sum(t.endswith(postfix) for t in tokens)
 
     return (
-        np.c_[list(map(number_ends_with, corpus.tokens))],
+        np.c_[list(map(number_ends_with, corpus.ngrams))],
         [f"Ends with {postfix}"],
     )
 
 
 def contains(
-    corpus: Corpus, text: str, callback: Callable
+    corpus: Corpus, text: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Number of words that contains string in `text`.
     """
+    source = get_source(corpus, source)
     return (
-        np.c_[
-            [count_appearances(d, [text], callback) for d in corpus.documents]
-        ],
+        np.c_[[count_appearances(d, [text], callback) for d in source]],
         [f"Contains {text}"],
     )
 
 
 def regex(
-    corpus: Corpus, expression: str, callback: Callable
+    corpus: Corpus, expression: str, source: str, callback: Callable
 ) -> Tuple[np.ndarray, List[str]]:
     """
     Count occurrences of pattern in `expression`.
     """
     pattern = re.compile(expression)
 
-    def number_regex(tokens: List[str]):
+    def regex_matches(text: Union[str, List]):
         callback()
-        return sum(bool(pattern.match(t)) for t in tokens)
+        if isinstance(text, str):
+            return len(re.findall(pattern, text))
+        else:
+            return sum(len(re.findall(pattern, ngram)) for ngram in text)
 
-    return (
-        np.c_[list(map(number_regex, corpus.tokens))],
-        [f"Regex {expression}"],
-    )
+    source = get_source(corpus, source)
+    return np.c_[list(map(regex_matches, source))], [f"Regex {expression}"]
 
 
 def pos_tags(
-    corpus: Corpus, pos_tags: str, callback: Callable
+    corpus: Corpus, pos_tags: str, source: str, callback: Callable
 ) -> Optional[Tuple[np.ndarray, List[str]]]:
     """
     Count number of specified pos tags in corpus
     """
+    assert source == Sources.TOKENS
     p_tags = [v.strip().lower() for v in pos_tags.split(",")]
 
     def cust_count(tags):
@@ -325,7 +322,7 @@ def pos_tags(
 
 
 def yule(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Optional[Tuple[np.ndarray, List[str]]]:
     """
     Yule's I measure: higher number is higher diversity - richer vocabulary
@@ -333,6 +330,7 @@ def yule(
     Mathematical Proceedings of the Cambridge Philosophical Society, 42(2), B1-B2.
     doi:10.1017/S0305004100022799
     """
+    assert source == Sources.TOKENS
     if corpus.pos_tags is None:
         return None
 
@@ -354,13 +352,13 @@ def yule(
 
 
 def lix(
-    corpus: Corpus, _: str, callback: Callable
+    corpus: Corpus, _: str, source: str, callback: Callable
 ) -> Optional[Tuple[np.ndarray, List[str]]]:
     """
     Readability index LIX
     https://en.wikipedia.org/wiki/Lix_(readability_test)
     """
-    corpus = preprocess_only_words(corpus)
+    assert source == Sources.TOKENS
     tokenizer = tokenize.PunktSentenceTokenizer()
 
     def lix_index(document, tokens):
@@ -393,18 +391,21 @@ class ComputeValue:
     pattern
         Some statistics need additional parameter with the pattern
         (e.g. starts with), for others it is set to empty string.
+    source
+        Part of the corpus used for computation: either tokens/ngrams or whole documents
     """
 
-    def __init__(self, function: Callable, pattern: str) -> None:
+    def __init__(self, function: Callable, pattern: str, source: str) -> None:
         self.function = function
         self.pattern = pattern
+        self.source = source
 
     def __call__(self, data: Corpus) -> np.ndarray:
         """
         This function compute values on new table.
         """
         # lambda is added as a placeholder for a callback.
-        return self.function(data, self.pattern, lambda: True)[0]
+        return self.function(data, self.pattern, self.source, lambda: True)[0]
 
     def __eq__(self, other):
         return self.function == other.function and self.pattern == other.pattern
@@ -419,30 +420,32 @@ class ComputeValue:
 STATISTICS = [
     # (name of the statistics, function to compute, default value)
     # if default value is None - text box is not required
-    ("Word count", words_count, None),
-    ("Character count", characters_count, None),
-    ("N-gram count", n_gram_count, None),
-    ("Average word length", average_word_len, None),
-    ("Punctuation count", punctuation_count, None),
-    ("Capital letter count", capital_count, None),
-    ("Vowel count", vowel_count, "a,e,i,o,u"),
+    ("Word count", words_count, None, (Sources.DOCUMENTS,)),
+    ("Character count", characters_count, None, (Sources.DOCUMENTS, Sources.TOKENS)),
+    ("N-gram count", n_gram_count, None, (Sources.TOKENS,)),
+    ("Average term length", average_word_len, None, (Sources.DOCUMENTS, Sources.TOKENS)),
+    ("Punctuation count", punctuation_count, None, (Sources.DOCUMENTS,)),
+    ("Capital letter count", capital_count, None, (Sources.DOCUMENTS,)),
+    ("Vowel count", vowel_count, "a,e,i,o,u", (Sources.DOCUMENTS,)),
     (
         "Consonant count",
         consonant_count,
         "b,c,d,f,g,h,j,k,l,m,n,p,q,r,s,t,v,w,x,y,z",
+        (Sources.DOCUMENTS,),
     ),
-    ("Per cent unique words", per_cent_unique_words, None),
-    ("Starts with", starts_with, ""),
-    ("Ends with", ends_with, ""),
-    ("Contains", contains, ""),
-    ("Regex", regex, ""),
-    ("POS tag", pos_tags, "NN,VV,JJ"),
-    ("Yule's I", yule, None),
-    ("LIX index", lix, None),
+    ("Per cent unique terms", per_cent_unique_words, None, (Sources.TOKENS,)),
+    ("Starts with", starts_with, "", (Sources.TOKENS,)),
+    ("Ends with", ends_with, "", (Sources.TOKENS,)),
+    ("Contains", contains, "", (Sources.DOCUMENTS, Sources.TOKENS)),
+    ("Regex", regex, "", (Sources.DOCUMENTS, Sources.TOKENS)),
+    ("POS tag", pos_tags, "NN,VV,JJ", (Sources.TOKENS,)),
+    ("Yule's I", yule, None, (Sources.TOKENS,)),
+    ("LIX index", lix, None, (Sources.TOKENS,)),
 ]
 STATISTICS_NAMES = list(list(zip(*STATISTICS))[0])
 STATISTICS_FUNCTIONS = list(list(zip(*STATISTICS))[1])
 STATISTICS_DEFAULT_VALUE = list(list(zip(*STATISTICS))[2])
+STATISTICS_DEFAULT_SOURCES = list(list(zip(*STATISTICS))[3])
 
 
 def run(corpus: Corpus, statistics: Tuple[int, str], state: TaskState) -> None:
@@ -466,12 +469,12 @@ def run(corpus: Corpus, statistics: Tuple[int, str], state: TaskState) -> None:
     def advance():
         state.set_progress_value(next(tick_values))
 
-    for s, patern in statistics:
+    for s, patern, source in statistics:
         fun = STATISTICS_FUNCTIONS[s]
-        result = fun(corpus, patern, advance)
+        result = fun(corpus, patern, source, advance)
         if result is not None:
-            result = result + (ComputeValue(fun, patern),)
-        state.set_partial_result((s, patern, result))
+            result = result + (ComputeValue(fun, patern, source),)
+        state.set_partial_result((s, patern, source, result))
 
 
 class OWStatistics(OWWidget, ConcurrentWidgetMixin):
@@ -491,12 +494,14 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
             "{} statistics cannot be computed and is omitted from results."
         )
 
+    # todo: update settings version and migration
     want_main_area = False
     mainArea_width_height_ratio = None
 
-    # settings
-    default_rules = [(0, ""), (1, "")]  # rules used to reset the active rules
-    active_rules: List[Tuple[int, str]] = Setting(default_rules[:])
+    settings_version = 2
+    # rules used to reset the active rules
+    default_rules = [(0, "", STATISTICS[0][-1][0]), (1, "", STATISTICS[0][-1][0])]
+    active_rules: List[Tuple[int, str, str]] = Setting(default_rules[:])
     # rules active at time of apply clicked
     applied_rules: Optional[List[Tuple[int, str]]] = None
 
@@ -507,12 +512,14 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
         ConcurrentWidgetMixin.__init__(self)
         self.corpus = None
 
-        # the list with combos from the widget
-        self.combos = []
+        # the list with combos for selecting statistics from the widget
+        self.statistics_combos = []
         # the list with line edits from the widget
         self.line_edits = []
         # the list of buttons in front of controls that removes them
         self.remove_buttons = []
+        # the list with combos for selecting on what statistics computes
+        self.source_combos = []
 
         self._init_controls()
 
@@ -542,6 +549,7 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
         grid.setColumnStretch(2, 100)
         grid.addWidget(QLabel("Feature"), 0, 1)
         grid.addWidget(QLabel("Pattern"), 0, 2)
+        grid.addWidget(QLabel("Compute for"), 0, 3)
 
         gui.button(
             box,
@@ -562,7 +570,7 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
         """
 
         def _add_line():
-            n_lines = len(self.combos) + 1
+            n_lines = len(self.statistics_combos) + 1
 
             # add delete symbol
             button = gui.button(
@@ -577,23 +585,29 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
             combo.addItems(STATISTICS_NAMES)
             combo.currentIndexChanged.connect(self._sync_edit_combo)
             self.rules_grid.addWidget(combo, n_lines, 1)
-            self.combos.append(combo)
+            self.statistics_combos.append(combo)
 
-            # add line edit for patern
+            # add line edit for pattern
             line_edit = QLineEdit()
             self.rules_grid.addWidget(line_edit, n_lines, 2)
             line_edit.textChanged.connect(self._sync_edit_line)
             self.line_edits.append(line_edit)
 
+            # add statistics type dropdown
+            combo = QComboBox()
+            combo.currentIndexChanged.connect(self._sync_edit_source_combo)
+            self.rules_grid.addWidget(combo, n_lines, 3)
+            self.source_combos.append(combo)
+
         def _remove_line():
-            self.combos.pop().deleteLater()
+            self.statistics_combos.pop().deleteLater()
             self.line_edits.pop().deleteLater()
+            self.source_combos.pop().deleteLater()
             self.remove_buttons.pop().deleteLater()
 
         def _fix_tab_order():
-            # TODO: write it differently - check create class
-            for i, (r, c, l) in enumerate(
-                zip(self.active_rules, self.combos, self.line_edits)
+            for i, (r, c, l, s) in enumerate(
+                zip(self.active_rules, self.statistics_combos, self.line_edits, self.source_combos)
             ):
                 c.setCurrentIndex(r[0])  # update combo
                 l.setText(r[1])  # update line edit
@@ -601,17 +615,23 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
                     l.setVisible(True)
                 else:
                     l.setVisible(False)
+                with disconnected(s.currentIndexChanged, self._sync_edit_source_combo):
+                    s.clear()
+                    items = STATISTICS_DEFAULT_SOURCES[r[0]]
+                    s.addItems(items)
+                    s.setCurrentText(r[2])
+                    s.setDisabled(len(items) == 1)
 
         n = len(self.active_rules)
-        while n > len(self.combos):
+        while n > len(self.statistics_combos):
             _add_line()
-        while len(self.combos) > n:
+        while len(self.statistics_combos) > n:
             _remove_line()
         _fix_tab_order()
 
     def _add_row(self) -> None:
         """ Add a new row to the statistic box """
-        self.active_rules.append((0, ""))
+        self.active_rules.append((0, "", STATISTICS_DEFAULT_SOURCES[0][0]))
         self.adjust_n_rule_rows()
 
     def _remove_row(self) -> None:
@@ -623,20 +643,27 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
     def _sync_edit_combo(self) -> None:
         """ Update rules when combo value changed """
         combo = self.sender()
-        edit_index = self.combos.index(combo)
+        edit_index = self.statistics_combos.index(combo)
         selected_i = combo.currentIndex()
-        default_value = STATISTICS_DEFAULT_VALUE[selected_i]
-        self.active_rules[edit_index] = (selected_i, default_value)
+        default_value = STATISTICS_DEFAULT_VALUE[selected_i] or ""
+        default_source = STATISTICS_DEFAULT_SOURCES[selected_i][0]
+        self.active_rules[edit_index] = (selected_i, default_value, default_source)
         self.adjust_n_rule_rows()
 
     def _sync_edit_line(self) -> None:
         """ Update rules when line edit value changed """
         line_edit = self.sender()
         edit_index = self.line_edits.index(line_edit)
-        self.active_rules[edit_index] = (
-            self.active_rules[edit_index][0],
-            line_edit.text(),
-        )
+        arules = self.active_rules[edit_index]
+        self.active_rules[edit_index] = (arules[0], line_edit.text(), arules[2])
+
+    def _sync_edit_source_combo(self) -> None:
+        """ Update rules when source value change """
+        combo = self.sender()
+        edit_index = self.source_combos.index(combo)
+        value = combo.currentText()
+        arules = self.active_rules[edit_index]
+        self.active_rules[edit_index] = (arules[0], arules[1], value)
 
     @Inputs.corpus
     def set_data(self, corpus) -> None:
@@ -666,10 +693,10 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
         raise exception
 
     def on_partial_result(
-        self, result: Tuple[int, str, Tuple[np.ndarray, List[str], Callable]]
+        self, result: Tuple[int, str, str, Tuple[np.ndarray, List[str], Callable]]
     ) -> None:
-        statistic, patern, result = result
-        self.result_dict[(statistic, patern)] = result
+        statistic, patern, source, result = result
+        self.result_dict[(statistic, patern, source)] = result
 
     def on_done(self, result: None) -> None:
         # join results
@@ -706,6 +733,21 @@ class OWStatistics(OWWidget, ConcurrentWidgetMixin):
             attributes, compute_values=comput_values
         )
         self.Outputs.corpus.send(new_corpus)
+
+    @classmethod
+    def migrate_settings(cls, settings: Dict, version: int):
+        def def_source(idx):
+            """Return source that behaviour is the most similar to previous version"""
+            if STATISTICS_NAMES[idx] == "Regex":
+                # regex was working on tokens in the previous version
+                return Sources.TOKENS
+            # others that allow both sources were working on documents
+            return STATISTICS_DEFAULT_SOURCES[idx][0]
+
+        if version < 2:
+            if "active_rules" in settings:
+                new_rules = [(r, v, def_source(r)) for r, v in settings["active_rules"]]
+                settings["active_rules"] = new_rules
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Regex counter counts only appearances in tokens, which ignore multi-word appearances.

##### Description of changes

As discussed with @ajdapretnar, I added a dropdown beside each statistic so that the user can decide whether to do computation on tokens/ngrams or a full document. Currently, it includes two options:
- Preprocessed tokens - Statistics are computed on either tokes or ngrams, depending on what is more suitable for the statistic.
- Documents - statistic computed on full document text

##### Discussion
- ~Is `Preprocessed tokens` a good term, or do we have any other idea?~ Changed to `Tokens`
- ~`Average word length` is currently implemented only on documents since the name doesn't make sense on N-grams. Should we rename it to `Average term length` and apply it to documents and n-grams? So that it is word length on documents and ngram length on ngrams.~ Renamed to `Average term length` and enabled for ngrams.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
