### PR TITLE
[ENH] UDPIPE - Use ISO language codes 

### DIFF
--- a/orangecontrib/text/language.py
+++ b/orangecontrib/text/language.py
@@ -41,7 +41,7 @@ ISO2LANG = {
     "ga": "Irish",
     "gl": "Galician",
     "got": "Gothic",
-    "grc": "Ancient greek",
+    "grc": "Ancient Greek",
     "gu": "Gujarati",
     "he": "Hebrew",
     "hi": "Hindi",


### PR DESCRIPTION
##### Issue

This PR is part of https://github.com/biolab/orange3-text/pull/963, which I am splitting into smaller pieces for easier review.

The primary motivation behind this is to make Preprocess work with language from Corpus.

##### Description of changes

This PR prepare a UDPIPE normalizer to communicate (get and return languages) as ISO codes, which is necessary to enable language from Corpus (languages are stored in Corpus in ISO format).

After I changed UDPIPE to work with ISO language codes, I also had to adapt the Preprocess Widget to store settings as ISO codes and call the Lemmagen filter with ISO language code.

This PR also slightly change the names of UDPIPE languages in the dropdown. The change is that the names of language variations (different models for the same language) are now written in parenthesis, and all words in the multi-word language are uppercase (to match ISO standard).

Udpipe will be implemented in separate PRs.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
