### PR TITLE
Update owcorpus.py

### DIFF
--- a/orangecontrib/text/widgets/owcorpus.py
+++ b/orangecontrib/text/widgets/owcorpus.py
@@ -374,9 +374,13 @@ class OWCorpus(OWWidget, ConcurrentWidgetMixin):
     def migrate_context(cls, context, version):
         if version < 2:
             if "language" in context.values:
-                language, type_ = context.values["language"]
-                language = LANG2ISO[migrate_language_name(language)]
-                context.values["language"] = (language, type_)
+                try:
+                    language, type_ = context.values["language"]
+                    language = LANG2ISO[migrate_language_name(language)]
+                    context.values["language"] = (language, type_)
+                except Exception as e:
+                    print("unable to load laguage :",e)
+                    return
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
if you create an ows file containing a corpus on one computer and open it on another, it happens that the second PC does not find the language and displays an error message in a loop. This PR allows you to load the workflow on the second PC.

if language not found continu

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
