### PR TITLE
Monkey-patch scipy.linalg.triu for gensim

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -19,6 +19,14 @@ from Orange.data import (
 )
 from Orange.preprocess.transformation import Identity
 from Orange.data.util import get_unique_names
+
+# Gensim is 4.3.2 is incompatible with scipy 1.3, where they removed triu/
+# thus hack what it is missing here it.
+# Remove this section after we depend on newer gensim
+import scipy.linalg
+if "triu" not in scipy.linalg.__dict__:
+    scipy.linalg.triu = np.triu
+
 from gensim import corpora
 from orangewidget.utils.signals import summarize, PartialSummary
 import scipy.sparse as sp

--- a/orangecontrib/text/tests/test_corpus.py
+++ b/orangecontrib/text/tests/test_corpus.py
@@ -27,6 +27,18 @@ from orangecontrib.text.preprocess import (
 from orangecontrib.text.tag import AveragedPerceptronTagger
 
 
+class ImportHack(unittest.TestCase):
+
+    def test_perhaps_remove_gensim_hack(self):
+        now = datetime.now()
+        if (now.year, now.month) >= (2024, 7):
+            self.fail(
+                "Check if gensim newer than 4.3.2 is available; if so, add it "
+                "to requirements, remove the scipy monkey-patch in corpus.py "
+                "and this test."
+            )
+
+
 class CorpusTests(unittest.TestCase):
     def setUp(self):
         self.pos_tagger = AveragedPerceptronTagger()


### PR DESCRIPTION
##### Issue
Fixes #1059, also see #1058 for failure. 

##### Description of changes
Because we can not expect gensim to release anytime soon, monkey patch scipy.linalg.triu when not available.
