### PR TITLE
Word List: Add option to copy a list

### DIFF
--- a/orangecontrib/text/widgets/owwordlist.py
+++ b/orangecontrib/text/widgets/owwordlist.py
@@ -240,6 +240,11 @@ class OWWordList(OWWidget):
         action.triggered.connect(self.__on_remove_word_list)
         actions_widget.addAction(action)
 
+        action = QAction("C", self)
+        action.setToolTip("Copy word list from library")
+        action.triggered.connect(self.__on_copy_word_list)
+        actions_widget.addAction(action)
+
         action = QAction("Update", self)
         action.setToolTip("Save changes in the editor to library")
         action.setShortcut(QKeySequence(QKeySequence.Save))
@@ -278,7 +283,7 @@ class OWWordList(OWWidget):
     def __on_add_word_list(self):
         taken = [l.name for l in self.library_model]
         name = WordList.generate_word_list_name(taken)
-        word_list = WordList(name, self.words_model[:])
+        word_list = WordList(name, [])
         self.library_model.append(word_list)
         self._set_selected_word_list(len(self.library_model) - 1)
 
@@ -288,6 +293,15 @@ class OWWordList(OWWidget):
             del self.library_model[index]
             self._set_selected_word_list(max(index - 1, 0))
             self._apply_update_rule()
+
+    def __on_copy_word_list(self):
+        index = self._get_selected_word_list_index()
+        if index is not None:
+            taken = [l.name for l in self.library_model]
+            name = WordList.generate_word_list_name(taken)
+            word_list = WordList(name, self.words_model[:])
+            self.library_model.append(word_list)
+            self._set_selected_word_list(len(self.library_model) - 1)
 
     def __on_update_word_list(self):
         self._set_word_list_modified(mod_type=self.LIBRARY)

--- a/orangecontrib/text/widgets/tests/test_owwordlist.py
+++ b/orangecontrib/text/widgets/tests/test_owwordlist.py
@@ -157,7 +157,7 @@ class TestOWWordList(WidgetTest):
         sel_words = self.widget._get_selected_words_indices()
         self.assertEqual(sel_wlist, 2)
         self.assertListEqual(sel_words, [])
-        self.assertListEqual(self.widget.words_model[:], self._word_list_1)
+        self.assertListEqual(self.widget.words_model[:], [])
 
         self.widget._set_selected_word_list(1)
         self.assertListEqual(self.widget.words_model[:], self._word_list_2)
@@ -178,6 +178,17 @@ class TestOWWordList(WidgetTest):
         sel_words = self.widget._get_selected_words_indices()
         self.assertIsNone(sel_wlist, 0)
         self.assertListEqual(sel_words, [])
+
+    def test_library_copy(self):
+        self.assertEqual(self.widget.library_model.rowCount(), 2)
+        self.widget._OWWordList__on_copy_word_list()
+        self.assertEqual(self.widget.library_model.rowCount(), 3)
+        self.assertEqual(self.widget.words_model.rowCount(), 3)
+        settings = self.widget.settingsHandler.pack_data(self.widget)
+        self.assertEqual(settings["word_list_library"][0]["words"],
+                         settings["word_list_library"][2]["words"])
+        self.assertNotEqual(settings["word_list_library"][1]["words"],
+                            settings["word_list_library"][2]["words"])
 
     def test_library_update(self):
         self.assertEqual(self.widget._get_selected_word_list_index(), 0)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Currently, adding a list copied entries from a previous list. This is counterintuitive. Add a separate option to copy a list.

##### Description of changes
Adding a new list now adds an empty list.
Another button is added with the option to copy an existing list.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
