### PR TITLE
language.py: Add Albanian

### DIFF
--- a/orangecontrib/text/language.py
+++ b/orangecontrib/text/language.py
@@ -11,6 +11,7 @@ from orangewidget.utils.itemmodels import PyListModel
 # language dependent methods: YAKE!, nltk - stopwords, sentiment methods,
 # normalizers, embedding
 ISO2LANG = {
+    "al": "Albanian",
     "af": "Afrikaans",
     "am": "Amharic",
     "ar": "Arabic",


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Since the recent addition of Albanian to NLTK, stopword list stopped working. I don't particularly like the fact that the entire list is empty, despite only Albanian missing, but here is a quick fix.

##### Description of changes
Add Albanian to the list.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
