### PR TITLE
[ENH] Snowball - Use ISO language codes

### DIFF
--- a/orangecontrib/text/preprocess/normalize.py
+++ b/orangecontrib/text/preprocess/normalize.py
@@ -10,6 +10,7 @@ from Orange.misc.environ import data_dir
 from Orange.util import wrap_callback, dummy_callback
 
 from orangecontrib.text import Corpus
+from orangecontrib.text.language import LANG2ISO, ISO2LANG
 from orangecontrib.text.misc import wait_nltk_data
 from orangecontrib.text.preprocess import Preprocessor, TokenizedPreprocessor
 
@@ -71,12 +72,16 @@ class PorterStemmer(BaseNormalizer):
 
 class SnowballStemmer(BaseNormalizer):
     name = 'Snowball Stemmer'
-    supported_languages = [l.capitalize() for l in
-                           stem.SnowballStemmer.languages]
+    supported_languages = {
+        LANG2ISO[l.capitalize()]
+        for l in stem.SnowballStemmer.languages
+        # skip porter since not language but porter stemmer that we implement separately
+        if l != "porter"
+    }
 
-    def __init__(self, language='English'):
+    def __init__(self, language='en'):
         super().__init__()
-        self.normalizer = stem.SnowballStemmer(language.lower()).stem
+        self.normalizer = stem.SnowballStemmer(ISO2LANG[language].lower()).stem
 
 
 def language_to_name(language):

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -289,11 +289,18 @@ class TokenNormalizerTests(unittest.TestCase):
         self.assertEqual(stemmer._preprocess('token'), 'toke')
 
     def test_snowball(self):
-        stemmer = preprocess.SnowballStemmer('french')
+        stemmer = preprocess.SnowballStemmer('fr')
         token = 'voudrais'
         self.assertEqual(
             stemmer._preprocess(token),
             nltk.SnowballStemmer(language='french').stem(token))
+
+    def test_snowball_all_langs(self):
+        for language in preprocess.SnowballStemmer.supported_languages:
+            normalizer = preprocess.SnowballStemmer(language)
+            tokens = normalizer(self.corpus).tokens
+            self.assertEqual(len(self.corpus), len(tokens))
+            self.assertTrue(all(tokens))
 
     def test_udpipe(self):
         """Test udpipe token lemmatization"""

--- a/orangecontrib/text/widgets/tests/test_owpreprocess.py
+++ b/orangecontrib/text/widgets/tests/test_owpreprocess.py
@@ -205,7 +205,7 @@ class TestOWPreprocessMigrateSettings(WidgetTest):
                                    "udpipe_tokenizer": True}}
         widget = self.create_widget(OWPreprocess, stored_settings=settings)
         params = [("preprocess.normalize",
-                   {"method": 2, "snowball_language": "French",
+                   {"method": 2, "snowball_language": "fr",
                     "udpipe_language": "German", "udpipe_tokenizer": True})]
         self.assertEqual(widget.storedsettings["preprocessors"], params)
 
@@ -331,6 +331,32 @@ class TestOWPreprocessMigrateSettings(WidgetTest):
         widget = self.create_widget(OWPreprocess, stored_settings=settings)
         normalize_settings = widget.storedsettings["preprocessors"][0][1]
         self.assertEqual("en", normalize_settings["lemmagen_language"])
+
+    def test_migrate_snowball_language_settings(self):
+        """Test migration to iso langauge codes"""
+        settings = {
+            "__version__": 3,
+            "storedsettings": {
+                "preprocessors": [
+                    ("preprocess.normalize", {"snowball_language": "Swedish"}),
+                ]
+            },
+        }
+        widget = self.create_widget(OWPreprocess, stored_settings=settings)
+        normalize_settings = widget.storedsettings["preprocessors"][0][1]
+        self.assertEqual("sv", normalize_settings["snowball_language"])
+
+        settings = {
+            "__version__": 3,
+            "storedsettings": {
+                "preprocessors": [
+                    ("preprocess.normalize", {"snowball_language": "English"}),
+                ]
+            },
+        }
+        widget = self.create_widget(OWPreprocess, stored_settings=settings)
+        normalize_settings = widget.storedsettings["preprocessors"][0][1]
+        self.assertEqual("en", normalize_settings["snowball_language"])
 
 
 class TestTransformationModule(WidgetTest):
@@ -473,7 +499,7 @@ class TestNormalizationModule(WidgetTest):
     def test_parameters(self):
         params = {
             "method": NormalizationModule.Porter,
-            "snowball_language": "English",
+            "snowball_language": "en",
             "udpipe_language": "English",
             "lemmagen_language": "en",
             "udpipe_tokenizer": False,
@@ -483,7 +509,7 @@ class TestNormalizationModule(WidgetTest):
     def test_set_parameters(self):
         params = {
             "method": NormalizationModule.UDPipe,
-            "snowball_language": "Dutch",
+            "snowball_language": "nl",
             "udpipe_language": "Slovenian",
             "lemmagen_language": "bg",
             "udpipe_tokenizer": True,
@@ -504,8 +530,7 @@ class TestNormalizationModule(WidgetTest):
         self.assertIsInstance(pp, SnowballStemmer)
         self.assertIn("<EnglishStemmer>", str(pp.normalizer))
 
-        params = {"method": NormalizationModule.Snowball,
-                  "snowball_language": "Dutch"}
+        params = {"method": NormalizationModule.Snowball, "snowball_language": "nl"}
         pp = self.editor.createinstance(params)
         self.assertIsInstance(pp, SnowballStemmer)
         self.assertIn("<DutchStemmer>", str(pp.normalizer))


### PR DESCRIPTION
##### Issue

This PR is part of https://github.com/biolab/orange3-text/pull/963, which I am splitting into smaller pieces for easier review.

The main motivation behind this is to make Preprocess work with language from Corpus.

##### Description of changes

This PR prepare a Snowball normalizer to communicate (get and return languages) as ISO codes, which is necessary to enable language from Corpus (languages are stored in Corpus in ISO format).

After I changed Snowball to work with ISO language codes, I also had to adapt the Preprocess Widget to store settings as ISO codes and call the Lemmagen filter with ISO language code.

Udpipe will be implemented in separate PRs.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
