### PR TITLE
[FIX] Corpus viewer: warn on bad regex

### DIFF
--- a/orangecontrib/text/widgets/owcorpusviewer.py
+++ b/orangecontrib/text/widgets/owcorpusviewer.py
@@ -133,11 +133,10 @@ def _count_matches(content: List[str], regex: re.Pattern, state: TaskState) -> i
     Number of all matches of search_string in all texts in content list
     """
     matches = 0
-    if regex:
-        if regex.pattern:
-            for i, text in enumerate(content):
-                matches += len(regex.findall(text))
-                state.set_progress_value((i + 1) / len(content) * 100)
+    if regex.pattern:
+        for i, text in enumerate(content):
+            matches += len(regex.findall(text))
+            state.set_progress_value((i + 1) / len(content) * 100)
     return matches
 
 
@@ -605,14 +604,19 @@ class OWCorpusViewer(OWWidget, ConcurrentWidgetMixin):
             self.update_info()
             try:
                 self.compiled_regex = re.compile(self.regexp_filter.strip("|"), re.IGNORECASE)
+                self.start(
+                    _count_matches,
+                    self.doc_list_model.get_filter_content(),
+                    self.compiled_regex,
+                )
             except re.error:
                 self.Error.invalid_regex()
-                self.compiled_regex = None
-            self.start(
-                _count_matches,
-                self.doc_list_model.get_filter_content(),
-                self.compiled_regex,
-            )
+                self.compiled_regex = None 
+                self.n_matching = "n/a"
+                self.n_matches = "n/a"
+                self.n_tokens = "n/a"
+                self.n_types = "n/a"
+                
             self.show_docs()
             self.commit.deferred()
 

--- a/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
@@ -146,7 +146,7 @@ class TestCorpusViewerWidget(WidgetTest):
         self.widget.regexp_filter = "*"
         self.widget.refresh_search()
         self.process_events()
-        self.assertEqual(self.widget.n_matches, 0)
+        self.assertEqual(self.widget.n_matches, "n/a")
         self.assertTrue(self.widget.Error.invalid_regex.is_shown())
         # Error is hidden when valid regex is entered
         self.widget.regexp_filter = "graph"

--- a/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
@@ -140,6 +140,20 @@ class TestCorpusViewerWidget(WidgetTest):
         self.wait_until_finished()
         self.assertEqual(self.widget.n_matches, 0)
 
+    def test_invalid_regex(self):
+        # Error is shown when invalid regex is entered
+        self.send_signal(self.widget.Inputs.corpus, self.corpus)
+        self.widget.regexp_filter = "*"
+        self.widget.refresh_search()
+        self.process_events()
+        self.assertEqual(self.widget.n_matches, 0)
+        self.assertTrue(self.widget.Error.invalid_regex.is_shown())
+        # Error is hidden when valid regex is entered
+        self.widget.regexp_filter = "graph"
+        self.widget.refresh_search()
+        self.process_events()
+        self.assertFalse(self.widget.Error.invalid_regex.is_shown())      
+   
     def test_highlighting(self):
         self.send_signal(self.widget.Inputs.corpus, self.corpus)
         # no intersection between filter and selection


### PR DESCRIPTION
##### Issue
Fixes #1068 


##### Description of changes
Instead of crashing, a warning message is thrown on bad regex.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
