### PR TITLE
[FIX] test_owsentimentanalysis - Fix path comparison in failing test

### DIFF
--- a/orangecontrib/text/widgets/tests/test_owsentimentanalysis.py
+++ b/orangecontrib/text/widgets/tests/test_owsentimentanalysis.py
@@ -168,7 +168,7 @@ class TestSentimentWidget(WidgetTest):
                                      "data/sentiment/pos.txt")
         self.widget._OWSentimentAnalysis__posfile_loader.add_path(pos_file_path)
         self.widget._OWSentimentAnalysis__posfile_loader._activate()
-        self.assertEqual(self.widget.pos_file, pos_file_path)
+        self.assertEqual(self.widget.pos_file, pos_file_path.replace("\\", "/"))
 
     def test_migrates_settings(self):
         settings = {"method_idx": 4}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The test fails on Windows where paths with \ and / are compared.

##### Description of changes
Fix the test by replacing \ with / before comparison.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
