### PR TITLE
Fix for deprecated support for classmethod with property since python 3.11

### DIFF
--- a/orangecontrib/text/preprocess/filter.py
+++ b/orangecontrib/text/preprocess/filter.py
@@ -7,6 +7,7 @@ import numpy as np
 from gensim import corpora
 from nltk.corpus import stopwords
 
+from orangewidget.io import classproperty
 from Orange.data.io import detect_encoding
 from Orange.util import wrap_callback, dummy_callback
 
@@ -116,8 +117,7 @@ class StopwordsFilter(BaseTokenFilter, FileWordListMixin):
         """
         return LANG2ISO.get(StopwordsFilter.NLTK2LANG.get(language, language))
 
-    @classmethod
-    @property
+    @classproperty
     @wait_nltk_data
     def supported_languages(_) -> Set[str]:
         """


### PR DESCRIPTION
##### Issue
Fixes #1146 

I set up environment where this error occur: (orange3.41-dev [from latest master] + orange3-text [latest master], python 3.13 (No 3.11, because like I said there on my machine it isn't produce that error yet.).
After this change error not occur anymore.

##### Description of changes

Add import from orangewidget.io as @janezd said and changed `@classmethod` `@property` to single `@classproperty`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
