### PR TITLE
[ENH] Filter - Use ISO language in StopwordsFilter

### DIFF
--- a/orangecontrib/text/annotate_documents.py
+++ b/orangecontrib/text/annotate_documents.py
@@ -289,7 +289,7 @@ if __name__ == "__main__":
 
     corpus_ = Corpus.from_file("book-excerpts")
     for pp in (LowercaseTransformer(), RegexpTokenizer(r"\w+"),
-               StopwordsFilter("English"), FrequencyFilter(0.1)):
+               StopwordsFilter("en"), FrequencyFilter(0.1)):
         corpus_ = pp(corpus_)
 
     transformed_corpus = BowVectorizer().transform(corpus_)

--- a/orangecontrib/text/keywords/__init__.py
+++ b/orangecontrib/text/keywords/__init__.py
@@ -15,12 +15,16 @@ from Orange.util import dummy_callback
 from orangecontrib.text import Corpus
 from orangecontrib.text.keywords.mbert import mbert_keywords
 from orangecontrib.text.keywords.rake import Rake
+from orangecontrib.text.language import ISO2LANG
 from orangecontrib.text.preprocess import StopwordsFilter
 
 # all available languages for RAKE
 from orangecontrib.text.vectorization import BowVectorizer
 
-RAKE_LANGUAGES = StopwordsFilter.supported_languages()
+
+# todo: refactor when refactoring language for keywords module
+# this is a temporary solution since supported_languages now returns lang ISO codes
+RAKE_LANGUAGES = [ISO2LANG[la] for la in StopwordsFilter.supported_languages()]
 # all available languages for YAKE!
 YAKE_LANGUAGE_MAPPING = {
     "Arabic": "ar",

--- a/orangecontrib/text/language.py
+++ b/orangecontrib/text/language.py
@@ -46,6 +46,9 @@ ISO2LANG = {
     "he": "Hebrew",
     "hi": "Hindi",
     "hi-Latn": "Hindi (latin)",
+    # https://en.wikipedia.org/wiki/Hinglish - since it doesn't really have ISO
+    # code we made one up to be able to used it for stopwords (supported in NLTK)
+    "hi_eng": "Hinglish",
     "hr": "Croatian",
     "ht": "Haitian",
     "hu": "Hungarian",

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -15,9 +15,17 @@ import numpy as np
 
 from orangecontrib.text import preprocess, tag
 from orangecontrib.text.corpus import Corpus
-from orangecontrib.text.preprocess import BASE_TOKENIZER, PreprocessorList
-from orangecontrib.text.preprocess.normalize import file_to_language, \
-    file_to_name, language_to_name, UDPipeModels
+from orangecontrib.text.preprocess import (
+    BASE_TOKENIZER,
+    PreprocessorList,
+    StopwordsFilter,
+)
+from orangecontrib.text.preprocess.normalize import (
+    file_to_language,
+    file_to_name,
+    language_to_name,
+    UDPipeModels,
+)
 
 
 SF_LIST = "orangecontrib.text.preprocess.normalize.serverfiles.ServerFiles.listfiles"
@@ -430,7 +438,7 @@ class FilteringTests(unittest.TestCase):
         self.assertEqual(filtered, ['a'])
 
     def test_stopwords(self):
-        f = preprocess.StopwordsFilter('english')
+        f = preprocess.StopwordsFilter("en")
         self.assertFalse(f._check('a'))
         self.assertTrue(f._check('filter'))
         with self.corpus.unlocked():
@@ -440,7 +448,7 @@ class FilteringTests(unittest.TestCase):
         self.assertEqual(len(corpus.used_preprocessor.preprocessors), 2)
 
     def test_stopwords_slovene(self):
-        f = preprocess.StopwordsFilter('slovene')
+        f = preprocess.StopwordsFilter("sl")
         self.assertFalse(f._check('in'))
         self.assertTrue(f._check('abeceda'))
         with self.corpus.unlocked():
@@ -448,6 +456,22 @@ class FilteringTests(unittest.TestCase):
         corpus = f(self.corpus)
         self.assertListEqual(["kača", "hiši"], corpus.tokens[0])
         self.assertEqual(len(corpus.used_preprocessor.preprocessors), 2)
+
+    def test_supported_languages(self):
+        langs = preprocess.StopwordsFilter.supported_languages()
+        self.assertIsInstance(langs, set)
+        # just testing few of most important languages since I want for test to be
+        # resistant for any potentially newly introduced languages by NLTK
+        self.assertIn("en", langs)
+        self.assertIn("sl", langs)
+        self.assertIn("fr", langs)
+        self.assertIn("sv", langs)
+        self.assertIn("fi", langs)
+        self.assertIn("de", langs)
+
+    def test_lang_to_iso(self):
+        self.assertEqual("en", StopwordsFilter.lang_to_iso("English"))
+        self.assertEqual("sl", StopwordsFilter.lang_to_iso("Slovene"))
 
     def test_lexicon(self):
         f = tempfile.NamedTemporaryFile(delete=False)

--- a/orangecontrib/text/widgets/owannotator.py
+++ b/orangecontrib/text/widgets/owannotator.py
@@ -618,7 +618,7 @@ if __name__ == "__main__":
 
     corpus_ = Corpus.from_file("book-excerpts")
     for pp in (LowercaseTransformer(), RegexpTokenizer(r"\w+"),
-               StopwordsFilter("English"), FrequencyFilter(0.1)):
+               StopwordsFilter("en"), FrequencyFilter(0.1)):
         corpus_ = pp(corpus_)
 
     transformed_corpus = BowVectorizer().transform(corpus_)

--- a/orangecontrib/text/widgets/tests/test_owannotator.py
+++ b/orangecontrib/text/widgets/tests/test_owannotator.py
@@ -21,7 +21,7 @@ from orangecontrib.text.widgets.owannotator import OWAnnotator
 
 def preprocess(corpus: Corpus) -> Corpus:
     for pp in (LowercaseTransformer(), RegexpTokenizer(r"\w+"),
-               StopwordsFilter("English"), FrequencyFilter(0.25, 0.5)):
+               StopwordsFilter("en"), FrequencyFilter(0.25, 0.5)):
         corpus = pp(corpus)
     corpus = BowVectorizer().transform(corpus)
     return add_embedding(corpus, 4)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description if the issue does not exist. -->
This PR is part of #963, which I am splitting into smaller pieces for easier review. 
The main motivation behind this is to make Preprocess work with language from Corpus.

##### Description of changes
This PR prepare a stop word filter to communicate (get and return languages) as ISO codes, which is necessary to enable language from Corpus (languages are stored in Corpus in ISO format). 

After I changed Stop Word to work with ISO language codes, I also had to adapt the Preprocess Widget to store settings as ISO codes and call the StopWords filter with ISO language code.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
