### PR TITLE
POS - remove unsupported and unused StanfordPOSTagger

### DIFF
--- a/orangecontrib/text/tag/pos.py
+++ b/orangecontrib/text/tag/pos.py
@@ -2,7 +2,6 @@ from typing import List, Callable
 
 import nltk
 import numpy as np
-
 from Orange.util import wrap_callback, dummy_callback
 
 from orangecontrib.text import Corpus
@@ -11,7 +10,7 @@ from orangecontrib.text.preprocess import TokenizedPreprocessor
 from orangecontrib.text.util import chunkable
 
 
-__all__ = ['POSTagger', 'StanfordPOSTagger', 'AveragedPerceptronTagger', 'MaxEntTagger']
+__all__ = ["POSTagger", "AveragedPerceptronTagger", "MaxEntTagger"]
 
 
 class POSTagger(TokenizedPreprocessor):
@@ -36,41 +35,6 @@ class POSTagger(TokenizedPreprocessor):
     def _preprocess(self, tokens: List[List[str]]) -> List[List[str]]:
         return list(map(lambda sent: list(map(lambda x: x[1], sent)),
                         self.tagger(tokens)))
-
-
-class StanfordPOSTaggerError(Exception):
-    pass
-
-
-class StanfordPOSTagger(nltk.StanfordPOSTagger, POSTagger):
-    name = 'Stanford POS Tagger'
-
-    @classmethod
-    def check(cls, path_to_model, path_to_jar):
-        """ Checks whether provided `path_to_model` and `path_to_jar` are valid.
-
-        Raises:
-            ValueError: in case at least one of the paths is invalid.
-
-        Notes:
-            Can raise an exception if Java Development Kit is not installed or not properly configured.
-
-        Examples:
-            >>> try:
-            ...    StanfordPOSTagger.check('path/to/model', 'path/to/stanford.jar')
-            ... except ValueError as e:
-            ...    print(e)
-            Could not find stanford-postagger.jar jar file at path/to/stanford.jar
-
-        """
-        try:
-            cls(path_to_model, path_to_jar).tag(())
-        except OSError as e:
-            raise StanfordPOSTaggerError(
-                'Either Java SDK not installed or some of the '
-                'files are invalid.\n' + str(e))
-        except LookupError as e:
-            raise StanfordPOSTaggerError(str(e).strip(' =\n'))
 
 
 class AveragedPerceptronTagger(POSTagger):

--- a/orangecontrib/text/tests/test_tags.py
+++ b/orangecontrib/text/tests/test_tags.py
@@ -1,11 +1,9 @@
 import pickle
 import copy
-import tempfile
 import unittest
 
 from orangecontrib.text import tag
 from orangecontrib.text.corpus import Corpus
-from orangecontrib.text.tag.pos import StanfordPOSTaggerError
 
 
 class POSTaggerTests(unittest.TestCase):
@@ -18,15 +16,6 @@ class POSTaggerTests(unittest.TestCase):
         self.assertTrue(hasattr(result, 'pos_tags'))
         for tokens, tags in zip(result.tokens, result.pos_tags):
             self.assertEqual(len(tokens), len(tags))
-
-    def test_Stanford_check(self):
-        model = tempfile.NamedTemporaryFile()
-        resource = tempfile.NamedTemporaryFile()
-        with self.assertRaises(StanfordPOSTaggerError):
-            tag.StanfordPOSTagger.check(model.name, resource.name)
-
-        with self.assertRaises(StanfordPOSTaggerError):
-            tag.StanfordPOSTagger.check('model', resource.name)
 
     def test_str(self):
         self.assertEqual('Averaged Perceptron Tagger', str(self.tagger))

--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -29,7 +29,6 @@ from orangecontrib.text.preprocess import *
 from orangecontrib.text.preprocess.normalize import UDPipeStopIteration
 from orangecontrib.text.tag import AveragedPerceptronTagger, MaxEntTagger, \
     POSTagger
-from orangecontrib.text.tag.pos import StanfordPOSTaggerError
 
 _DEFAULT_NONE = "(none)"
 
@@ -973,7 +972,7 @@ class NgramsModule(PreprocessorModule):
 
 
 class POSTaggingModule(SingleMethodModule):
-    Averaged, MaxEnt, Stanford = range(3)
+    Averaged, MaxEnt = range(2)
     Methods = {Averaged: AveragedPerceptronTagger,
                MaxEnt: MaxEntTagger}
     DEFAULT_METHOD = Averaged
@@ -1041,7 +1040,6 @@ class OWPreprocess(Orange.widgets.data.owpreprocess.OWPreprocess,
         file_not_found = Msg("File not found.")
         invalid_encoding = Msg("Invalid file encoding. Please save the "
                                "file as UTF-8 and try again.")
-        stanford_tagger = Msg("Problem loading Stanford POS Tagger:\n{}")
 
     class Warning(Orange.widgets.data.owpreprocess.OWPreprocess.Warning):
         no_token_left = Msg("No tokens on the output.")
@@ -1162,8 +1160,6 @@ class OWPreprocess(Orange.widgets.data.owpreprocess.OWPreprocess,
             self.Error.file_not_found()
         except UnicodeError as e:
             self.Error.invalid_encoding(e)
-        except StanfordPOSTaggerError as e:
-            self.Error.stanford_tagger(e)
         except Exception as e:
             self.Error.unknown_error(str(e))
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
I am splitting #963 into smaller PRs for easier review.
StanfordPOSTagger is deprecated and unused. https://github.com/nltk/nltk/pull/1843

##### Description of changes

StanfordPOSTagger was excluded in #506 since it should be implemented in the server (as far as I understood correctly - it uses Java). If we decide to do this, it will be a completely new implementation, so I suggest removing it for now and writing an issue that we remember.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
