### PR TITLE
Fix failing tests

### DIFF
--- a/orangecontrib/text/tests/test_annotate_documents.py
+++ b/orangecontrib/text/tests/test_annotate_documents.py
@@ -37,7 +37,7 @@ class TestClusterDocuments(unittest.TestCase):
     def test_gmm(self):
         labels = ClusterDocuments.gmm(self.corpus.metas[:, -2:], 2, 0.6)
         self.assertIn(
-            list(labels), ([0, 1, 0, 1, 0, 1, 0, 1, 0], [0, 1, 0, 1, 0, 1, 0, 1, 0])
+            list(labels), ([0, 1, 0, 1, 0, 1, 0, 1, 0], [1, 0, 1, 0, 1, 0, 1, 0, 1])
         )
 
     def test_gmm_n_comp(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Annotator tests started to fail due to changes in scikit-learn (in version 1.3.0). The reason is using the same random seed returns different results since clusters in data are not well distinguishable. 

##### Description of changes
Fix the issue with artificial embeddings to produce better distinguishable clusters.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
