### PR TITLE
[FIX] Add Albanian to dictionary of languages

### DIFF
--- a/orangecontrib/text/language.py
+++ b/orangecontrib/text/language.py
@@ -87,6 +87,7 @@ ISO2LANG = {
     "si": "Sinhala",
     "sk": "Slovak",
     "sl": "Slovenian",
+    "sq": "Albanian",
     "sr": "Serbian",
     "sv": "Swedish",
     "ta": "Tamil",

--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -101,7 +101,7 @@ class StopwordsFilter(BaseTokenFilter, FileWordListMixin):
             self.__stopwords = set(x.strip() for x in stopwords.words(language))
 
     @staticmethod
-    def lang_to_iso(language: str) -> str:
+    def lang_to_iso(language: str) -> str | None:
         """
         Returns the ISO language code for the NLTK language. NLTK have a different name
         for Slovenian. This function takes it into account while transforming to ISO.
@@ -110,12 +110,11 @@ class StopwordsFilter(BaseTokenFilter, FileWordListMixin):
         ----------
         language
             NLTK language name
-
         Returns
         -------
-        ISO language code for input language
+        ISO language code for input language, return None if language is not supported.
         """
-        return LANG2ISO[StopwordsFilter.NLTK2LANG.get(language, language)]
+        return LANG2ISO.get(StopwordsFilter.NLTK2LANG.get(language, language))
 
     @classmethod
     @property
@@ -133,7 +132,7 @@ class StopwordsFilter(BaseTokenFilter, FileWordListMixin):
                 StopwordsFilter.lang_to_iso(file.title())
                 for file in os.listdir(stopwords._get_root())
                 if file.islower()
-            }
+            } - {None}
         except LookupError:  # when no NLTK data is available
             return set()
 

--- a/orangecontrib/text/tests/test_preprocess.py
+++ b/orangecontrib/text/tests/test_preprocess.py
@@ -10,6 +10,7 @@ from unittest.mock import patch, Mock
 import nltk
 from gensim import corpora
 from lemmagen3 import Lemmatizer
+from nltk.corpus import stopwords
 from requests.exceptions import ConnectionError
 import numpy as np
 
@@ -496,6 +497,7 @@ class FilteringTests(unittest.TestCase):
         self.assertIn("sv", langs)
         self.assertIn("fi", langs)
         self.assertIn("de", langs)
+        self.assertNotIn(None, langs)
 
     def test_lang_to_iso(self):
         self.assertEqual("en", StopwordsFilter.lang_to_iso("English"))
@@ -518,6 +520,18 @@ class FilteringTests(unittest.TestCase):
         self.assertEqual(["baz"], processed.tokens[0])
         f.close()
         os.unlink(f.name)
+
+    def test_langauge_missing(self):
+        """
+        When NLTK adds language that is not in dict of languages module
+        should raise an error. If this test fall add missing langauge to LANG2ISO
+        """
+        for file in os.listdir(stopwords._get_root()):
+            if file.islower():
+                self.assertIsNotNone(
+                    StopwordsFilter.lang_to_iso(file.title()),
+                    f"Missing language {file.title()} in StopwordsFilter.LANG2ISO"
+                )
 
     def test_lexicon(self):
         f = tempfile.NamedTemporaryFile(delete=False)

--- a/orangecontrib/text/widgets/tests/test_owcreatecorpus.py
+++ b/orangecontrib/text/widgets/tests/test_owcreatecorpus.py
@@ -205,7 +205,7 @@ class TestOWCreateCorpus(WidgetTest):
         combo = self.widget.controlArea.findChild(QComboBox)
         simulate.combobox_activate_index(combo, 2)
         corpus = self.get_output(self.widget.Outputs.corpus)
-        self.assertEqual("am", corpus.language)
+        self.assertEqual("sq", corpus.language)
 
     def test_migrate_settings(self):
         settings = {"__version__": 1, "language": "French"}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
NLTK added Albanian as one of the languages for stopwords. Fixes https://github.com/biolab/orange3-text/issues/1099

##### Description of changes
- Add Albanian to the dictionary of languages.
- Make sure that the next time NLTK adds a language module, it doesn't fail.
- Introduce a test that will warn about the new language.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
