### PR TITLE
[FIX] Preprocess - Replace deprecated pkg_resources

### DIFF
--- a/orangecontrib/text/widgets/owpreprocess.py
+++ b/orangecontrib/text/widgets/owpreprocess.py
@@ -2,7 +2,6 @@ from typing import Dict, Optional, List, Callable, Tuple, Type, Union, Iterable
 from types import SimpleNamespace
 import os
 import random
-import pkg_resources
 
 from AnyQt.QtCore import Qt, pyqtSignal, QModelIndex
 from AnyQt.QtWidgets import QComboBox, QButtonGroup, QLabel, QCheckBox, \
@@ -35,7 +34,7 @@ _DEFAULT_NONE = "(none)"
 
 
 def icon_path(basename):
-    return pkg_resources.resource_filename(__name__, "icons/" + basename)
+    return os.path.join(os.path.dirname(__file__), "icons", basename)
 
 
 class Result(SimpleNamespace):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`pkg_resources` is deprecated

##### Description of changes
Replacing pkg_resources with `os.path`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
