### PR TITLE
Update language.py to add Albanian

### DIFF
--- a/orangecontrib/text/language.py
+++ b/orangecontrib/text/language.py
@@ -12,6 +12,7 @@ from orangewidget.utils.itemmodels import PyListModel
 # normalizers, embedding
 ISO2LANG = {
     "af": "Afrikaans",
+    "al": "Albanian",    
     "am": "Amharic",
     "ar": "Arabic",
     "az": "Azerbaijani",


### PR DESCRIPTION
NLTK stopword corpus now includes Albanian.  Without this entry, StopwordsFilter.supported_languages returns an empty set.
