### PR TITLE
Add privacy warning to Document Embedding widget (#1089)

### DIFF
--- a/orangecontrib/text/widgets/owdocumentembedding.py
+++ b/orangecontrib/text/widgets/owdocumentembedding.py
@@ -58,12 +58,21 @@ class OWDocumentEmbedding(OWBaseVectorizer):
     class Warning(OWWidget.Warning):
         unsuccessful_embeddings = Msg("Some embeddings were unsuccessful.")
 
+    class Information(OWWidget.Information):
+        privacy_warning = Msg(
+            "This widget sends documents to an external server. "
+            "Avoid using it with sensitive data."
+        )
+
     method: int = Setting(default=0)
     language: str = Setting(default=DEFAULT_LANGUAGE, schema_only=True)
     aggregator: str = Setting(default="Mean")
 
     def __init__(self):
         super().__init__()
+
+        self.Information.privacy_warning()
+
         self.cancel_button = QPushButton(
             "Cancel", icon=self.style().standardIcon(QStyle.SP_DialogCancelButton)
         )


### PR DESCRIPTION
### Add Privacy Warning to Document Embedding Widget (#1089)

#### Issue  
Fixes #1089

#### Description of Changes  
This PR adds an informational message to the **Document Embedding** widget to inform users that the widget sends documents to an external server (`api.garaza.io`).  
The goal is to help users avoid submitting sensitive or private data unintentionally.

- Added `self.Information.privacy_warning()` to the widget’s `__init__` method.
- Shown message:  
  > *"This widget sends documents to an external server. Avoid using it with sensitive data."*

#### Includes  
- [x] Code changes  
- [ ] Tests  
- [ ] Documentation  
