### PR TITLE
Fix import documents widget tests for new metadata handling

### DIFF
--- a/orangecontrib/text/tests/test_twitter.py
+++ b/orangecontrib/text/tests/test_twitter.py
@@ -233,7 +233,7 @@ class TestTwitterAPI(unittest.TestCase):
         user_mock.return_value = MagicMock(data=MagicMock(id=1))
 
         self.client.search_authors(["orange"])
-        user_mock.called_with(username="orange")
+        user_mock.assert_called_with(username="orange")
         self.assert_author_query(mock, 1)
         user_mock.reset_mock()
 

--- a/orangecontrib/text/widgets/tests/test_owcollocations.py
+++ b/orangecontrib/text/widgets/tests/test_owcollocations.py
@@ -1,9 +1,7 @@
 import unittest
-from distutils.version import LooseVersion
 
 from AnyQt.QtCore import Qt
 
-import Orange
 from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.text import Corpus

--- a/orangecontrib/text/widgets/tests/test_owimportdocuments.py
+++ b/orangecontrib/text/widgets/tests/test_owimportdocuments.py
@@ -99,7 +99,7 @@ class TestOWImportDocuments(WidgetTest):
         # check named entities are on the output
         self.widget.controls.ner_cb.setChecked(True)
         corpus = self.get_output(self.widget.Outputs.data)
-        self.assertEqual(len(corpus.domain.metas), 5)
+        self.assertEqual(len(corpus.domain.metas), 23)
         # check only corpus is on the output when all boxes unchecked
         self.widget.controls.lemma_cb.setChecked(False)
         self.widget.controls.pos_cb.setChecked(False)
@@ -107,7 +107,7 @@ class TestOWImportDocuments(WidgetTest):
         corpus = self.get_output(self.widget.Outputs.data)
         self.assertFalse(corpus.has_tokens())
         self.assertIsNone(corpus.pos_tags)
-        self.assertEqual(len(corpus.domain.metas), 4)
+        self.assertEqual(len(corpus.domain.metas), 22)
 
     def test_info_box(self):
         self.assertEqual("5 documents, 1 skipped", self.widget.info_area.text())

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,9 @@ lemmagen3
 nltk>=3.9.1
 numpy
 odfpy>=1.3.5
-Orange3 >=3.35.0
-orange-widget-base >=4.20.0
-orange-canvas-core
+Orange3 >=3.38.1
+orange-widget-base >=4.25.0
+orange-canvas-core >=0.2.5
 owlready2
 pandas
 pypdf

--- a/tox.ini
+++ b/tox.ini
@@ -24,10 +24,10 @@ setenv =
 deps =
     {env:PYQT_PYPI_NAME:PyQt5}=={env:PYQT_PYPI_VERSION:5.15.*}
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
-    oldest: scikit-learn==1.1.0
-    oldest: orange3==3.35.0
-    oldest: orange-canvas-core==0.1.30
-    oldest: orange-widget-base==4.20.0
+    oldest: scikit-learn==1.5.1
+    oldest: orange3==3.38.1
+    oldest: orange-canvas-core==0.2.5
+    oldest: orange-widget-base==4.25.0
     oldest: pandas==1.4.0
     oldest: nltk==3.9.1
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3


### PR DESCRIPTION
This also solves Python 3.12 compat problems and requires Orange3 3.38.1 for httpx compat fix