### PR TITLE
Fix: Support relative file paths in Corpus widget (#534)

### DIFF
--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -1,3 +1,6 @@
+print("🧠 Uporabljam corpus.py iz: ", __file__)
+
+
 import os
 from collections import Counter, defaultdict
 from copy import copy
@@ -669,6 +672,8 @@ def summarize_corpus(corpus: Corpus) -> PartialSummary:
         if corpus.has_tokens()
         else "<br/><nobr>Corpus is not preprocessed</nobr>"
     )
-    language = ISO2LANG[corpus.language] if corpus.language else "not set"
+    print(">>> DEBUG: summarize_corpus() pokliče ISO2LANG z vrednostjo:", corpus.language)
+    # language = ISO2LANG[corpus.language] if corpus.language else "not set"
+    language = ISO2LANG.get(corpus.language, "not set")
     extras += f"<br/><nobr>Language: {language}</nobr>"
     return PartialSummary(table_summary.summary, table_summary.details + extras)

--- a/orangecontrib/text/corpus.py
+++ b/orangecontrib/text/corpus.py
@@ -1,6 +1,3 @@
-print("🧠 Uporabljam corpus.py iz: ", __file__)
-
-
 import os
 from collections import Counter, defaultdict
 from copy import copy
@@ -672,8 +669,6 @@ def summarize_corpus(corpus: Corpus) -> PartialSummary:
         if corpus.has_tokens()
         else "<br/><nobr>Corpus is not preprocessed</nobr>"
     )
-    print(">>> DEBUG: summarize_corpus() pokliče ISO2LANG z vrednostjo:", corpus.language)
-    # language = ISO2LANG[corpus.language] if corpus.language else "not set"
     language = ISO2LANG.get(corpus.language, "not set")
     extras += f"<br/><nobr>Language: {language}</nobr>"
     return PartialSummary(table_summary.summary, table_summary.details + extras)


### PR DESCRIPTION
#### Description

This PR addresses issue #534 by implementing proper support for saving and loading corpus file paths **relative** to the `.ows` workflow file. This ensures better **portability of workflows** when shared across machines or directories.

#### Changes made
- When saving settings, the corpus path is stored relative to `workflow_file`, if possible.
- When loading settings, the relative path is resolved back to an absolute path based on the location of `workflow_file`.

#### Tests
- Added a unit test `test_relative_corpus_path_serialization` to validate:
  - Corpus file is correctly saved with a relative path.
  - Corpus file can be successfully located after being moved with the workflow.
  - The path is resolved as absolute at runtime.

Test is located in `TestOWCorpus` class (`test_owcorpus.py`).
