### PR TITLE
Import Documents: add options for meta matching in CoNLL-U

### DIFF
--- a/orangecontrib/text/import_documents.py
+++ b/orangecontrib/text/import_documents.py
@@ -335,7 +335,7 @@ class ConlluReader(Reader):
 class ImportDocuments:
     META_DATA_FILE_KEY = "Text file"
     # this is what we will merge meta data on, change to user-set variable
-    CONLLU_META_DATA = "ID"
+    CONLLU_META_DATA = ["ID", "Text_ID"]
 
     def __init__(
         self,
@@ -513,13 +513,17 @@ class ImportDocuments:
             or self._meta_data is None
             or (
                 self.META_DATA_FILE_KEY not in self._meta_data.columns
-                and self.CONLLU_META_DATA not in self._meta_data.columns
+                and not any(i in self._meta_data.columns for i in
+                         self.CONLLU_META_DATA)
             )
         ):
             return corpus
 
         if self.is_conllu:
-            df = self._meta_data.set_index(self.CONLLU_META_DATA)
+            # find the first matching column
+            match_id = next((idx for idx in self.CONLLU_META_DATA if idx in
+                             self._meta_data.columns))
+            df = self._meta_data.set_index(match_id)
             path_column = corpus.get_column("utterance")
         else:
             df = self._meta_data.set_index(

--- a/orangecontrib/text/tests/test_import_documents.py
+++ b/orangecontrib/text/tests/test_import_documents.py
@@ -247,6 +247,8 @@ class TestImportDocuments(unittest.TestCase):
         self.assertEqual(len(corpus), len(lemma))
         self.assertEqual(len(corpus), len(pos))
         self.assertEqual(len(corpus), len(ner))
+        self.assertTrue(np.any(~np.isnan(corpus.get_column(
+            "Speaker_birth"))))
 
     @patch(SF_LIST, return_value=SPECIAL_CHAR_FILES)
     @patch(PATCH_METHOD, side_effect=ConnectTimeout("test message", request=""))

--- a/orangecontrib/text/widgets/tests/data/conllu/ParlaMint01-meta.tsv
+++ b/orangecontrib/text/widgets/tests/data/conllu/ParlaMint01-meta.tsv
@@ -1,0 +1,3 @@
+ID	Title	From	To	House	Term	Session	Meeting	Sitting	Agenda	Subcorpus	Speaker_role	Speaker_type	Speaker_party	Speaker_party_name	Party_status	Speaker_name	Speaker_gender	Speaker_birth
+ParlaMint-SI_2014-08-01-SDZ7-Redna-01.u1	Minutes of the National Assembly of the Republic of Slovenia, Term 7, Regular Session 1, 1.8.2014	2014-08-01	2014-08-01	Lower house	7		1			Reference	Chairperson	MP	DeSUS	Demokratična stranka upokojencev Slovenije		Kotnik Poropat, Marjana	F	1944
+ParlaMint-SI_2014-08-01-SDZ7-Redna-01.u2	Minutes of the National Assembly of the Republic of Slovenia, Term 7, Regular Session 1, 1.8.2014	2014-08-01	2014-08-01	Lower house	7		1			Reference	Regular	MP	SD	Socialni demokrati		Veber, Janko	M	1960

--- a/orangecontrib/text/widgets/tests/data/conllu/ParlaMint02-meta.tsv
+++ b/orangecontrib/text/widgets/tests/data/conllu/ParlaMint02-meta.tsv
@@ -1,0 +1,4 @@
+ID	Title	From	To	House	Term	Session	Meeting	Sitting	Agenda	Subcorpus	Speaker_role	Speaker_type	Speaker_party	Speaker_party_name	Party_status	Speaker_name	Speaker_gender	Speaker_birth
+ParlaMint-SI_2014-08-25-SDZ7-Izredna-01.u1	Minutes of the National Assembly of the Republic of Slovenia, Term 7, Extraordinary Session 1, 25.8.2014	2014-08-25	2014-08-25	Lower house	7		1			Reference	Chairperson	MP	SMC	Stranka Mira Cerarja		Brglez, Milan	M	1967
+ParlaMint-SI_2014-08-25-SDZ7-Izredna-01.u2	Minutes of the National Assembly of the Republic of Slovenia, Term 7, Extraordinary Session 1, 25.8.2014	2014-08-25	2014-08-25	Lower house	7		1			Reference	Chairperson	MP	SMC	Stranka Mira Cerarja		Brglez, Milan	M	1967
+ParlaMint-SI_2014-08-25-SDZ7-Izredna-01.u3	Minutes of the National Assembly of the Republic of Slovenia, Term 7, Extraordinary Session 1, 25.8.2014	2014-08-25	2014-08-25	Lower house	7		1			Reference	Regular	MP	SD	Socialni demokrati		Židan, Dejan	M	1967


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
CoNLL-U files were only matched by "Text_ID". However, sometimes the data should be matched by "ID".

##### Description of changes
This is only a workaround, until we figure out how could the user define the proper column for joining metas to corpus.
Please, can someone comment on the tests?

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
