### PR TITLE
[ENH] Lemmagen - Use ISO language codes

### DIFF
--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -342,14 +342,21 @@ class TokenNormalizerTests(unittest.TestCase):
         )
 
     def test_lemmagen(self):
-        normalizer = preprocess.LemmagenLemmatizer('Slovenian')
-        sentence = 'Gori na gori hiša gori'
+        normalizer = preprocess.LemmagenLemmatizer("sl")
+        sentence = "Gori na gori hiša gori"
         with self.corpus.unlocked():
             self.corpus.metas[0, 0] = sentence
         self.assertEqual(
             [Lemmatizer("sl").lemmatize(t) for t in sentence.split()],
             normalizer(self.corpus).tokens[0],
         )
+
+    def test_lemmagen_all_langs(self):
+        for language in preprocess.LemmagenLemmatizer.supported_languages:
+            normalizer = preprocess.LemmagenLemmatizer(language)
+            tokens = normalizer(self.corpus).tokens
+            self.assertEqual(len(self.corpus), len(tokens))
+            self.assertTrue(all(tokens))
 
     def test_normalizers_picklable(self):
         """ Normalizers must be picklable, tests if it is true"""


### PR DESCRIPTION
##### Issue
This PR is part of https://github.com/biolab/orange3-text/pull/963, which I am splitting into smaller pieces for easier review.
The main motivation behind this is to make Preprocess work with language from Corpus.

##### Description of changes
This PR prepare a Lemmagen normalizer to communicate (get and return languages) as ISO codes, which is necessary to enable language from Corpus (languages are stored in Corpus in ISO format).

After I changed Lemmagen to work with ISO language codes, I also had to adapt the Preprocess Widget to store settings as ISO codes and call the Lemmagen filter with ISO language code.

Udpipe and Snowball will be implemented in separate PRs.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
