### PR TITLE
[FIX] Topic Modelling - Do not recompute when spin value doesn't change

### DIFF
--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -37,11 +37,21 @@ class TopicWidget(gui.OWComponent, QGroupBox):
         self.model = self.create_model()
         QVBoxLayout(self)
         for parameter, description, minv, maxv, step, _type in self.parameters:
-            spin = gui.spin(self, self, parameter, minv=minv, maxv=maxv, step=step,
-                            label=self.spin_format.format(description=description, parameter=parameter),
-                            labelWidth=220, spinType=_type)
+            spin = gui.spin(
+                self,
+                self,
+                parameter,
+                minv=minv,
+                maxv=maxv,
+                step=step,
+                label=self.spin_format.format(
+                    description=description, parameter=parameter
+                ),
+                labelWidth=220,
+                spinType=_type,
+                callback=self.on_change,
+            )
             spin.clearFocus()
-            spin.editingFinished.connect(self.on_change)
 
     def on_change(self):
         self.model = self.create_model()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
Topic modelling run recomputation everytime spin focus is lost (even when value doesn't change)

##### Description of changes
Do not rerun if spin value doesn't change

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
