### PR TITLE
adding logic to handle new nltk languages

### DIFF
--- a/orangecontrib/text/keywords/__init__.py
+++ b/orangecontrib/text/keywords/__init__.py
@@ -30,6 +30,8 @@ YAKE_LANGUAGES = [
 ]
 # fmt: on
 
+def get_rake_languages():
+    return StopwordsFilter.supported_languages()
 
 def tfidf_keywords(
     corpus: Corpus, progress_callback: Callable = None

--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -115,7 +115,11 @@ class StopwordsFilter(BaseTokenFilter, FileWordListMixin):
         -------
         ISO language code for input language
         """
-        return LANG2ISO[StopwordsFilter.NLTK2LANG.get(language, language)]
+        try:
+            return LANG2ISO[StopwordsFilter.NLTK2LANG.get(language, language)]
+        except LookupError:
+            print ('Missing language in ISO2LANG: '+language)
+            return ('None')
 
     @classmethod
     @property
@@ -128,14 +132,13 @@ class StopwordsFilter(BaseTokenFilter, FileWordListMixin):
         -------
         Set of all languages supported by NLTK
         """
-        try:
-            return {
-                StopwordsFilter.lang_to_iso(file.title())
-                for file in os.listdir(stopwords._get_root())
-                if file.islower()
-            }
-        except LookupError:  # when no NLTK data is available
-            return set()
+        languages_list = {
+            StopwordsFilter.lang_to_iso(file.title())
+            for file in os.listdir(stopwords._get_root())
+            if file.islower()
+        }
+        languages_list = {element for element in languages_list if "None" not in element}
+        return languages_list
 
     def _check(self, token):
         return token not in self.__stopwords and token not in self._lexicon

--- a/orangecontrib/text/widgets/owkeywords.py
+++ b/orangecontrib/text/widgets/owkeywords.py
@@ -22,7 +22,7 @@ from Orange.widgets.widget import Input, Output, OWWidget, Msg
 
 from orangecontrib.text import Corpus
 from orangecontrib.text.keywords import ScoringMethods, AggregationMethods, \
-    YAKE_LANGUAGES, RAKE_LANGUAGES
+    YAKE_LANGUAGES, RAKE_LANGUAGES, get_rake_languages
 from orangecontrib.text.language import LanguageModel
 from orangecontrib.text.preprocess import BaseNormalizer
 from orangecontrib.text.widgets.utils.words import create_words_table, \
@@ -260,6 +260,7 @@ class OWKeywords(OWWidget, ConcurrentWidgetMixin):
             model=LanguageModel(include_none=False, languages=YAKE_LANGUAGES),
             callback=self.__on_yake_lang_changed
         )
+        RAKE_LANGUAGES = get_rake_languages()
         rake_cb = gui.comboBox(
             self.controlArea,
             self,


### PR DESCRIPTION
##### Issue

When new languages appear in NLTK, the Orange3 Text widgets encounter an exception and provide a blank language list.
See issues: 
https://github.com/biolab/orange3-text/issues/1099

See previous pull request:
https://github.com/biolab/orange3-text/pull/1102

##### Description of changes
Added try-catch inside of lang_to_iso instead of around it in  supported_languages.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
