### PR TITLE
Fix: Reduced decimal precision for topic metrics in Topic Modelling widget (#1073)

### DIFF
--- a/orangecontrib/text/widgets/owtopicmodeling.py
+++ b/orangecontrib/text/widgets/owtopicmodeling.py
@@ -276,7 +276,7 @@ class OWTopicModeling(OWWidget, ConcurrentWidgetMixin):
 
         if self.model.name == "Latent Dirichlet Allocation":
             bound = self.model.model.log_perplexity(infer_ngrams_corpus(corpus))
-            self.perplexity = "{:.5f}".format(np.exp2(-bound))
+            self.perplexity = "{:.2f}".format(np.exp2(-bound))
         else:
             self.perplexity = "n/a"
         # for small corpora it is slower to use more processes
@@ -291,7 +291,7 @@ class OWTopicModeling(OWWidget, ConcurrentWidgetMixin):
             processes=processes,
         )
         coherence = cm.get_coherence()
-        self.coherence = "{:.5f}".format(coherence)
+        self.coherence = "{:.2f}".format(coherence)
 
         self.Outputs.all_topics.send(self.model.get_all_topics_table())
 


### PR DESCRIPTION
##### Issue
Fixes #1073 – decimal precision for topic metrics was too high, leading to unnecessary detail in UI.

##### Description of changes
Changed the decimal formatting in the Topic Modelling widget:
- Reduced precision from 5 to 2 decimal places for:
  - **Log perplexity**
  - **Topic coherence**

Updated format strings from:
```python
"{:.5f}".format(...)
