### PR TITLE
Corpus - Remove dictionary

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -382,17 +382,13 @@ class Corpus(Table):
         return [' '.join(f.str_val(val) for f, val in zip(data.domain.metas, row))
                 for row in data.metas]
 
-    def store_tokens(self, tokens, dictionary=None):
+    def store_tokens(self, tokens: List):
         """
-        Args:
-            tokens (list): List of lists containing tokens.
+        Parameters
+        ----------
+        tokens
+            List of lists containing tokens.
         """
-        if dictionary is not None:
-            warn(
-                "dictionary argument is deprecated and doesn't have effect."
-                "It will be removed in future orange3-text 1.15.",
-                FutureWarning,
-            )
         self._tokens = np.array(tokens, dtype=object)
 
     @property
@@ -417,14 +413,6 @@ class Corpus(Table):
         base_preprocessors = PreprocessorList([BASE_TRANSFORMER, BASE_TOKENIZER])
         corpus = base_preprocessors(self)
         return corpus.tokens
-
-    @property
-    def dictionary(self):
-        warn(
-            "dictionary is deprecated and will be removed in Orange3-text 1.15",
-            FutureWarning,
-        )
-        return corpora.Dictionary(self.tokens)
 
     @property
     def pos_tags(self):

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -723,15 +723,6 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(5, corpus[:2].count_unique_tokens())
         self.assertEqual(2, corpus[:1].count_unique_tokens())
 
-    def test_remove_dictionary(self):
-        """
-        When this test starts to fail remove:
-        - this test
-        - dictionary property from Corpus
-        - dictionary argument from Corpus.store_tokens
-        """
-        self.assertFalse(orangecontrib.text.__version__.startswith("1.16"))
-
 
 class TestCorpusSummaries(unittest.TestCase):
     def test_corpus_not_preprocessed(self):


### PR DESCRIPTION
##### Issue
The test warning about the dictionary needing to be removed started to fail.

##### Description of changes
Remove the deprecated dictionary, which is not used anymore.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
