### PR TITLE
Statistics: Fix ComputeValue.__eq__

### DIFF
--- a/orangecontrib/text/widgets/owstatistics.py
+++ b/orangecontrib/text/widgets/owstatistics.py
@@ -408,7 +408,8 @@ class ComputeValue:
         return self.function(data, self.pattern, self.source, lambda: True)[0]
 
     def __eq__(self, other):
-        return self.function == other.function and self.pattern == other.pattern
+        return type(self) is type(other) and self.function == other.function \
+            and self.pattern == other.pattern
 
     def __hash__(self):
         return hash((self.function, self.pattern))

--- a/orangecontrib/text/widgets/tests/test_owstatistics.py
+++ b/orangecontrib/text/widgets/tests/test_owstatistics.py
@@ -4,6 +4,7 @@ import numpy as np
 from AnyQt.QtWidgets import QPushButton
 
 from Orange.data import Domain, StringVariable
+from Orange.preprocess import SklImpute
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate
 from orangecontrib.text import Corpus
@@ -520,6 +521,12 @@ class TestStatisticsWidget(WidgetTest):
             (15, "", Sources.TOKENS),
         ]
         self.assertListEqual(expected, widget.active_rules)
+
+    def test_preprocess_output(self):
+        self.send_signal(self.widget.Inputs.corpus, self.corpus)
+        output = self.get_output(self.widget.Outputs.corpus)
+        imputed = SklImpute()(output)
+        self.assertIsNotNone(imputed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #1075

When comparing variables compute_value objects are not necessarily of the same type, but they should be, to be equal. 

##### Description of changes
Check object types in __eq__ method.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
