### PR TITLE
Add privacy warning to Document Embedding widget (#1089)

### DIFF
--- a/orangecontrib/text/widgets/owcreatecorpus.py
+++ b/orangecontrib/text/widgets/owcreatecorpus.py
@@ -152,13 +152,19 @@ class OWCreateCorpus(OWWidget):
     @gui.deferred
     def commit(self):
         """Create a new corpus and output it"""
+        filtered_texts = [(title, text) for title, text in self.texts if text.strip()]
+
+        if not filtered_texts:
+            self.Outputs.corpus.send(None)
+            return
+
         doc_var = StringVariable("Document")
         title_var = StringVariable("Title")
         domain = Domain([], metas=[title_var, doc_var])
         corpus = Corpus.from_numpy(
             domain,
-            np.empty((len(self.texts), 0)),
-            metas=np.array(self.texts),
+            np.empty((len(filtered_texts), 0)),
+            metas=np.array(filtered_texts),
             text_features=[doc_var],
             language=self.language,
         )

--- a/orangecontrib/text/widgets/owdocumentembedding.py
+++ b/orangecontrib/text/widgets/owdocumentembedding.py
@@ -58,12 +58,21 @@ class OWDocumentEmbedding(OWBaseVectorizer):
     class Warning(OWWidget.Warning):
         unsuccessful_embeddings = Msg("Some embeddings were unsuccessful.")
 
+    class Information(OWWidget.Information):
+        privacy_warning = Msg(
+            "This widget sends documents to an external server. "
+            "Avoid using it with sensitive data."
+        )
+
     method: int = Setting(default=0)
     language: str = Setting(default=DEFAULT_LANGUAGE, schema_only=True)
     aggregator: str = Setting(default="Mean")
 
     def __init__(self):
         super().__init__()
+
+        self.Information.privacy_warning()
+
         self.cancel_button = QPushButton(
             "Cancel", icon=self.style().standardIcon(QStyle.SP_DialogCancelButton)
         )


### PR DESCRIPTION
### Privacy Warning Added
This PR adds an informational message to the Document Embedding widget, warning users that the widget sends documents to an external server (`api.garaza.io`).

Fixes issue #1089.

### Changes
- Added `self.Information.text = "..."` to `__init__()` of `OWDocumentEmbedding`.
- Message warns users to avoid embedding sensitive documents.