### PR TITLE
test_owcorpusviewer: fix type mismatch in test_search

### DIFF
--- a/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
+++ b/orangecontrib/text/widgets/tests/test_owcorpusviewer.py
@@ -122,7 +122,7 @@ class TestCorpusViewerWidget(WidgetTest):
         self.process_events()
         out_corpus = self.get_output(self.widget.Outputs.matching_docs)
         self.assertEqual(len(out_corpus), 1)
-        self.assertEqual(self.widget.n_matches, 7)
+        self.assertEqual(int(self.widget.n_matches), 7)
 
         # first document is selected, when filter with word that is not in
         # selected document, first of shown documents is selected
@@ -131,7 +131,7 @@ class TestCorpusViewerWidget(WidgetTest):
         self.process_events()
         self.assertEqual(1, len(self.get_output(self.widget.Outputs.matching_docs)))
         # word count doesn't depend on selection
-        self.assertEqual(self.widget.n_matches, 7)
+        self.assertEqual(int(self.widget.n_matches), 7)
 
         # when filter is removed, matched words is 0
         self.widget.regexp_filter = ""


### PR DESCRIPTION
### Description
Fixes type mismatch in `test_search` by casting `n_matches` to integer.  
The test was failing with `AssertionError: '7' != 7`.

### Related
This test was unrelated to the changes in PR #1133 and is now isolated into its own PR.