### PR TITLE
[ENH] Use ISO language setting in widgets

### DIFF
--- a/orangecontrib/text/widgets/tests/test_owcreatecorpus.py
+++ b/orangecontrib/text/widgets/tests/test_owcreatecorpus.py
@@ -207,6 +207,19 @@ class TestOWCreateCorpus(WidgetTest):
         corpus = self.get_output(self.widget.Outputs.corpus)
         self.assertEqual("am", corpus.language)
 
+    def test_migrate_settings(self):
+        settings = {"__version__": 1, "language": "French"}
+        widget = self.create_widget(OWCreateCorpus, stored_settings=settings)
+        self.assertEqual("fr", widget.language)
+
+        settings = {"__version__": 1, "language": "Ancient greek"}
+        widget = self.create_widget(OWCreateCorpus, stored_settings=settings)
+        self.assertEqual("grc", widget.language)
+
+        settings = {"__version__": 1, "language": None}
+        widget = self.create_widget(OWCreateCorpus, stored_settings=settings)
+        self.assertIsNone(widget.language)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
In the beginning, I was keeping language names in widget settings. It turned out it is better to keep languages as ISO codes since language names can change in the future (like we did with Ancient Greek), but ISO codes will probably not.

This 

##### Description of changes
- It should fix the issue reported in https://github.com/biolab/orange3-text/pull/1030
- Change the `Ancient greek` language to `Ancient Greek` to be compatible with other languages (and compatible with ISO standards).
- Keep languages as ISO codes in settings to bypass problems with language name changes and easier management.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
